### PR TITLE
Fix Redis unavailable error handling in progress service

### DIFF
--- a/backend/modules/pdf_processing/progress_service.py
+++ b/backend/modules/pdf_processing/progress_service.py
@@ -249,6 +249,22 @@ class ProgressManager:
         
         # Load from Redis (shared across all replicas)
         progress_data = self._load_progress_data(session_id)
+        
+        # Handle case where Redis is unavailable or session doesn't exist
+        if progress_data is None:
+            logger.warning(f"[PROGRESS_API] No progress data for session {session_id} - Redis may be unavailable")
+            return {
+                "overall_progress": 0,
+                "current_stage": "upload",
+                "stage_progress": 0,
+                "message": "Progress tracking unavailable - Redis connection required",
+                "timestamp": time.time(),
+                "completed": False,
+                "error": "Redis connection unavailable. Please ensure Redis is running on localhost:6379",
+                "field_updates": {},
+                "simulation_id": None,
+                "result": None
+            }
 
         # Format response for HTTP polling (not WebSocket)
         response_data = {


### PR DESCRIPTION
## Summary
- Prevents 500 errors when Redis is unavailable during PDF processing progress polling
- Returns informative error message instead of crashing on null pointer
- Adds logging for better debugging

## Problem
When Redis is not running or unavailable:
1. `_load_progress_data()` returns `None`
2. Code attempted to call `.get()` on `None`, causing `AttributeError`
3. Results in 500 Internal Server Error for progress polling requests

## Solution
Added null safety check in `get_progress_status()`:
- Detects when Redis connection fails (progress_data is None)
- Returns structured error response with clear message: "Redis connection unavailable"
- Logs warning for developers
- Allows frontend to display error to users instead of indefinite loading

## Test plan
- [ ] Start backend without Redis running
- [ ] Upload PDF and verify progress polling returns 200 with error message instead of 500
- [ ] Start Redis and verify progress tracking works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for progress tracking when the backend service is temporarily unavailable. Users now receive a clear message about the service dependency instead of an error.

* **Documentation**
  * Updated documentation references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->