### PR TITLE
Fix Redis key size issue with data URL image uploads

### DIFF
--- a/backend/modules/publishing/tasks.py
+++ b/backend/modules/publishing/tasks.py
@@ -545,9 +545,10 @@ async def process_upload_job(job: Dict[str, Any], db: Session) -> bool:
             # Remove from pending list using lrem (atomic operation)
             redis_manager.lrem(f"{status_key}:pending", 1, in_progress_key)
             
-            # Mark temp URL as completed and store S3 URL for reuse
-            temp_url_key = f"upload:temp_url:{simulation_id}:{temp_url}"
-            redis_manager.set(temp_url_key, existing_url, ttl=86400)  # Store S3 URL instead of "completed"
+            # Mark temp URL as completed and store S3 URL for reuse (skip for data URLs to avoid huge keys)
+            if not is_data_url(temp_url):
+                temp_url_key = f"upload:temp_url:{simulation_id}:{temp_url}"
+                redis_manager.set(temp_url_key, existing_url, ttl=86400)
             
             logger.info(f"[IMAGE_WORKER] Updated database with existing S3 URL for {image_type} {image_id}")
             return True
@@ -592,9 +593,10 @@ async def process_upload_job(job: Dict[str, Any], db: Session) -> bool:
             # Remove from pending list using lrem (atomic operation)
             redis_manager.lrem(f"{status_key}:pending", 1, in_progress_key)
             
-            # Mark temp URL as completed and store S3 URL for reuse
-            temp_url_key = f"upload:temp_url:{simulation_id}:{temp_url}"
-            redis_manager.set(temp_url_key, s3_url, ttl=86400)  # Store S3 URL instead of "completed"
+            # Mark temp URL as completed and store S3 URL for reuse (skip for data URLs to avoid huge keys)
+            if not is_data_url(temp_url):
+                temp_url_key = f"upload:temp_url:{simulation_id}:{temp_url}"
+                redis_manager.set(temp_url_key, s3_url, ttl=86400)
             
             logger.info(f"[IMAGE_WORKER] Successfully uploaded {image_type} {image_id} to S3: {s3_url}")
             return True


### PR DESCRIPTION
## Summary
- Fixes Redis key size issue when processing image uploads with data URLs
- Prevents performance degradation from storing large base64 images as Redis keys
- Only caches external temp URLs, skipping inline data URLs

## Problem
When processing image uploads, the system was attempting to store data URLs (base64-encoded images) as Redis cache keys. Since data URLs can be extremely large (often 100KB+ for images), this caused:
- Redis performance issues due to massive key sizes
- Memory bloat in Redis
- Potential key size limit errors

## Solution
Added `is_data_url()` check before caching temp URLs in Redis:
- Skip Redis caching for data URLs (inline base64 images)
- Only cache external temp URLs that reference external resources
- Maintains caching benefits for legitimate temp URLs while avoiding huge keys

Changes in `backend/modules/publishing/tasks.py`:
- Added conditional check before storing temp_url in Redis
- Applied fix to both database update path (existing S3 URL) and upload path (new S3 upload)

## Test plan
- [x] Upload images with data URLs and verify they process correctly
- [ ] Check Redis keys don't contain large base64 strings
- [ ] Verify external temp URLs are still cached properly
- [ ] Monitor Redis memory usage during image uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized image URL caching to reduce storage overhead and improve system performance by preventing unnecessary cache entries for certain URL types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->