### PR TITLE
fix: default invite links to multi-use with no expiry

### DIFF
--- a/backend/modules/cohorts/schemas.py
+++ b/backend/modules/cohorts/schemas.py
@@ -12,7 +12,7 @@ class InviteLinkCreate(BaseModel):
     """Schema for creating a new invite link"""
     type: str = Field(default="SINGLE_USE", description="SINGLE_USE or MULTI_USE")
     max_uses: Optional[int] = Field(default=None, ge=1, description="Maximum uses (only for MULTI_USE)")
-    expires_in_days: int = Field(default=7, ge=1, le=90, description="Days until expiration")
+    expires_in_days: Optional[int] = Field(default=None, ge=1, le=90, description="Days until expiration (leave empty for no expiry)")
 
 
 class InviteLinkResponse(BaseModel):

--- a/backend/modules/cohorts/service.py
+++ b/backend/modules/cohorts/service.py
@@ -1005,8 +1005,11 @@ class CohortService:
         if invite_type not in ["SINGLE_USE", "MULTI_USE"]:
             raise ValueError("Invalid invite type. Must be SINGLE_USE or MULTI_USE")
         
-        # Calculate expiration
-        expires_at = datetime.now(timezone.utc) + timedelta(days=invite_data.expires_in_days)
+        # Calculate expiration (None = no expiry, use far-future date)
+        if invite_data.expires_in_days is not None:
+            expires_at = datetime.now(timezone.utc) + timedelta(days=invite_data.expires_in_days)
+        else:
+            expires_at = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
         
         # Create the invite
         invite = self.repository.create_invite(

--- a/frontend/components/InviteLinkModal.tsx
+++ b/frontend/components/InviteLinkModal.tsx
@@ -37,9 +37,9 @@ export default function InviteLinkModal({
   const [inviteLinks, setInviteLinks] = useState<InviteLink[]>([])
   const [loading, setLoading] = useState(true)
   const [showCreateForm, setShowCreateForm] = useState(false)
-  const [inviteType, setInviteType] = useState<"SINGLE_USE" | "MULTI_USE">("SINGLE_USE")
+  const [inviteType, setInviteType] = useState<"SINGLE_USE" | "MULTI_USE">("MULTI_USE")
   const [maxUses, setMaxUses] = useState<string>("")
-  const [expiresInDays, setExpiresInDays] = useState<string>("7")
+  const [expiresInDays, setExpiresInDays] = useState<string>("")
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<number | null>(null)
@@ -74,7 +74,9 @@ export default function InviteLinkModal({
     try {
       const inviteData: any = {
         type: inviteType,
-        expires_in_days: parseInt(expiresInDays) || 7
+      }
+      if (expiresInDays) {
+        inviteData.expires_in_days = parseInt(expiresInDays)
       }
       
       if (inviteType === "MULTI_USE" && maxUses) {
@@ -90,9 +92,9 @@ export default function InviteLinkModal({
       await apiClient.generateInviteLink(cohortId, inviteData)
       
       // Reset form and reload links
-      setInviteType("SINGLE_USE")
+      setInviteType("MULTI_USE")
       setMaxUses("")
-      setExpiresInDays("7")
+      setExpiresInDays("")
       setShowCreateForm(false)
       await loadInviteLinks()
     } catch (err) {
@@ -319,12 +321,13 @@ export default function InviteLinkModal({
                   type="number"
                   value={expiresInDays}
                   onChange={(e) => setExpiresInDays(e.target.value)}
+                  placeholder="Leave empty for no expiry"
                   className="w-full px-4 py-3 bg-white/80 backdrop-blur-sm border border-gray-200/80 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400/50 transition-all"
                   min="1"
                   max="90"
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  Link will expire after this many days (1-90 days)
+                  Leave empty for no expiry, or enter 1-90 days
                 </p>
               </div>
 
@@ -432,7 +435,7 @@ export default function InviteLinkModal({
                           <div>
                             <p className="text-xs text-gray-500">Expires</p>
                             <p className="font-medium text-gray-900 text-xs">
-                              {new Date(invite.expires_at).toLocaleDateString()}
+                              {new Date(invite.expires_at).getFullYear() >= 9999 ? "Never" : new Date(invite.expires_at).toLocaleDateString()}
                             </p>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- **Default invite type changed** from Single Use → **Multi Use**
- **Default expiry changed** from 7 days → **No expiry** (leave empty)
- Existing links with no expiry show "Never" in the Expires column

## Why
User research showed professors were not changing the defaults, causing students to run out of invite link uses. Multi-use + no-expiry is a safer default for most cohort use cases.

## Changes
- `frontend/components/InviteLinkModal.tsx`: default state to `MULTI_USE` / empty expiry; update post-generate reset; show "Never" for no-expiry links; add placeholder text
- `backend/modules/cohorts/schemas.py`: `expires_in_days` is now `Optional[int]` (null = no expiry)
- `backend/modules/cohorts/service.py`: when `expires_in_days` is null, set `expires_at = 9999-12-31` (effectively never expires)

## Test plan
- [ ] Open Invite Links modal → confirm Multi Use is selected by default
- [ ] Confirm Expires In (Days) field is empty with "Leave empty for no expiry" placeholder
- [ ] Generate link with empty expiry → link created successfully
- [ ] Confirm generated link shows "Never" in the Expires column
- [ ] Generate link with a specific day count (e.g. 30) → still works normally
- [ ] Single Use links still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Invitation links can now be created without expiration dates. The expiration field is now optional, defaulting to no expiry when left empty.
  * Default invite type updated to allow multi-use invitations by default.
  * UI updated to display "Never" for non-expiring invites and includes guidance on leaving the expiration field empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->