### PR TITLE
feat: add CSV grade export for professor cohort simulations

### DIFF
--- a/frontend/app/professor/cohorts/page.tsx
+++ b/frontend/app/professor/cohorts/page.tsx
@@ -379,6 +379,11 @@ export default function Cohorts() {
     const simulationTitle = selectedSimulation?.simulation?.title || 'Simulation'
     const cohortTitle = selectedCohort?.title || 'Cohort'
 
+    const csvEscape = (value: unknown): string => {
+      const str = String(value ?? '')
+      return `"${str.replace(/"/g, '""')}"`
+    }
+
     const headers = [
       'Student Name',
       'Email',
@@ -402,8 +407,8 @@ export default function Cohorts() {
       instance.completion_percentage ?? '',
       instance.ai_grade ?? '',
       instance.grade ?? '',
-      instance.ai_feedback ? `"${instance.ai_feedback.replace(/"/g, '""')}"` : '',
-      instance.feedback ? `"${instance.feedback.replace(/"/g, '""')}"` : '',
+      instance.ai_feedback || '',
+      instance.feedback || '',
       instance.total_time_spent ? Math.floor(instance.total_time_spent / 60) : '',
       instance.started_at ? new Date(instance.started_at).toLocaleString() : '',
       instance.completed_at ? new Date(instance.completed_at).toLocaleString() : '',
@@ -411,7 +416,7 @@ export default function Cohorts() {
       instance.graded_at ? new Date(instance.graded_at).toLocaleString() : ''
     ])
 
-    const csvContent = [headers, ...rows].map(row => row.join(',')).join('\n')
+    const csvContent = [headers, ...rows].map(row => row.map(csvEscape).join(',')).join('\n')
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')

--- a/frontend/app/professor/cohorts/page.tsx
+++ b/frontend/app/professor/cohorts/page.tsx
@@ -25,7 +25,8 @@ import {
   CheckCircle,
   Clock,
   Pencil,
-  MoreVertical
+  MoreVertical,
+  Download
 } from "lucide-react"
 import RoleBasedSidebar from "@/components/RoleBasedSidebar"
 import { useAuth } from "@/lib/auth-context"
@@ -372,6 +373,52 @@ export default function Cohorts() {
     if (cohortSimulations.length > 0) {
       await fetchSimulationCompletionCounts(cohortSimulations)
     }
+  }
+
+  const exportGradesToCSV = () => {
+    const simulationTitle = selectedSimulation?.simulation?.title || 'Simulation'
+    const cohortTitle = selectedCohort?.title || 'Cohort'
+
+    const headers = [
+      'Student Name',
+      'Email',
+      'Status',
+      'Completion (%)',
+      'AI Grade',
+      'Professor Grade',
+      'AI Feedback',
+      'Professor Feedback',
+      'Time Spent (min)',
+      'Started At',
+      'Completed At',
+      'Submitted At',
+      'Graded At'
+    ]
+
+    const rows = studentInstances.map((instance: any) => [
+      instance.student_name || '',
+      instance.student_email || '',
+      instance.status || '',
+      instance.completion_percentage ?? '',
+      instance.ai_grade ?? '',
+      instance.grade ?? '',
+      instance.ai_feedback ? `"${instance.ai_feedback.replace(/"/g, '""')}"` : '',
+      instance.feedback ? `"${instance.feedback.replace(/"/g, '""')}"` : '',
+      instance.total_time_spent ? Math.floor(instance.total_time_spent / 60) : '',
+      instance.started_at ? new Date(instance.started_at).toLocaleString() : '',
+      instance.completed_at ? new Date(instance.completed_at).toLocaleString() : '',
+      instance.submitted_at ? new Date(instance.submitted_at).toLocaleString() : '',
+      instance.graded_at ? new Date(instance.graded_at).toLocaleString() : ''
+    ])
+
+    const csvContent = [headers, ...rows].map(row => row.join(',')).join('\n')
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${cohortTitle} - ${simulationTitle} - Grades.csv`
+    link.click()
+    URL.revokeObjectURL(url)
   }
 
   // Fetch cohort details when a cohort is selected
@@ -1472,6 +1519,13 @@ export default function Cohorts() {
                             {selectedSimulation?.simulation?.title || 'Simulation'} - Student Progress
                           </h3>
                         </div>
+                        <button
+                          onClick={exportGradesToCSV}
+                          className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium bg-black text-white hover:bg-gray-800 transition-colors"
+                        >
+                          <Download className="h-4 w-4 mr-2" />
+                          Export Grades
+                        </button>
                       </div>
 
                       <div className="mb-6">


### PR DESCRIPTION
## Summary
- Adds an **Export Grades** button to the student progress view on the professor cohorts page (Simulations tab → individual simulation)
- Generates a client-side CSV download with 13 columns: Student Name, Email, Status, Completion %, AI Grade, Professor Grade, AI Feedback, Professor Feedback, Time Spent (min), Started At, Completed At, Submitted At, Graded At
- No backend changes — uses already-loaded `studentInstances` data

## Test plan
- [ ] Navigate to a cohort → Simulations tab → click a simulation to view student progress
- [ ] Verify the "Export Grades" button appears in the top-right of the header
- [ ] Click the button → CSV file downloads named `{Cohort} - {Simulation} - Grades.csv`
- [ ] Open the CSV in Excel/Google Sheets → verify all 13 columns are present and data is correct
- [ ] Verify feedback columns with commas/quotes are properly escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Professors can export student grades and performance data to CSV from the Cohorts student progress view.
  * Added an "Export Grades" button to download detailed grading info (student names, identifiers, scores, submission times, and instructor feedback) for the selected cohort and simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->