### PR TITLE
Fix PDF parsing endpoint consistency 

### DIFF
--- a/backend/api/parse_pdf.py
+++ b/backend/api/parse_pdf.py
@@ -778,7 +778,7 @@ async def parse_pdf_with_progress(
             progress_manager.error_processing(session_id, f"PDF parsing failed: {e}")
         raise HTTPException(status_code=500, detail=f"PDF parsing failed: {e}")
 
-@router.post("/parse-pdf-with-progress")
+@router.post("/api/parse-pdf-with-progress")
 async def parse_pdf_with_progress_route(
     file: UploadFile = File(...),
     context_files: Optional[List[UploadFile]] = File(None),

--- a/frontend/hooks/usePDFParsingWithProgress.ts
+++ b/frontend/hooks/usePDFParsingWithProgress.ts
@@ -53,7 +53,7 @@ export function usePDFParsingWithProgress() {
         console.log('📚 Context files count:', contextFiles.length)
       }
 
-      const url = buildApiUrl('/parse-pdf-with-progress')
+      const url = buildApiUrl('/api/parse-pdf-with-progress')
 
       const response = await fetch(url, {
         method: 'POST',


### PR DESCRIPTION
 add /api/ prefix to match other endpoints