### PR TITLE
feat(ui): Make begin simulation button more prominent

### DIFF
--- a/frontend/app/professor/test-simulations/page.tsx
+++ b/frontend/app/professor/test-simulations/page.tsx
@@ -9,15 +9,16 @@ import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
-import { 
-  Send, 
-  Users, 
-  Target, 
-  Clock, 
-  CheckCircle, 
+import {
+  Send,
+  Users,
+  Target,
+  Clock,
+  CheckCircle,
   AlertCircle,
   HelpCircle,
   Play,
+  PlayCircle,
   RefreshCw,
   ArrowRight,
   BookOpen,
@@ -3421,12 +3422,14 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
                       <div className="flex gap-2 flex-wrap">
                         {!simulationHasBegun && (
                           <Button
-                            size="sm"
-                            variant="outline"
+                            size="lg"
+                            variant="default"
                             onClick={() => sendMessage("begin")}
                             disabled={inputBlocked || isLoading || isTyping || simulationComplete || gradingInProgress}
+                            className="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 animate-pulse"
                           >
-                            Begin
+                            <PlayCircle className="w-5 h-5 mr-2" />
+                            Begin Simulation
                           </Button>
                         )}
                         <Button

--- a/frontend/app/student/run-simulation/[instanceId]/page.tsx
+++ b/frontend/app/student/run-simulation/[instanceId]/page.tsx
@@ -29,7 +29,8 @@ import {
   MessageCircle,
   Mic,
   Type,
-  ChevronDown
+  ChevronDown,
+  PlayCircle
 } from "lucide-react"
 import { ChatMessages } from '@/components/ChatMessages'
 import { ChatInput } from '@/components/ChatInput'
@@ -3261,12 +3262,14 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
                     <div className="flex gap-2 flex-wrap">
                       {!simulationHasBegun && (
                         <Button
-                          size="sm"
-                          variant="outline"
+                          size="lg"
+                          variant="default"
                           onClick={() => sendMessage("begin")}
-                              disabled={inputBlocked || isLoading || isTyping || simulationComplete || gradingInProgress}
+                          disabled={inputBlocked || isLoading || isTyping || simulationComplete || gradingInProgress}
+                          className="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 animate-pulse"
                         >
-                          Begin
+                          <PlayCircle className="w-5 h-5 mr-2" />
+                          Begin Simulation
                         </Button>
                       )}
                       <Button


### PR DESCRIPTION
## Summary
- Made the "Begin" button larger and more visible in the simulation interface
- Added green background color with pulse animation to draw user attention
- Added PlayCircle icon for visual clarity
- Changed text from "Begin" to "Begin Simulation" for better UX

## Changes
- `frontend/app/student/run-simulation/[instanceId]/page.tsx` - Student simulation view
- `frontend/app/professor/test-simulations/page.tsx` - Professor test simulation view

## Screenshots
**Before:** Small outline button labeled "Begin"
**After:** Large green pulsing button with icon labeled "Begin Simulation"

## Test plan
- [ ] Navigate to student simulation view - verify button is visible and prominent
- [ ] Navigate to professor test simulation view - verify same changes
- [ ] Click the button - verify simulation starts correctly
- [ ] Verify button disappears after simulation begins

Fixes: "Starting a simulation is not intuitive" feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PlayCircle icon to Begin Simulation buttons for better visual clarity.

* **Style**
  * Enhanced Begin Simulation button styling with larger size and more prominent appearance across test simulation interfaces.
  * Integrated pulsing animation effects for improved user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->