### PR TITLE
docs: fix incorrect comment - maxAge is 180 minutes not 30

### DIFF
--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
         if (key && value && key.trim() === 'access_token') {
           // Recreate cookie with correct attributes for frontend
           const isProduction = process.env.NODE_ENV === 'production'
-          const maxAge = 180 * 60 // 30 minutes in seconds
+          const maxAge = 180 * 60 // 180 minutes in seconds
           
           // Build cookie string with correct attributes
           let cookieString = `${key.trim()}=${value.trim()}`


### PR DESCRIPTION
## Summary
- Fixed misleading comment in cookie expiration code
- Comment said "30 minutes" but the value was actually 180 minutes (10800 seconds)

## Changes
- `frontend/app/api/auth/register/route.ts` - Updated comment to correctly state "180 minutes"

## Test plan
- [x] Verify comment matches actual value

🤖 Generated with [Claude Code](https://claude.com/claude-code)