### PR TITLE
fix(auth): align token expiration to 24 hours

### DIFF
--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
     # Default to SQLite for local development only
     database_url: str = f"sqlite:///{BASE_DIR / 'app.db'}"
     secret_key: str = "super-secret-key"
-    access_token_exp_minutes: int = 360
+    access_token_exp_minutes: int = 1440  # 24 hours
     
     # CORS Config
     # Default to None - must be set via CORS_ORIGINS environment variable

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
         if (key && value && key.trim() === 'access_token') {
           // Recreate cookie with correct attributes for frontend
           const isProduction = process.env.NODE_ENV === 'production'
-          const maxAge = 30 * 60 // 30 minutes in seconds
+          const maxAge = 24 * 60 * 60 // 24 hours in seconds
           
           // Build cookie string with correct attributes
           let cookieString = `${key.trim()}=${value.trim()}`

--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
         if (key && value && key.trim() === 'access_token') {
           // Recreate cookie with correct attributes for frontend
           const isProduction = process.env.NODE_ENV === 'production'
-          const maxAge = 180 * 60 // 30 minutes in seconds
+          const maxAge = 24 * 60 * 60 // 24 hours in seconds
           
           // Build cookie string with correct attributes
           let cookieString = `${key.trim()}=${value.trim()}`

--- a/frontend/app/api/auth/set-token/route.ts
+++ b/frontend/app/api/auth/set-token/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
       secure: isProduction,
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 6, // 6 hours (matches backend ACCESS_TOKEN_EXPIRE_MINUTES)
+      maxAge: 60 * 60 * 24, // 24 hours (matches backend ACCESS_TOKEN_EXPIRE_MINUTES)
     })
     
     return response


### PR DESCRIPTION
## Summary
Aligns all authentication token expiration times to **24 hours** across frontend and backend to prevent users from losing unsaved work due to premature session expiration.

## Problem
Users were experiencing lost work because:
- Backend token expired at 6 hours
- Frontend login cookie expired at 30 minutes
- Frontend register cookie expired at 180 minutes
- Frontend set-token cookie expired at 6 hours

This mismatch caused confusing auth failures where the cookie was still valid but the token had expired.

## Changes
| Location | Before | After |
|----------|--------|-------|
| `backend/common/config.py` | 360 min (6h) | 1440 min (24h) |
| `frontend/app/api/auth/login/route.ts` | 30 min | 24 hours |
| `frontend/app/api/auth/register/route.ts` | 180 min | 24 hours |
| `frontend/app/api/auth/set-token/route.ts` | 6 hours | 24 hours |

## Test plan
- [ ] Login and verify session persists for extended period
- [ ] Register new user and verify session persists
- [ ] Verify no premature logouts during normal usage
- [ ] Confirm cookie Max-Age matches backend token expiry

Fixes: User feedback "changes were erased" due to session timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended user session duration by increasing access token expiration from 6 hours to 24 hours, allowing users to remain logged in longer without re-authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->