### PR TITLE
fix: remove trailing slashes from PDF parsing routes

### DIFF
--- a/backend/modules/pdf_processing/router.py
+++ b/backend/modules/pdf_processing/router.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/parse-pdf-fast-autofill/")
+@router.post("/parse-pdf-fast-autofill")
 async def parse_pdf_fast_autofill(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
@@ -241,7 +241,7 @@ async def parse_pdf_with_progress_route(
     }
 
 
-@router.post("/parse-pdf/")
+@router.post("/parse-pdf")
 async def parse_pdf(
     file: UploadFile = File(...),
     context_files: Optional[List[UploadFile]] = File(None),


### PR DESCRIPTION
## Summary
- Removes trailing slashes from `/parse-pdf/` and `/parse-pdf-fast-autofill/` route definitions in the PDF processing router
- Fixes 422 Unprocessable Entity errors when uploading PDFs via the simulation builder

## Problem
FastAPI's `redirect_slashes` (enabled by default) causes a **307 redirect** when the Next.js API proxy strips trailing slashes from the request URL. The 307 redirect loses the multipart form body (the PDF file), resulting in a `422 Unprocessable Entity` from the redirected request.

```
POST /api/pdf-processing/parse-pdf HTTP/1.1  → 307 Redirect
POST /api/pdf-processing/parse-pdf/ HTTP/1.1 → 422 (body lost in redirect)
```

## Fix
Define routes without trailing slashes so they match requests directly. Requests *with* trailing slashes still work via FastAPI's redirect (GET-safe), but the common path (proxy without slash) no longer triggers a redirect.

## Test plan
- [ ] Upload a PDF on the simulation builder page — should succeed without 307/422 in logs
- [ ] Verify `/parse-pdf-fast-autofill` endpoint also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized API endpoint paths for PDF processing services by removing trailing slashes, improving URL consistency and alignment with REST API conventions across integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->