### PR TITLE
fix(personas): improve extraction, fix scene_context, unify figure mapping, update docs

### DIFF
--- a/PERSONA_PROMPTING_REFERENCE.md
+++ b/PERSONA_PROMPTING_REFERENCE.md
@@ -1,96 +1,192 @@
 # Persona Prompting Reference Guide
 
-> Working reference for understanding and improving the PDF → Persona → Simulation prompting pipeline.
+> Working reference for the PDF → Persona → Simulation prompting pipeline.
+> Last updated: 2026-02-20 — reflects all changes from the Enhanced Persona Extraction & Meta Prompt overhaul.
 
 ---
 
-## 1. Architecture Overview
+## 1. End-to-End Architecture
 
 ```
-PDF Upload
-  └─→ PDFProcessingPipeline
-        ├─→ LlamaParse  (text extraction)
-        ├─→ AIExtractionService  (GPT-4o — persona & scene generation)
-        ├─→ ImageGenerationService  (avatars, scene images)
-        └─→ Repository  (saves to DB)
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 1: PDF UPLOAD & EXTRACTION                           │
+│                                                             │
+│  Browser                                                    │
+│    └─→ POST /api/pdf-processing/parse-pdf-fast-autofill     │
+│          └─→ PDFProcessingPipeline.process_fast_autofill()  │
+│                ├─→ LlamaParse (PDF → markdown)              │
+│                ├─→ AIExtractionService                      │
+│                │     └─→ extract_personas_and_key_figures() │
+│                ├─→ ImageGenerationService (avatars)         │
+│                └─→ Repository.save_autofill_data()          │
+│                      └─→ DB: simulation_personas (all fields)│
+│                                                             │
+│    OR:                                                      │
+│    └─→ POST /api/pdf-processing/parse-pdf-with-progress     │
+│          └─→ PDFProcessingPipeline.process_full_with_progress()
+│                ├─→ LlamaParse                               │
+│                ├─→ AIExtractionService                      │
+│                │     ├─→ extract_personas_and_key_figures() │
+│                │     ├─→ generate_scenes()                  │
+│                │     └─→ generate_learning_outcomes()       │
+│                ├─→ ImageGenerationService (avatars + scenes)│
+│                ├─→ Repository.save_full_pdf_data()          │
+│                │     └─→ DB: simulation_personas (all fields)│
+│                └─→ ProgressManager.send_field_update()      │
+│                      └─→ Redis → HTTP polling → Frontend    │
+└─────────────────────────────────────────────────────────────┘
 
-Simulation Runtime
-  └─→ SimulationService
-        └─→ ChatOrchestrator  (scene state machine)
-              └─→ PersonaAgent (per persona, LangChain)
-                    ├─→ _get_system_prompt()  ← CORE PROMPTING
-                    ├─→ ConversationBufferWindowMemory (fresh per request)
-                    └─→ Tools: get_scene_context, get_persona_knowledge (PGVector)
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 2: SIMULATION BUILDER (Frontend)                     │
+│                                                             │
+│  PDFProgressTrackerHTTP polls /pdf-progress/{session_id}    │
+│    └─→ onFieldUpdate("personas", key_figures[])             │
+│          └─→ handleFieldUpdate() in page.tsx                │
+│                └─→ mapFigureToPersona() ← single source     │
+│                      └─→ setPersonas(newPersonas)           │
+│                                                             │
+│  OR (fast autofill path):                                   │
+│  handleAutofill() → API response.key_figures[]              │
+│    └─→ mapFigureToPersona() ← same function                 │
+│          └─→ setPersonas(newPersonas)                       │
+│                                                             │
+│  Professor reviews/edits persona cards, then clicks Save:   │
+│  handleSave() → POST /api/publishing/simulations/{id}/draft │
+│    └─→ PublishingService.save_simulation_draft()            │
+│          └─→ DB: simulation_personas updated (all fields)   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 3: PUBLISH                                           │
+│                                                             │
+│  POST /api/publishing/simulations/{id}/publish              │
+│    └─→ PublishingService.publish_simulation()               │
+│          └─→ simulation.is_draft = False                    │
+│          └─→ simulation.status = "active"                   │
+│          NOTE: Personas are NOT copied — referenced in-place│
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 4: STUDENT STARTS SIMULATION                         │
+│                                                             │
+│  POST /api/simulation/start                                 │
+│    └─→ LifecycleService.start_simulation()                  │
+│          ├─→ Queries: SimulationPersona (all DB fields)     │
+│          ├─→ Builds orchestrator_data dict (incl. db_id)    │
+│          └─→ Creates UserProgress (stores orchestrator_data)│
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 5: RUNTIME CHAT                                      │
+│                                                             │
+│  POST /api/simulation/stream                                │
+│    └─→ ChatHandler.handle_stream_message()                  │
+│          ├─→ OrchestratorManager.load_orchestrator()        │
+│          │     └─→ ChatOrchestrator(orchestrator_data)      │
+│          ├─→ orchestrator.initialize_langchain_session()    │
+│          │     └─→ _create_agent_sessions()                 │
+│          │           └─→ _get_persona_from_db(db_id)        │
+│          │                 └─→ SimulationPersona (fresh DB) │
+│          │                       └─→ PersonaAgent(persona)  │
+│          └─→ persona_agent.chat_stream(                     │
+│                  message,                                   │
+│                  scene_context={                            │
+│                    "current_scene": {title, desc, objs},    │
+│                    "simulation": {title, desc, challenge,   │
+│                                   student_role}             │
+│                  }                                          │
+│              )                                              │
+│                └─→ _get_system_prompt() → 4-block prompt   │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
 ## 2. Stage 1 — PDF → Persona Extraction
 
-### Files
+### Key Files
 | File | Purpose |
 |---|---|
-| `backend/modules/pdf_processing/pipeline.py` | Orchestrates the full pipeline |
+| `backend/modules/pdf_processing/router.py` | FastAPI endpoints |
+| `backend/modules/pdf_processing/pipeline.py` | Pipeline orchestration |
 | `backend/modules/pdf_processing/parser_service.py` | LlamaParse PDF → markdown |
 | `backend/modules/pdf_processing/ai_extraction_service.py` | GPT-4o extraction prompts |
+| `backend/modules/pdf_processing/image_generation_service.py` | Avatar + scene image generation |
+| `backend/modules/pdf_processing/repository.py` | DB writes |
 
-### Two Extraction Modes
+### Single Extraction Function (consolidated)
 
-#### A. Fast Autofill (`extract_personas_fast`)
-- **Model**: `gpt-4o`, temp=0.1, max_tokens=4000
-- **Input**: First 2000 chars of content only
-- **System role**: `"You are a JSON generator for business case study analysis. Create detailed descriptions with specific information, numbers, and context. Be thorough and informative."`
-- **Returns**: title, description (5-7 paragraphs), student_role, key_figures
+Both the fast autofill endpoint and the full progress endpoint now call the **same** function:
 
-Key instruction in the prompt:
-```
-PRIORITY: Look for the MAIN CHARACTER or PROTAGONIST of the case study first.
-If there's a clear main character/protagonist, use their name and title (e.g., "John Smith (CEO of Company Name)").
-If no specific character is mentioned, default to "Business Analyst".
-```
+**`extract_personas_and_key_figures(content, title, session_id=None)`**
+- **Model**: `gpt-4o`, `temperature=0.3`, `max_tokens=12000`
+- **Input**: Full preprocessed content
+- **Prompt instructs**: "aim for at least 4–6 personas, err on the side of including more"
+- **Post-processing**: Filters out the student-role character using `is_main_character` flag + 4-char minimum name overlap
 
-#### B. Full Extraction (`extract_personas_and_key_figures`)
-- **Model**: `gpt-4o`, temp=0.2, max_tokens=12000
-- **Input**: Full combined content
-- **System role**: `"You are a JSON generator for business case study analysis. Focus on creating comprehensive, detailed descriptions that give students complete context."`
-- **Post-processing**: Filters out student role character from key_figures using name/role matching + `is_main_character` flag
+> `extract_personas_fast` was deleted. There is one prompt to maintain.
 
-Key instruction:
-```
-⚠️ CRITICAL EXCLUSION RULE ⚠️
-DO NOT include the student role character in the key_figures array.
-key_figures are NPCs (non-player characters) that the student will interact with.
-```
-
-### Extracted Persona Shape (→ Database)
+### Extracted Persona Shape (from GPT-4o → to DB)
 ```json
 {
-  "name": "string",
-  "role": "string",
-  "correlation": "relationship to narrative",
-  "background": "2-3 sentence background",
-  "primary_goals": ["goal1", "goal2", "goal3"],
+  "name": "Full name and title as stated in the case",
+  "role": "Their position/title",
+  "background": "Professional history and organizational context. 2-3 sentences.",
+  "current_context": "Current responsibilities, challenges, case-specific perspective. 2-3 sentences.",
+  "correlation": "How this persona relates to the student role",
   "personality_traits": {
-    "analytical": 0-10,
-    "creative": 0-10,
-    "assertive": 0-10,
-    "collaborative": 0-10,
-    "detail_oriented": 0-10
+    "openness": 7,
+    "conscientiousness": 8,
+    "extraversion": 4,
+    "agreeableness": 6,
+    "neuroticism": 3
   },
+  "primary_goals": ["Goal 1", "Goal 2", "Goal 3"],
+  "knowledge_areas": [
+    "Specific fact or data point from the case",
+    "Another specific piece this persona would know"
+  ],
+  "communication_style": "Direct and data-driven, formal in group settings",
   "is_main_character": false
 }
 ```
 
-### Scene Generation (`generate_scenes`)
-- **Model**: `gpt-4o`, temp=0.3, max_tokens=2048
-- **Input**: First 2000 chars + available persona names (NPCs only)
-- **Output**: 4 scenes with progression: Crisis → Investigation → Solution → Implementation
-- Also post-processes scenes to remove student role from `personas_involved`
+> **Personality model**: Big Five (1–10 each). The old 8-trait schema
+> (`analytical`, `creative`, `assertive`, `collaborative`, `detail_oriented`,
+> `risk_taking`, `empathetic`, `decisive`) was fully replaced. Old rows with
+> those keys had `personality_traits` reset to `NULL` in the Alembic migration.
 
-### Learning Outcomes (`generate_learning_outcomes`)
-- **Model**: `gpt-4o`, temp=0.2, max_tokens=1024
-- **Input**: First 1500 chars
-- **Output**: 5 numbered learning outcomes
+### Student Role Filtering (backend)
+```python
+# ai_extraction_service.py — after GPT-4o returns
+student_role_parts = re.match(r'([^(]+)', student_role)
+student_name = student_role_parts.group(1).strip().lower()
+
+for figure in result["key_figures"]:
+    # Primary: model flagged this as the protagonist
+    if figure.get("is_main_character"):
+        is_student_role = True
+
+    # Secondary: name overlap (4-char minimum to avoid false matches)
+    if not is_student_role and student_name and len(student_name) >= 4:
+        if student_name in figure_name or figure_name in student_name:
+            is_student_role = True
+
+    if not is_student_role:
+        filtered_figures.append(figure)
+```
+
+### Fast Autofill vs Full Pipeline
+
+| | Fast Autofill | Full with Progress |
+|---|---|---|
+| **Endpoint** | `POST /parse-pdf-fast-autofill` | `POST /parse-pdf-with-progress` |
+| **Pipeline method** | `process_fast_autofill()` | `process_full_with_progress()` |
+| **Extraction** | `extract_personas_and_key_figures()` | `extract_personas_and_key_figures()` |
+| **Also generates** | Avatars only | Scenes + learning outcomes + all images |
+| **DB save** | `save_autofill_data()` | `save_full_pdf_data()` |
+| **Response** | JSON: `{ key_figures, title, student_role, simulation_id }` | SSE field updates via Redis polling |
+| **Frontend handler** | `handleAutofill()` response | `handleFieldUpdate('personas', ...)` |
 
 ---
 
@@ -101,236 +197,351 @@ key_figures are NPCs (non-player characters) that the student will interact with
 id, simulation_id
 name: str
 role: str
-background: str       # 2-3 sentence background from extraction
-correlation: str      # how they relate to the case
-primary_goals: List[str]
-personality_traits: Dict   # {"analytical": 7, "creative": 5, ...}
-system_prompt: str    # OPTIONAL custom prompt; if set, used verbatim at runtime
+background: str              # Professional history — 2-3 sentences
+current_context: str         # NEW — Current challenges/perspective in the case
+correlation: str             # How they relate to the student role
+primary_goals: List[str]     # JSON array
+personality_traits: Dict     # Big Five: {openness, conscientiousness, extraversion,
+                             #            agreeableness, neuroticism} each 1–10
+knowledge_areas: List[str]   # NEW — Specific facts/data this persona knows from the case
+communication_style: str     # NEW — How this persona communicates
+system_prompt: str           # OPTIONAL — custom author-written prompt (Identity block only)
 image_url: str
-deleted_at: DateTime  # soft deletion
+deleted_at: DateTime         # Soft deletion
 ```
 
-**`system_prompt` is the key field for prompting work.** If blank → runtime generates default. If set → used mostly verbatim (with scene context appended).
+**Migration**: `backend/common/db/migrations/versions/2026_02_20_1200-add_enhanced_persona_fields.py`
+- Adds `current_context`, `knowledge_areas`, `communication_style` (all nullable)
+- Resets `personality_traits` to `NULL` for rows using old trait keys (no Big Five keys present)
+- Uses `personality_traits::jsonb ? 'openness'` for the check (json type requires explicit cast)
 
 ### `SimulationScene` (table: `simulation_scenes`)
 ```python
 id, simulation_id
 title: str
 description: str
-user_goal: str        # student's specific objective
+user_goal: str          # Student's specific objective for this scene
 scene_order: int
 timeout_turns: int
-goal_criteria: Dict
+success_metric: str
 image_url: str
 ```
 
 ### `scene_personas` (join table)
 ```python
-scene_id, persona_id
-involvement_level: str   # "key", "participant", "mentioned"
+scene_id, persona_id, involvement_level   # "participant", "key", "mentioned"
 ```
 
 ---
 
-## 4. Stage 3 — Runtime Persona Prompting
+## 4. Stage 2 — Frontend: Simulation Builder
+
+### The Core Problem That Was Fixed
+
+The frontend had **four separate places** that mapped raw AI extraction output to `PersonaCard` format. Three of them were duplicates of each other; none of them mapped the new fields. Each had its own inline object literal using the old 8 trait keys, and all were missing `current_context`, `knowledge_areas`, `communication_style`, and `correlation`.
+
+**The fix**: A single `mapFigureToPersona(figure, index)` helper was added at module level in `page.tsx` (line 39). All four handlers now call this function. It is the **single source of truth** for this mapping.
+
+### `mapFigureToPersona(figure, index)` — What it maps
+
+```typescript
+// figure = raw object from AI extraction API response
+{
+  id:                `persona-${Date.now()}-${index}`,
+  name:              figure.name,
+  position:          figure.role,           // → PersonaCard "position"
+  description:       figure.background,     // → PersonaCard "description"
+  currentContext:    figure.current_context, // NEW
+  correlation:       figure.correlation,    // NEW (was ignored before)
+  primaryGoals:      formatted string,      // • Goal 1\n• Goal 2... (from array or string)
+  traits: {
+    openness:          figure.personality_traits?.openness ?? 5,
+    conscientiousness: figure.personality_traits?.conscientiousness ?? 5,
+    extraversion:      figure.personality_traits?.extraversion ?? 5,
+    agreeableness:     figure.personality_traits?.agreeableness ?? 5,
+    neuroticism:       figure.personality_traits?.neuroticism ?? 5,
+  },
+  defaultTraits:     { all 5 traits: 5 },
+  knowledgeAreas:    figure.knowledge_areas ?? [],  // NEW
+  communicationStyle: figure.communication_style,  // NEW
+  imageUrl:          figure.image_url || figure.imageUrl,
+  systemPrompt:      figure.system_prompt,
+}
+```
+
+### Four Call Sites (all using `mapFigureToPersona`)
+
+| Location (page.tsx) | Trigger | Notes |
+|---|---|---|
+| `handleAutofill()` response block | Fast autofill API returns JSON directly | Also does student-role filter via `is_main_character` flag |
+| `handleFieldUpdate('personas', ...)` | Full pipeline: `PDFProgressTrackerHTTP` fires `onFieldUpdate` | **This was the primary broken path** |
+| `handleAutofill()` secondary path | Fast autofill with `key_figures` in `aiData` | Handles response shape variations |
+| Background/teaching-notes handler | Late-arriving field update from background pipeline | |
+
+### handleSave → API Payload (field name mapping)
+
+```typescript
+// page.tsx handleSave() — maps camelCase → snake_case for backend
+personas: personas.map(persona => ({
+  ...persona,
+  role:               persona.position,
+  background:         persona.description,
+  current_context:    persona.currentContext,   // ← snake_case for backend
+  correlation:        persona.correlation,
+  primary_goals:      persona.primaryGoals,
+  personality_traits: persona.traits,
+  knowledge_areas:    persona.knowledgeAreas,
+  communication_style: persona.communicationStyle,
+}))
+```
+
+### DB Load → Frontend State (field name mapping)
+
+```typescript
+// page.tsx loadDraft() — maps snake_case → camelCase for PersonaCard
+{
+  id:               persona.id,          // numeric DB id — CRITICAL to preserve
+  name:             persona.name,
+  position:         persona.role,
+  description:      persona.background,
+  currentContext:   persona.current_context,
+  correlation:      persona.correlation,
+  primaryGoals:     persona.primary_goals (array → joined string),
+  traits:           persona.personality_traits || {},
+  knowledgeAreas:   persona.knowledge_areas || [],
+  communicationStyle: persona.communication_style,
+  imageUrl:         persona.image_url,
+  systemPrompt:     persona.system_prompt,
+}
+```
+
+---
+
+## 5. Stage 3 — Publish
+
+`POST /api/publishing/simulations/{id}/publish` → `PublishingService.publish_simulation()`
+
+**What it does**: Sets `simulation.is_draft = False`, `simulation.is_public = True`, `simulation.status = "active"`.
+
+**What it does NOT do**: Copy, duplicate, or re-serialize any persona data. All `SimulationPersona` rows are referenced in-place by `simulation_id`. No new fields are lost at publish time.
+
+---
+
+## 6. Stage 4 — Student Starts Simulation
+
+`POST /api/simulation/start` → `LifecycleService.start_simulation()`
+
+Builds `orchestrator_data` dict and stores it in `UserProgress.orchestrator_data` (JSONB):
+
+```python
+orchestrator_data = {
+    "id": simulation.id,
+    "title": simulation.title,
+    "description": simulation.description,
+    "challenge": simulation.challenge,
+    "student_role": simulation.student_role,
+    "scenes": [ { id, title, description, agent_ids, personas_involved, ... } ],
+    "personas": [
+        {
+            "id": sanitized_name_slug,  # used as agent lookup key
+            "db_id": persona.id,        # ← CRITICAL: numeric PK for DB fetch at runtime
+            "identity": { name, role, bio },
+            "personality": { goals, traits },
+            "system_prompt": ...,
+            "image_url": ...,
+        }
+    ]
+}
+```
+
+> `orchestrator_data["personas"]` contains only a lightweight summary. The **full persona data** (including `current_context`, `knowledge_areas`, `communication_style`) is fetched fresh from DB at runtime using `db_id`.
+
+---
+
+## 7. Stage 5 — Runtime Persona Prompting
 
 ### File: `backend/modules/simulation/agents/persona_agent.py`
 
-### 4.1 Prompt Construction: Two Paths
+### 7.1 Persona Loading at Runtime
 
-The method `_create_persona_prompt_with_attempt(attempt_number, scene_context)` is called on every chat turn.
+```
+ChatHandler.handle_stream_message()
+  └─→ OrchestratorManager.load_orchestrator(user_progress)
+        └─→ ChatOrchestrator(orchestrator_data)
+              └─→ orchestrator.initialize_langchain_session(user_progress_id)
+                    └─→ _create_agent_sessions()
+                          for each persona in orchestrator_data["personas"]:
+                            db_id = persona["db_id"]
+                            persona_obj = await _get_persona_from_db(db_id)
+                            # persona_obj = full SimulationPersona SQLAlchemy object
+                            # all new fields are present from DB query
+                            PersonaAgent(persona_obj, session_id, user_progress_id)
+```
 
-**Path A — Custom `system_prompt` exists:**
+### 7.2 scene_context Structure (fixed)
+
+All three chat paths now pass the same nested structure to `persona_agent.chat_stream()`:
+
 ```python
-# persona.system_prompt is stored verbatim in DB
-# The runtime appends case study context + scene context + a conversation note
-system_prompt = (
-    self.persona.system_prompt          # verbatim
-    + case_study_context                # simulation title/description/challenge + student_role + scene title/desc/objectives
-    + scene_context_str                 # from scene_context dict (key:value pairs)
-    + conversation_instruction          # "Conversation history is already available in your memory..."
-)
-# All curly braces escaped for LangChain template safety
-```
-
-**Path B — No custom prompt (default generated):**
-`_get_system_prompt(attempt_number, scene_context)` builds the full prompt inline.
-
-### 4.2 `_get_system_prompt()` — The Default Prompt (lines 338–413)
-
-```
-You are {name}, a {role} in this business simulation.
-
-CASE STUDY CONTEXT:
-Title: {simulation.title}
-Description: {simulation.description}
-Challenge: {simulation.challenge}
-
-STUDENT ROLE: You are interacting with a student who is playing the role of: {simulation.student_role}
-
-CURRENT SCENE: {scene.title}
-Scene Description: {scene.description}
-Scene Objectives: {scene.objectives joined by comma}
-
-PERSONA BACKGROUND:
-{persona.background}
-
-CORRELATION TO CASE:
-{persona.correlation}
-
-PERSONALITY TRAITS:
-{comma-joined k:v pairs from personality_traits dict}
-
-PRIMARY GOALS:
-• {goal1}
-• {goal2}
-...
-
-INSTRUCTIONS:
-- CONVERSATION HISTORY: You have access to recent conversation history in your memory. Use it to maintain context and respond appropriately.
-- CONVERSATION ANALYSIS: When analyzing conversation history, pay attention to the chronological order of messages to determine what happened first, last, etc.
-- PERSONA ISOLATION: NEVER copy or mimic other personas' responses, patterns, or behaviors. Stay true to YOUR unique character and role.
-- Stay in character as {name} at all times
-- Respond based on your role, background, and personality traits
-- Help guide the user toward scene objectives through realistic business interaction
-- Don't directly give away answers, but provide realistic business insights
-- Keep responses concise and professional (2-4 sentences typically)
-- Use your tools to access relevant context and knowledge
-- If the user seems stuck, provide subtle hints through natural conversation
-- Maintain consistent character behavior based on your personality traits, goals, and role
-
-Remember: You are {name}, not an AI assistant. Respond as this character would in a real business situation.
-```
-
-### 4.3 Scene Context Injection
-
-`scene_context` dict passed to `_create_persona_prompt_with_attempt()` has this shape:
-```python
-{
-    "simulation": {
-        "title": ...,
-        "description": ...,
-        "challenge": ...,
-        "student_role": ...
-    },
+scene_context = {
     "current_scene": {
-        "title": ...,
-        "description": ...,
-        "objectives": [...]
-    }
+        "title":       current_scene.get("title"),
+        "description": current_scene.get("description"),
+        "objectives":  current_scene.get("objectives", []),
+    },
+    "simulation": {
+        "title":        orchestrator.simulation.get("title"),
+        "description":  orchestrator.simulation.get("description"),
+        "challenge":    orchestrator.simulation.get("challenge"),
+        "student_role": orchestrator.simulation.get("student_role"),
+    },
 }
 ```
 
-**NOTE**: The orchestrator intentionally passes ONLY `current_scene` (not the full simulation dict) to `chat_with_persona_langchain()`:
+**Previously broken**: The `@all` path (line ~243 in chat_handler.py) passed `scene_context=current_scene` (flat dict). `_get_system_prompt()` could not find the `simulation` or `current_scene` keys, so both the CASE STUDY block and SCENE ENVIRONMENT block were always empty for `@all` messages.
+
+### 7.3 `_get_system_prompt()` — 4-Block Architecture
+
+Every call to `persona_agent.chat_stream()` builds a fresh system prompt from four composable blocks:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  BLOCK 1: IDENTITY                                          │
+│                                                             │
+│  If persona.system_prompt exists (professor-authored):      │
+│    PERSONA IDENTITY:                                        │
+│    {system_prompt verbatim}                                 │
+│                                                             │
+│  Otherwise auto-generated from DB fields:                   │
+│    You are {name}, {role}.                                  │
+│    BACKGROUND: {background}                                 │
+│    CURRENT CONTEXT: {current_context}                       │
+│    RELATIONSHIP TO STUDENT: {correlation}                   │
+│    PRIMARY GOALS: {primary_goals bullet list}               │
+│    KNOWLEDGE AREAS: {knowledge_areas bullet list}           │
+│    COMMUNICATION STYLE: {communication_style}               │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  BLOCK 2: SIMULATION & STUDENT CONTEXT (always present)     │
+│                                                             │
+│    CASE STUDY:                                              │
+│    Title: {simulation.title}                                │
+│    Overview: {simulation.description}                       │
+│    Central Challenge: {simulation.challenge}                │
+│                                                             │
+│    STUDENT ROLE: The student is playing: {student_role}     │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  BLOCK 3: SCENE ENVIRONMENT (always present)                │
+│                                                             │
+│    CURRENT SCENE: {scene.title}                             │
+│    {scene.description}                                      │
+│    Scene Objectives: {objectives}                           │
+│                                                             │
+│    SCENE AWARENESS — Adapt your emotional register:         │
+│    "If the scene describes urgency, let that tension come   │
+│     through. If it's a planning session, be deliberate."    │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  BLOCK 4: BEHAVIORAL FRAMEWORK & TONE (always present)      │
+│                                                             │
+│  YOUR PERSONALITY:                                          │
+│    {Big Five traits translated to plain-language behavior}  │
+│    e.g. "Conscientiousness (8/10 — high): diligent,        │
+│           thorough, and goal-driven..."                     │
+│                                                             │
+│  RULES — NON-NEGOTIABLE:                                    │
+│    - You are {name}. Not an AI. A person with stakes.       │
+│    - NEVER break character.                                 │
+│    - NEVER volunteer unsolicited situation summaries.       │
+│    - NEVER use assistant-style closers.                     │
+│    - NEVER repeat the student's question before answering.  │
+│                                                             │
+│  OFF-TOPIC GUARDRAIL:                                       │
+│    - React with confusion or redirect, not a literal answer.│
+│                                                             │
+│  WRITING STYLE:                                             │
+│    - Prose only. No bullets, lists, or headers. Ever.       │
+│    - Default short (1-3 sentences).                         │
+│    - Write like you are in the room.                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key behavior for custom `system_prompt`**: It becomes Block 1 (IDENTITY) only. Blocks 2–4 are always appended. This ensures every persona — regardless of professor customization — receives full scene awareness and consistent tone rules.
+
+### 7.4 Big Five Trait → Behavioral Description
+
 ```python
-# orchestrator.py line 447-451
-combined_context = {
-    "current_scene": current_scene   # <-- no "simulation" key
-}
-```
-This means `case_study_context` is empty string when called through the orchestrator's non-streaming path. The streaming router (`linear-chat-stream`) likely passes the full context — check `simulation/router.py` and `simulation/service.py` to confirm.
+# persona_agent.py — _BIG_FIVE_DESCRIPTORS + _describe_personality_traits()
+# Input:  {"openness": 7, "conscientiousness": 8, "extraversion": 3, ...}
+# Output: "- Openness (7/10 — high): curious and imaginative; actively seeks fresh ideas
+#          - Conscientiousness (8/10 — high): diligent, thorough, and goal-driven
+#          - Extraversion (3/10 — low): prefers one-on-one conversations..."
 
-### 4.4 LangChain Prompt Template Structure
-
-```
-[system]      ← _get_system_prompt() output
-[chat_history] ← MessagesPlaceholder (ConversationBufferWindowMemory)
-[human]       ← "{input}" (student's current message)
-[agent_scratchpad] ← MessagesPlaceholder (tool call results)
+Score range → label:
+  1-2  → "very low"
+  3-4  → "low"
+  5-6  → "moderate"
+  7-8  → "high"
+  9-10 → "very high"
 ```
 
-### 4.5 Agent Setup Per Request (Stateless)
+### 7.5 LangChain Prompt Template (per request, stateless)
 
-Every call to `chat()` or `chat_stream()` creates fresh:
-1. `ConversationBufferWindowMemory` — loaded from DB/Redis cache
-2. `ChatPromptTemplate`
-3. `create_openai_tools_agent(llm, tools, prompt)`
-4. `AgentExecutor` with `max_iterations=PERSONA_AGENT_MAX_ITERATIONS` (default 2)
+```
+[system]           ← _get_system_prompt() — full 4-block output
+[chat_history]     ← MessagesPlaceholder (ConversationBufferWindowMemory, fresh from DB/Redis)
+[human]            ← "{input}" — student's current message
+[agent_scratchpad] ← MessagesPlaceholder — tool call results
+```
 
-**LLM**: `langchain_manager.create_fresh_llm()` — isolated per agent instance, same OpenAI API
-
-### 4.6 Tools Available to Each Persona Agent
-
-| Tool | Description | Vector Filter | Cache TTL |
-|---|---|---|---|
-| `get_scene_context(scene_description)` | Semantic search of scene context | `persona_id + context_type=scene` | 5 min |
-| `get_persona_knowledge(query)` | Semantic search of persona background | `persona_id + context_type=knowledge` | 1 hr |
-
-Both use `_cached_vector_search()` → Redis → PGVector fallback.
+Tools available to each persona agent:
+- `get_scene_context(query)` — semantic search of scene context (PGVector, 5-min Redis cache)
+- `get_persona_knowledge(query)` — semantic search of persona background (PGVector, 1-hr Redis cache)
 
 ---
 
-## 5. Conversation History Loading
+## 8. Original Gap Audit (Section 7 of prior version)
 
-### Flow
-1. Check Redis cache (`conversation_cache.get_cached_history(user_progress_id, scene_id, session_id_filter)`)
-2. Cache miss → query `ConversationLog` table filtered by `user_progress_id + scene_id + session_id` variants
-3. Max messages: `settings.max_conversation_history_messages` (default 20)
-4. Loaded into fresh `ConversationBufferWindowMemory`:
-   - `"user"` → `add_user_message()`
-   - `"ai_persona"` → `add_ai_message()` (ALL personas, not just current one)
-   - `"orchestrator"` → `add_ai_message()`
+| # | Gap | Status |
+|---|---|---|
+| 7.1 | Case study context missing in default path | **Fixed** — `scene_context` dict structure corrected in all 3 chat paths (single `@mention`, multi-mention `@name1 @name2`, and `@all`) and in orchestrator fallback |
+| 7.2 | Personality traits are raw numbers | **Fixed** — `_describe_personality_traits()` translates Big Five scores to plain-language behavioral descriptions in Block 4 |
+| 7.3 | No behavioral differentiation per scene | **Fixed** — Block 3 (SCENE ENVIRONMENT) instructs personas to adapt emotional register to scene stakes |
+| 7.4 | `attempt_number` parameter unused | **Still unused** — parameter wired through but no per-attempt logic implemented |
+| 7.5 | Custom prompt context appended inconsistently | **Fixed** — custom prompt is always Block 1 (IDENTITY) only; Blocks 2–4 always wrap it regardless of code path |
+| 7.6 | No tone/register control | **Fixed** — Block 4 WRITING STYLE rules enforce prose-only, short default length, natural speech patterns |
+| 7.7 | Persona isolation instruction is reactive | **Improved** — Block 4 RULES now lead with strong positive character definition ("You are a person with stakes") rather than only "don't mimic" |
 
-**Session ID scheme**: `session_{base}_persona_{persona.id}` — ensures isolation between personas in same scene while still loading all scene conversation history.
+### Additional Gap Fixed (not in original list)
 
----
-
-## 6. Orchestrator System Prompt (Fallback Path)
-
-File: `backend/modules/simulation/core/orchestrator.py` — `get_system_prompt()` (line 611)
-
-This prompt is used when LangChain is **not** available or for the non-LangChain orchestration path. It's a different model:
-- Lists all personas with `@agent_id: name (role) - bio` format
-- Includes scene objectives, success metric, turns remaining
-- Instructs the orchestrator to respond as different agents using `**@agent_name:** "dialogue here"` format
-
-This is separate from the per-persona `PersonaAgent` prompts and should not be confused with them.
+| | Gap | Fix |
+|---|---|---|
+| — | `handleFieldUpdate('personas')` in frontend used old 8 trait keys and dropped all new fields — this was the **primary render path** for the full pipeline and caused the persona cards to always show empty Current Context, Communication Style, Knowledge Areas, and Relation to Student | **Fixed** — replaced inline mapping with `mapFigureToPersona()` call |
 
 ---
 
-## 7. Key Prompt Gaps / Observations (Starting Points for Improvement)
-
-### 7.1 Case Study Context Missing in Default Path
-The orchestrator's `chat_with_persona_langchain()` passes only `{"current_scene": ...}` — the `simulation` key is absent. So the default `_get_system_prompt()` renders the CASE STUDY CONTEXT block as empty strings for title/description/challenge. **The persona doesn't know what case study it's in when called from the orchestrator.**
-
-### 7.2 Personality Traits Are Numbers, Not Descriptions
-Traits like `{"analytical": 8, "creative": 5}` are passed as raw integers. The LLM has to infer what "analytical: 8" means behaviorally. There's no translation layer to natural language (e.g., "highly analytical, data-driven, methodical").
-
-### 7.3 No Behavioral Differentiation Per Scene
-The same full system prompt is used for every scene. There's no mechanism to give a persona different emphases or constraints per-scene (e.g., "In this scene, be more resistant" or "In this scene, you're under time pressure").
-
-### 7.4 `attempt_number` Parameter Is Unused
-`_create_persona_prompt_with_attempt(attempt_number, ...)` accepts `attempt_number` but the parameter is not used in the default prompt generation — there's no actual per-attempt few-shot examples injected. The parameter is wired through but inactive.
-
-### 7.5 Custom `system_prompt` Gets Context Appended Inconsistently
-- In `_get_system_prompt()` (line 341–344): returns custom prompt **verbatim** with no appended context.
-- In `_create_persona_prompt_with_attempt()` (line 293–327): appends `case_study_context + scene_context_str + conversation_instruction` to custom prompt.
-- These two methods are called from different code paths, leading to inconsistent behavior depending on which path the request takes.
-
-### 7.6 No Tone / Register Control
-The default instructions say "2-4 sentences typically" but there's no mechanism for a persona to be configured to be more verbose, use formal/informal language, or reflect domain-specific communication styles.
-
-### 7.7 Persona Isolation Instruction Is Reactive
-"NEVER copy or mimic other personas" is a negative instruction. It doesn't give positive guidance on how to differentiate. When all personas receive each other's messages in their conversation history (by design), the risk of cross-persona bleed is real.
-
----
-
-## 8. File Path Quick Reference
+## 9. File Path Quick Reference
 
 | What | Where |
 |---|---|
-| PDF pipeline orchestration | `backend/modules/pdf_processing/pipeline.py` |
-| Fast persona extraction prompt | `backend/modules/pdf_processing/ai_extraction_service.py:151` |
-| Full persona extraction prompt | `backend/modules/pdf_processing/ai_extraction_service.py:260` |
-| Scene generation prompt | `backend/modules/pdf_processing/ai_extraction_service.py:441` |
+| PDF router (endpoints) | `backend/modules/pdf_processing/router.py` |
+| Pipeline orchestration | `backend/modules/pdf_processing/pipeline.py` |
+| Persona + scene extraction prompts | `backend/modules/pdf_processing/ai_extraction_service.py` |
+| DB writes (autofill + full) | `backend/modules/pdf_processing/repository.py` |
+| Progress tracking (Redis + WS) | `backend/modules/pdf_processing/progress_service.py` |
 | DB model: SimulationPersona | `backend/common/db/models/publishing/simulation.py` |
-| Runtime persona agent | `backend/modules/simulation/agents/persona_agent.py` |
-| Default system prompt generation | `backend/modules/simulation/agents/persona_agent.py:338` |
-| Prompt template construction | `backend/modules/simulation/agents/persona_agent.py:271` |
-| Tools (scene/knowledge search) | `backend/modules/simulation/agents/persona_agent.py:155` |
-| Conversation history loading | `backend/modules/simulation/agents/persona_agent.py:415` |
-| Orchestrator (state machine) | `backend/modules/simulation/core/orchestrator.py` |
-| Orchestrator system prompt | `backend/modules/simulation/core/orchestrator.py:611` |
-| Chat handler | `backend/modules/simulation/handlers/chat_handler.py` |
-| Simulation router (streaming) | `backend/modules/simulation/router.py` |
-| Callback (saves response to DB) | `backend/modules/simulation/agents/callbacks.py` |
+| Alembic migration (new columns) | `backend/common/db/migrations/versions/2026_02_20_1200-add_enhanced_persona_fields.py` |
+| Publishing service (CRUD) | `backend/modules/publishing/service.py` |
+| Publishing router (API responses) | `backend/modules/publishing/router.py` |
+| Simulation lifecycle (start) | `backend/modules/simulation/services/lifecycle_service.py` |
+| Orchestrator (scene state machine) | `backend/modules/simulation/core/orchestrator.py` |
+| Orchestrator manager | `backend/modules/simulation/core/orchestrator_manager.py` |
+| Chat handler (all 3 mention paths) | `backend/modules/simulation/handlers/chat_handler.py` |
+| PersonaAgent + `_get_system_prompt` | `backend/modules/simulation/agents/persona_agent.py` |
+| Persona callback (saves to DB) | `backend/modules/simulation/agents/callbacks.py` |
+| Frontend: simulation builder | `frontend/app/professor/simulation-builder/page.tsx` |
+| Frontend: `mapFigureToPersona` | `frontend/app/professor/simulation-builder/page.tsx:39` |
+| Frontend: `handleFieldUpdate` | `frontend/app/professor/simulation-builder/page.tsx:1921` |
+| Frontend: progress tracker component | `frontend/components/PDFProgressTrackerHTTP.tsx` |
+| Frontend: PersonaCard component | `frontend/components/PersonaCard.tsx` |

--- a/SCENE_SYSTEM_REFERENCE.md
+++ b/SCENE_SYSTEM_REFERENCE.md
@@ -1,0 +1,603 @@
+# Scene System Reference Guide
+
+> End-to-end reference for how scenes are extracted, stored, edited, and used at runtime.
+> Last updated: 2026-02-20
+
+---
+
+## 1. End-to-End Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 1: EXTRACTION (PDF → Scenes)                         │
+│                                                             │
+│  PDFProcessingPipeline.process_full_with_progress()         │
+│    ├─→ Step 1: extract_personas_and_key_figures()           │
+│    │     └─→ personas_result (key_figures[], student_role)  │
+│    └─→ Step 2: generate_scenes(content, title, personas)    │
+│           └─→ GPT-4o: 4 scenes with persona references      │
+│                 └─→ Post-process: filter student role       │
+│                       from personas_involved in each scene  │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 2: DB SAVE (Repository)                              │
+│                                                             │
+│  Repository.save_full_pdf_data()                            │
+│    ├─→ Create SimulationScene rows (one per scene)          │
+│    │     Field mapping: sequence_order → scene_order        │
+│    └─→ Create scene_personas rows (join table)              │
+│           For each name in personas_involved:               │
+│             look up SimulationPersona.id, insert join row   │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 3: SIMULATION BUILDER (Frontend)                     │
+│                                                             │
+│  PDFProgressTrackerHTTP polls progress endpoint             │
+│    └─→ onFieldUpdate("scenes", scenes[])                    │
+│          └─→ handleFieldUpdate() in page.tsx                │
+│                └─→ setScenes(formattedScenes)               │
+│                                                             │
+│  Professor edits scenes in SceneCard components             │
+│    └─→ handleSave() → normalizeScenes() → API payload       │
+│          └─→ POST /api/publishing/simulations/{id}/draft    │
+│                └─→ PublishingService.save_simulation_draft()│
+│                      Smart update: by ID → by title → new  │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 4: SIMULATION START                                  │
+│                                                             │
+│  LifecycleService.start_simulation()                        │
+│    ├─→ Query: all scenes ordered by scene_order             │
+│    ├─→ Query: scene_personas join table (bulk load)         │
+│    └─→ Build orchestrator_data.scenes[]                     │
+│           scenes[i].personas_involved = [name, name, ...]   │
+│           Stored in UserProgress.orchestrator_data (JSONB)  │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  STAGE 5: RUNTIME (Chat)                                    │
+│                                                             │
+│  ChatOrchestrator(orchestrator_data)                        │
+│    ├─→ current_scene = scenes[state.current_scene_index]    │
+│    ├─→ current_scene.personas_involved → route @mentions    │
+│    ├─→ scene_context passed to every PersonaAgent prompt    │
+│    └─→ SceneProgressionHandler                              │
+│           └─→ progress_to_next_scene() when timeout/complete│
+│                 └─→ advance index, reset turn_count,        │
+│                       create SceneProgress, intro message   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Stage 1 — Scene Extraction
+
+### Key Files
+| File | Purpose |
+|---|---|
+| `backend/modules/pdf_processing/ai_extraction_service.py` | `generate_scenes()` function |
+| `backend/modules/pdf_processing/pipeline.py` | Calls `generate_scenes()` after persona extraction |
+
+### `generate_scenes(content, title, session_id, personas_result)`
+
+- **Model**: `gpt-4o`, `temperature=0.3`, `max_tokens=2048`
+- **Called after**: `extract_personas_and_key_figures()` — persona data is a required input
+- **Content used**: First 2000 characters of the cleaned case study
+
+### What the Prompt Receives
+
+The scene generation prompt is given three pieces of context derived from the prior persona extraction step:
+
+```python
+available_personas = [fig["name"] for fig in personas_result.get("key_figures", [])]
+student_role = personas_result.get("student_role", "Business Analyst")
+
+# Included in prompt:
+# "STUDENT ROLE: {student_role}"
+# "AVAILABLE PERSONAS: {', '.join(available_personas)}"
+# "⚠️ DO NOT include the student role in personas_involved arrays"
+```
+
+This wires persona names directly into the scene prompt, so GPT-4o references actual extracted characters by name rather than inventing new ones.
+
+### What GPT-4o Returns
+
+Exactly 4 scenes following a fixed narrative arc:
+
+```
+Scene 1 — Crisis/Opening:      The inciting event; introduces the core problem
+Scene 2 — Investigation:       Deeper exploration; student gathers information
+Scene 3 — Solution/Decision:   Student must synthesize findings and decide
+Scene 4 — Implementation:      Act on the decision; manage consequences
+```
+
+Each scene object:
+```json
+{
+  "title": "string",
+  "description": "2-3 sentences with vivid detail (used for image generation)",
+  "personas_involved": ["Name A", "Name B"],
+  "user_goal": "Specific actionable objective for the student in this scene",
+  "goal": "General summary",
+  "success_metric": "Measurable criteria for scene completion",
+  "sequence_order": 1
+}
+```
+
+### Post-Processing: Student Role Filter
+
+After GPT-4o returns, the student role character is removed from every scene's `personas_involved` array. The backend does this with normalized name comparison:
+
+```python
+def normalize_name(name: str) -> str:
+    # Remove title prefixes (Mr., Dr., Prof., etc.)
+    normalized = re.sub(r'^(Mr\.|Mrs\.|Ms\.|Miss|Dr\.|Prof\.)\s+', '', name.strip(), flags=re.IGNORECASE)
+    # Strip all non-alpha characters, lowercase
+    return re.sub(r'[^a-zA-Z]', '', normalized).lower()
+
+# Extract name portion of student_role (ignore parenthetical title)
+# e.g. "Luigi Ferrari (President)" → "luigi ferrari" → "luigiferrari"
+student_name_normalized = normalize_name(student_role.split('(')[0].strip())
+
+for scene in scenes:
+    scene["personas_involved"] = [
+        p for p in scene.get("personas_involved", [])
+        if normalize_name(p) != student_name_normalized
+    ]
+```
+
+> This is the **second** filter — the extraction prompt already instructs GPT-4o not to include the student role. The post-process is a safety net.
+
+---
+
+## 3. Stage 2 — Database Model & Saving
+
+### `SimulationScene` Model (`simulation_scenes` table)
+
+```python
+# backend/common/db/models/publishing/simulation.py
+
+class SimulationScene(Base):
+    __tablename__ = "simulation_scenes"
+
+    id: int                       # Primary key
+    simulation_id: int            # FK → simulations.id
+
+    # Core content
+    title: str
+    description: str              # Scene narrative (also used for image gen prompt context)
+    user_goal: str                # Student's objective for this scene
+
+    # Ordering & timing
+    scene_order: int              # Determines linear progression order (1, 2, 3, 4)
+    timeout_turns: int            # Max student turns before scene auto-advances (default 15)
+
+    # Success tracking
+    success_metric: str           # Text description of measurable success
+    max_attempts: int             # Optional retry limit (nullable)
+    success_threshold: float      # Optional score threshold (nullable)
+
+    # Advanced configuration (all nullable)
+    goal_criteria: Dict           # JSON — structured goal evaluation config
+    hint_triggers: Dict           # JSON — conditions for surfacing hints
+    scene_context: str            # Text — additional context for AI agents
+    persona_instructions: Dict    # JSON — per-persona behavioral overrides
+
+    # Media
+    image_url: str                # Scene background image
+    image_prompt: str             # Prompt used to generate image
+
+    # Soft delete & timestamps
+    deleted_at: datetime          # NULL = active; set = soft-deleted
+    created_at: datetime
+    updated_at: datetime
+```
+
+### `scene_personas` Join Table
+
+```python
+scene_personas = Table(
+    "scene_personas",
+    Column("scene_id",          FK → simulation_scenes.id, CASCADE, primary_key=True),
+    Column("persona_id",        FK → simulation_personas.id, CASCADE, primary_key=True),
+    Column("involvement_level", String, default="participant"),
+    Column("created_at",        DateTime),
+)
+# Composite PK: (scene_id, persona_id) — one row per persona per scene
+# involvement_level: always "participant" in the current extraction pipeline
+```
+
+### `Repository.save_full_pdf_data()` — Scene Section
+
+```python
+# backend/modules/pdf_processing/repository.py
+
+# 1. Deduplicate by title (skip if scene with same title already exists)
+existing_scene_titles = {s.title for s in existing_scenes}
+
+for scene_data in scenes:
+    if scene_data.get("title") in existing_scene_titles:
+        continue  # Idempotent — won't double-create on retry
+
+    scene = SimulationScene(
+        simulation_id = simulation.id,
+        title         = scene_data.get("title"),
+        description   = scene_data.get("description", ""),
+        user_goal     = scene_data.get("user_goal", ""),
+        scene_order   = scene_data.get("sequence_order", 0),  # ← key: maps sequence_order → scene_order
+        image_url     = scene_data.get("image_url", ""),
+        image_prompt  = f"Business scene: {scene_title}",
+        timeout_turns = int(scene_data.get("timeout_turns") or 15),
+        success_metric = scene_data.get("success_metric", ""),
+    )
+    db.add(scene)
+    db.flush()  # get scene.id immediately
+
+    # 2. Create scene_personas rows
+    personas_involved_filtered = [
+        p for p in scene_data.get("personas_involved", [])
+        if not is_main_character(p, student_role)
+    ]
+
+    for name in set(personas_involved_filtered):
+        # Exact match first, then case-insensitive fallback
+        persona_id = persona_mapping.get(name) or next(
+            (pid for pname, pid in persona_mapping.items()
+             if name.lower().strip() == pname.lower().strip()), None
+        )
+        if persona_id:
+            db.execute(scene_personas.insert().values(
+                scene_id=scene.id,
+                persona_id=persona_id,
+                involvement_level="participant"
+            ))
+```
+
+> **Field name mismatch to know about**: GPT-4o outputs `sequence_order`; the DB column is `scene_order`. The repository maps this explicitly. The frontend also handles both keys in `normalizeScenes()`.
+
+---
+
+## 4. Stage 3 — Simulation Builder (Frontend)
+
+### Key Files
+| File | Purpose |
+|---|---|
+| `frontend/app/professor/simulation-builder/page.tsx` | Main builder page — all scene state |
+| `frontend/components/SceneCard.tsx` | Individual scene display + edit component |
+
+### How Scenes Arrive in the Frontend
+
+**Path A — Full pipeline (primary):**
+The backend sends a `field_update` event with `fieldName = "scenes"` via the progress tracker. `handleFieldUpdate` in `page.tsx` receives it:
+
+```typescript
+// page.tsx — handleFieldUpdate('scenes', fieldValue)
+case 'scenes':
+  const formattedScenes = fieldValue.map((scene: any, index: number) => ({
+    id:              `scene-${index}`,         // Temporary client-side ID
+    title:           scene.title,
+    description:     scene.description,
+    personasInvolved: scene.personas_involved || [],
+    userGoal:        scene.user_goal,
+    sequenceOrder:   scene.sequence_order || index + 1,
+    imageUrl:        scene.image_url || '',
+    successMetric:   scene.success_metric,
+    goal:            scene.goal,
+    ...scene                                   // Preserve all other AI fields
+  }));
+  setScenes(formattedScenes);
+```
+
+> Note: at this stage `id` is a temporary `scene-${index}` string, not a DB integer. The real DB IDs are only present after a Save round-trip.
+
+**Path B — Loading a saved draft:**
+```typescript
+// page.tsx — loadDraft() — DB IDs are preserved
+const transformedScenes = draftData.scenes.map((scene: any) => ({
+  ...scene,
+  id:             scene.id,               // ← numeric DB ID, CRITICAL to preserve
+  sequence_order: scene.scene_order,      // Map scene_order → sequence_order for frontend
+  successMetric:  scene.success_metric,
+  personas_involved: scene.personas_involved || []
+}));
+setScenes(transformedScenes);
+```
+
+### SceneCard Component
+
+**Props & Interface:**
+```typescript
+interface Scene {
+  id: string | number;
+  title: string;
+  description: string;
+  personas_involved: string[];   // Array of persona names (not IDs)
+  user_goal: string;
+  sequence_order: number;
+  image_url?: string;
+  successMetric?: string;
+  timeout_turns?: number;
+}
+
+interface SceneCardProps {
+  scene: Scene;
+  allPersonas?: any[];           // Full persona list for the dropdown
+  studentRole?: string;          // Filtered out of personas_involved display
+  onSave?: (scene: Scene) => void;
+  onDelete?: () => void;
+  editMode?: boolean;
+}
+```
+
+**What professors can edit per scene:**
+
+| Field | UI Control | Notes |
+|---|---|---|
+| `title` | Text input | Scene name |
+| `user_goal` | Text input | Student's objective |
+| `description` | Textarea | Scene narrative |
+| `personas_involved` | Tag pills + dropdown | Select from available personas; student role auto-excluded |
+| `sequence_order` | Number input | Linear order (1–4) |
+| `timeout_turns` | Number input | Max turns before auto-advance (default 15) |
+| `successMetric` | Textarea | Measurable success criteria |
+| `image_url` | Image upload | Scene background |
+
+**Persona filtering in SceneCard:**
+```typescript
+// Same normalize_name logic as backend — strips titles, non-alpha chars, lowercases
+const normStudentRole = normalizeName(studentRole || "");
+
+// Personas shown in the "add persona" dropdown exclude the student role
+allPersonas.filter(p => normalizeName(p.name) !== normStudentRole)
+```
+
+### Saving Scenes Back to the API
+
+`handleSave()` runs scenes through `normalizeScenes()` before including them in the payload:
+
+```typescript
+// normalizeScenes() — frontend/app/professor/simulation-builder/page.tsx
+function normalizeScenes(scenes: any[]) {
+  return scenes.map(scene => ({
+    ...scene,
+    id:            scene.id,             // Preserved — backend uses this to match existing rows
+    image_url:     scene.image_url,
+    timeout_turns: scene.timeout_turns ?? 15,
+    // Normalize scene_order from either field name
+    scene_order:   scene.sequence_order ?? scene.scene_order,
+  }));
+}
+
+// In handleSave payload:
+const payload = {
+  scenes: normalizeScenes(scenes),
+  // ...
+};
+```
+
+---
+
+## 5. Stage 3 — Publishing Service: Smart Scene Update
+
+`PublishingService.save_simulation_draft()` uses a three-way match strategy when scenes arrive in the save payload:
+
+```
+For each incoming scene:
+  1. Does scene.id match an existing SimulationScene.id?
+     → Yes: update that row in-place
+  2. Does scene.title match an existing scene's title?
+     → Yes: update that row (handles case where ID was not preserved)
+  3. Neither?
+     → Create a new SimulationScene row
+
+After processing all incoming scenes:
+  → Any existing scenes NOT in the incoming list are soft-deleted
+    (deleted_at = now())
+
+For scene_personas:
+  → DELETE all existing associations for the scene
+  → INSERT new ones based on the incoming personas_involved[] names
+    (look up SimulationPersona by name + simulation_id)
+```
+
+This approach is safe for:
+- Reordering scenes (ID preserved)
+- Renaming a scene (falls back to create)
+- Deleting a scene (not in incoming list → soft-deleted)
+- Adding a scene (no ID → created)
+
+---
+
+## 6. Stage 4 — Simulation Start: Serialization into orchestrator_data
+
+`LifecycleService.start_simulation()` builds the `orchestrator_data` dict stored in `UserProgress.orchestrator_data` (JSONB). This snapshot is the source of truth for the runtime — it is not re-queried from DB during a session.
+
+```python
+orchestrator_data = {
+    "id": simulation.id,
+    "title": simulation.title,
+    "description": simulation.description,
+    "challenge": simulation.challenge,
+    "student_role": simulation.student_role,
+    "scenes": [
+        {
+            "id":                scene.id,
+            "title":             scene.title,
+            "description":       scene.description,
+            "user_goal":         scene.user_goal,
+            "objectives":        [scene.user_goal] or ["Complete the scene interaction"],
+            "image_url":         scene.image_url,
+            "personas_involved": scene_personas_map[scene.id],  # List of persona names
+            "agent_ids":         [sanitized_name_slug, ...],    # For @mention routing
+            "timeout_turns":     scene.timeout_turns or 15,
+            "max_turns":         scene.timeout_turns or 15,
+            "success_criteria":  f"User achieves: {scene.user_goal}",
+            "scene_order":       scene.scene_order,
+        }
+        for scene in all_scenes   # Ordered by scene_order
+    ],
+    "personas": [ ... ]           # See PERSONA_PROMPTING_REFERENCE.md
+}
+```
+
+**Key query: scene-persona map (bulk load, avoids N+1):**
+```python
+scene_ids = [scene.id for scene in all_scenes]
+personas_by_scene = repository.get_personas_for_scenes(scene_ids)
+scene_personas_map = {
+    scene.id: [p.name for p in personas_by_scene.get(scene.id, [])]
+    for scene in all_scenes
+}
+```
+
+---
+
+## 7. Stage 5 — Runtime Scene Usage
+
+### Current Scene Access
+
+```python
+# ChatOrchestrator
+current_scene = orchestrator.simulation["scenes"][orchestrator.state.current_scene_index]
+
+# current_scene shape:
+{
+  "id":                2,
+  "title":             "The Board Meeting",
+  "description":       "The executive team has gathered...",
+  "user_goal":         "Convince the board to approve the restructuring plan",
+  "objectives":        ["Convince the board to approve the restructuring plan"],
+  "personas_involved": ["Elena Rossi", "Marco Bianchi"],
+  "agent_ids":         ["elena_rossi", "marco_bianchi"],
+  "timeout_turns":     15,
+  "scene_order":       2,
+}
+```
+
+### How scenes feed the persona system prompt
+
+`scene_context` is built from `current_scene` + `orchestrator.simulation` and passed to every `PersonaAgent.chat_stream()` call:
+
+```python
+scene_context = {
+    "current_scene": {
+        "title":       current_scene.get("title"),
+        "description": current_scene.get("description"),
+        "objectives":  current_scene.get("objectives", []),
+    },
+    "simulation": {
+        "title":        orchestrator.simulation.get("title"),
+        "description":  orchestrator.simulation.get("description"),
+        "challenge":    orchestrator.simulation.get("challenge"),
+        "student_role": orchestrator.simulation.get("student_role"),
+    },
+}
+```
+
+Inside `_get_system_prompt()`, this becomes Block 3 of the system prompt:
+```
+CURRENT SCENE: The Board Meeting
+The executive team has gathered for an emergency meeting...
+
+Scene Objectives: Convince the board to approve the restructuring plan
+
+SCENE AWARENESS — Adapt your emotional register to this environment:
+If the scene describes urgency or conflict, let that tension come through in how you
+speak. If it's exploratory, be more deliberate. Let the stakes inform your language.
+```
+
+### @mention Routing
+
+`personas_involved` in the current scene determines which personas respond:
+
+```python
+# chat_handler.py — @all handling
+personas_involved = current_scene.get("personas_involved", [])  # List of names
+
+for persona in orchestrator.simulation.get("personas", []):
+    if persona["identity"]["name"] in personas_involved:
+        scene_personas.append(persona)
+```
+
+For `@name` mentions, `agent_ids` (sanitized slugs) are used as lookup keys.
+
+### Scene Progression
+
+`SceneProgressionHandler.progress_to_next_scene()` advances the simulation when:
+- `orchestrator.state.turn_count >= current_scene.timeout_turns` (timeout)
+- Scene is marked complete by the grading agent or manual trigger
+
+```python
+# scene_progression.py
+def progress_to_next_scene(orchestrator, user_progress, current_scene_id):
+    next_index = orchestrator.state.current_scene_index + 1
+    scenes = orchestrator.simulation["scenes"]
+
+    if next_index < len(scenes):
+        next_scene = scenes[next_index]
+
+        # Advance orchestrator state
+        orchestrator.state.current_scene_index = next_index
+        orchestrator.state.turn_count = 0
+        orchestrator.state.scene_completed = False
+        orchestrator.state.current_scene_id = next_scene["id"]
+
+        # DB: mark current scene complete, create SceneProgress for next
+        mark_scene_complete(user_progress, current_scene_id)
+        initialize_new_scene(user_progress, next_scene["id"], orchestrator)
+
+        return { "next_scene": next_scene, "scene_intro_message": ... }
+    else:
+        # All scenes done
+        user_progress.simulation_status = "completed"
+        return { "simulation_complete": True }
+```
+
+---
+
+## 8. Field Name Mapping Reference
+
+One of the friction points in this system is that the same concept uses different field names at different layers. This table tracks them:
+
+| Concept | GPT-4o output | DB column | orchestrator_data | Frontend state | SceneCard prop |
+|---|---|---|---|---|---|
+| Display order | `sequence_order` | `scene_order` | `scene_order` | `sequence_order` | `sequence_order` |
+| Student goal | `user_goal` | `user_goal` | `user_goal` | `userGoal` | `user_goal` |
+| Linked personas | `personas_involved` | `scene_personas` (join) | `personas_involved` | `personas_involved` | `personas_involved` |
+| Success criteria | `success_metric` | `success_metric` | `success_criteria` | `successMetric` | `successMetric` |
+| Turn limit | *(not in output)* | `timeout_turns` | `timeout_turns` + `max_turns` | `timeout_turns` | `timeout_turns` |
+| Scene image | `image_url` | `image_url` | `image_url` | `imageUrl` | `image_url` |
+
+> `normalizeScenes()` in page.tsx handles the `sequence_order ↔ scene_order` translation on every save. The repository handles `sequence_order → scene_order` on initial extraction save.
+
+---
+
+## 9. File Path Quick Reference
+
+| What | Where |
+|---|---|
+| Scene extraction prompt | `backend/modules/pdf_processing/ai_extraction_service.py:324` |
+| Student role post-filter (extraction) | `backend/modules/pdf_processing/ai_extraction_service.py:422` |
+| Scene save (initial extraction) | `backend/modules/pdf_processing/repository.py:299` |
+| scene_personas creation (extraction) | `backend/modules/pdf_processing/repository.py:330` |
+| DB model: SimulationScene | `backend/common/db/models/publishing/simulation.py:92` |
+| DB model: scene_personas join table | `backend/common/db/models/publishing/simulation.py:120` |
+| Publishing scene read (API response) | `backend/modules/publishing/router.py:456` |
+| Publishing scene save (draft) | `backend/modules/publishing/service.py:400` |
+| scene_personas rebuild on save | `backend/modules/publishing/service.py:477` |
+| Scene serialization for runtime | `backend/modules/simulation/services/lifecycle_service.py:129` |
+| Scene-persona map (bulk query) | `backend/modules/simulation/services/lifecycle_service.py:108` |
+| Current scene access at runtime | `backend/modules/simulation/core/orchestrator.py:381` |
+| scene_context passed to agents | `backend/modules/simulation/handlers/chat_handler.py:246` |
+| Scene progression handler | `backend/modules/simulation/core/scene_progression.py` |
+| Frontend: handleFieldUpdate scenes | `frontend/app/professor/simulation-builder/page.tsx:1975` |
+| Frontend: normalizeScenes | `frontend/app/professor/simulation-builder/page.tsx` (search `normalizeScenes`) |
+| Frontend: draft load (scenes) | `frontend/app/professor/simulation-builder/page.tsx:444` |
+| SceneCard component | `frontend/components/SceneCard.tsx` |

--- a/architecture.md
+++ b/architecture.md
@@ -48,9 +48,9 @@ backend/
 │   │   │   │   └── user.py      # User model
 │   │   │   ├── publishing/       # Publishing models
 │   │   │   │   ├── __init__.py
-│   │   │   │   ├── scenario.py  # Scenario, ScenarioPersona, ScenarioScene
-│   │   │   │   ├── review.py    # ScenarioReview
-│   │   │   │   └── file.py      # ScenarioFile
+│   │   │   │   ├── simulation.py  # Simulation, SimulationPersona, SimulationScene
+│   │   │   │   ├── review.py      # ScenarioReview
+│   │   │   │   └── file.py        # ScenarioFile
 │   │   │   ├── pdf_processing/   # PDF processing models (future)
 │   │   │   ├── simulation/       # Simulation runtime models
 │   │   │   │   ├── __init__.py
@@ -127,10 +127,14 @@ backend/
 │   │       └── summarization_agent.py    # Summarization agent
 │   ├── pdf_processing/           # PDF processing feature
 │   │   ├── __init__.py
-│   │   ├── router.py             # FastAPI router
+│   │   ├── router.py             # FastAPI router (fast-autofill + progress endpoints)
 │   │   ├── pipeline.py           # Main orchestrator (extract → analyze → generate)
 │   │   ├── parser_service.py     # PDF text extraction (LlamaParse)
-│   │   ├── ai_extraction_service.py  # AI analysis (scenario extraction)
+│   │   ├── ai_extraction_service.py  # GPT-4o persona/scene extraction
+│   │   ├── image_generation_service.py  # Avatar + scene image generation (DALL-E)
+│   │   ├── progress_service.py   # Redis-backed SSE progress tracking
+│   │   ├── service.py            # Supporting service logic
+│   │   ├── tasks.py              # Background tasks
 │   │   ├── repository.py         # Data access (scenario creation, file storage)
 │   │   └── schemas.py            # Request/response models
 │   ├── auth/                     # Authentication & authorization
@@ -297,7 +301,7 @@ backend/
 - **What it does**: SQLAlchemy ORM models organized by module
 - **Structure**: Models are organized in subdirectories by feature module:
   - `models/auth/` - Authentication models (User)
-  - `models/publishing/` - Publishing models (Scenario, ScenarioPersona, ScenarioScene, ScenarioReview, ScenarioFile)
+  - `models/publishing/` - Publishing models (Simulation, SimulationPersona, SimulationScene, ScenarioReview, ScenarioFile)
   - `models/pdf_processing/` - PDF processing models (future)
   - `models/simulation/` - Simulation runtime models
     - `user_progress.py` - UserProgress, StudentSimulationInstance
@@ -309,7 +313,7 @@ backend/
   - `models/student/` - Student models (future)
   - `models/notifications/` - Notification models (future)
 - **Responsibilities**:
-  - Define database tables (User, Scenario, ScenarioPersona, etc.)
+  - Define database tables (User, Simulation, SimulationPersona, etc.)
   - Define relationships (foreign keys, many-to-many)
   - Define table constraints
 - **Backward compatibility**: `common/db/models.py` re-exports all models for existing imports
@@ -796,49 +800,59 @@ This subdirectory contains specialized services that handle specific aspects of 
 **Purpose**: Handles PDF upload, parsing, and scenario generation from business case studies.
 
 **`modules/pdf_processing/router.py`**
-- **What it does**: HTTP endpoints for PDF processing
+- **What it does**: HTTP endpoints for PDF processing (mounted at `/api/pdf-processing/`)
 - **Endpoints**:
-  - `POST /api/parse-pdf/upload` - Upload PDF
-  - `GET /api/parse-pdf/progress/{session_id}` - Get processing progress
-  - `WebSocket /api/parse-pdf/ws/{session_id}` - Real-time progress updates
-- **Current location**: `api/parse_pdf.py`, `api/pdf_progress.py`
-- **Migration**: Extract route handlers
+  - `POST /api/pdf-processing/parse-pdf-fast-autofill` - Extract personas + avatars, return JSON immediately
+  - `POST /api/pdf-processing/parse-pdf-with-progress` - Full pipeline (personas, scenes, images) with Redis-backed progress updates
+  - `GET /api/pdf-processing/pdf-progress/{session_id}` - HTTP polling for progress updates (replaces WebSocket)
+  - `POST /api/pdf-processing/pdf-progress/{session_id}/reset` - Reset progress state
+  - `GET /api/pdf-processing/get-default-personas/` - Return default persona set
+  - `GET /api/pdf-processing/llamaparse-health/` - LlamaParse health check
+  - `POST /api/pdf-processing/parse-pdf` - Legacy endpoint
 
 **`modules/pdf_processing/pipeline.py`**
 - **What it does**: Main orchestrator for PDF processing
 - **Responsibilities**:
   - Coordinate extraction → analysis → generation
-  - Manage processing state
+  - `process_fast_autofill()` — personas + avatars only, synchronous response
+  - `process_full_with_progress()` — full pipeline with Redis progress events
   - Handle errors and retries
-- **Current location**: `api/parse_pdf.py` (inline logic)
-- **Migration**: Extract pipeline logic here
 
 **`modules/pdf_processing/parser_service.py`**
-- **What it does**: PDF text extraction
+- **What it does**: PDF text extraction via LlamaParse
 - **Responsibilities**:
-  - Call LlamaParse API
+  - Call LlamaParse API (PDF → markdown)
   - Extract text and structure
   - Handle PDF parsing errors
-- **Current location**: `api/parse_pdf.py` (inline)
-- **Migration**: Extract parsing logic here
 
 **`modules/pdf_processing/ai_extraction_service.py`**
-- **What it does**: AI-powered scenario extraction
+- **What it does**: GPT-4o-powered persona and scene extraction
 - **Responsibilities**:
-  - Analyze extracted text with GPT-4
-  - Extract scenarios, personas, scenes
-  - Generate scene images (DALL-E)
-- **Current location**: `api/parse_pdf.py` (inline)
-- **Migration**: Extract AI analysis logic here
+  - Single consolidated function `extract_personas_and_key_figures()` used by both pipeline paths
+  - Extract personas (Big Five personality, `current_context`, `knowledge_areas`, `communication_style`)
+  - Extract scenes and learning outcomes
+  - Filter student-role character from persona list
+
+**`modules/pdf_processing/image_generation_service.py`**
+- **What it does**: AI image generation for avatars and scenes
+- **Responsibilities**:
+  - Generate persona avatar images (DALL-E)
+  - Generate scene background images
+  - Upload generated images to S3
+
+**`modules/pdf_processing/progress_service.py`**
+- **What it does**: Redis-backed progress tracking for the full pipeline
+- **Responsibilities**:
+  - Store and emit field-level progress events to Redis
+  - Support HTTP polling from frontend (`PDFProgressTrackerHTTP`)
+  - `send_field_update()` — push named field updates as they complete
 
 **`modules/pdf_processing/repository.py`**
 - **What it does**: Data access for PDF processing
 - **Responsibilities**:
-  - Save uploaded files
-  - Save processing state
-  - Create scenarios from extracted data
-- **Current location**: Inline queries in `api/parse_pdf.py`
-- **Migration**: Extract database operations here
+  - `save_autofill_data()` — persist fast-autofill extraction results
+  - `save_full_pdf_data()` — persist full pipeline results
+  - Create and update `SimulationPersona`, `SimulationScene` records
 
 #### `modules/auth/` - Authentication Feature
 
@@ -944,17 +958,19 @@ This subdirectory contains specialized services that handle specific aspects of 
 **Purpose**: Handles publishing of simulations generated from the simulation builder so they can be assigned to students. Publishing makes a simulation available for assignment by changing its status from draft to published.
 
 **`modules/publishing/router.py`**
-- **What it does**: Publishing endpoints for simulations
+- **What it does**: Publishing endpoints for simulations (prefix: `/api/publishing/simulations`)
 - **Endpoints**:
-  - `GET /api/publishing/simulations/` - Get user's simulations
-  - `GET /api/publishing/simulations/drafts/` - Get draft simulations
-  - `POST /api/publishing/simulations/publish/{scenario_id}` - Publish a simulation (makes it available for assignment)
-  - `POST /api/publishing/simulations/save` - Save simulation changes
-  - `GET /api/publishing/simulations/{scenario_id}/full` - Get full simulation details
-  - `GET /api/publishing/simulations/{id}/upload-status` - Get image upload status
-- **Note**: The API uses "simulations" terminology, but database models use "Scenario" table name
-- **Current location**: `api/publishing.py`
-- **Migration**: Extract routes here
+  - `GET /api/publishing/simulations/` - Get user's simulations (with optional status/draft filters)
+  - `GET /api/publishing/simulations/drafts/` - Get all draft simulations
+  - `GET /api/publishing/simulations/drafts/{simulation_id}` - Get specific draft simulation
+  - `POST /api/publishing/simulations/publish/{simulation_id}` - Publish simulation (draft → active)
+  - `POST /api/publishing/simulations/save` - Save simulation draft (personas, scenes, metadata)
+  - `GET /api/publishing/simulations/{simulation_id}/full` - Get full simulation with personas and scenes
+  - `GET /api/publishing/simulations/{simulation_id}/upload-status` - Get image upload status
+  - `PUT /api/publishing/simulations/{simulation_id}/status` - Update simulation status
+  - `DELETE /api/publishing/simulations/{simulation_id}` - Delete simulation
+  - `WebSocket /api/publishing/simulations/ws/{user_id}` - Real-time upload status updates
+- **Note**: The API uses "simulations" terminology; the primary DB model class is `Simulation` (with `Scenario` as a backward-compat alias)
 
 **`modules/publishing/service.py`**
 - **What it does**: Publishing business logic for simulations
@@ -1007,7 +1023,7 @@ This subdirectory contains specialized services that handle specific aspects of 
 - **`domain.py`**: Domain models (dataclasses) for internal use
   - `PDFMetadata` - Metadata for PDF file storage
   - `ImageUploadInfo` - Information for image uploads
-- **Note**: SQLAlchemy models (Scenario, ScenarioFile) are in `common/db/models/publishing/`. Note: The database uses "Scenario" as the table name, but the API layer refers to them as "simulations".
+- **Note**: SQLAlchemy models (`Simulation`, `SimulationPersona`, `SimulationScene`, `ScenarioFile`) are in `common/db/models/publishing/simulation.py` and siblings. The primary classes are `Simulation`, `SimulationPersona`, `SimulationScene`; legacy `Scenario`/`ScenarioPersona`/`ScenarioScene` aliases are re-exported from `common/db/models/__init__.py` for backward compatibility.
 
 ---
 
@@ -1201,7 +1217,7 @@ modules/simulation/
 - Use `UPPER_SNAKE_CASE`: `MAX_RETRY_ATTEMPTS`, `DEFAULT_TIMEOUT`, `API_BASE_URL`
 
 **Database Models**:
-- Use `PascalCase` singular: `User`, `Scenario`, `ScenarioPersona`
+- Use `PascalCase` singular: `User`, `Simulation`, `SimulationPersona`
 - Table names follow SQLAlchemy conventions (usually plural, lowercase)
 
 ### Import Organization

--- a/backend/modules/pdf_processing/ai_extraction_service.py
+++ b/backend/modules/pdf_processing/ai_extraction_service.py
@@ -168,9 +168,9 @@ class AIExtractionService:
 CRITICAL: You must identify ALL named individuals, companies, organizations, and significant unnamed roles mentioned within the case study narrative.
 
 ━━━ KEY FIGURES IDENTIFICATION ━━━
-- Find ALL key figures that can be turned into simulation personas (NPCs)
-- Include both named and unnamed roles that appear in the business story
-- Even briefly-mentioned figures should be included if they have a clear role
+- Find ALL named individuals and significant roles — aim for at least 4–6 personas
+- Err on the side of including more rather than fewer; a briefly-mentioned figure with a clear role belongs here
+- Include both named and unnamed roles (e.g., "Board Chair", "Union Representative") if they appear in the story
 - Base ALL information STRICTLY on what is stated in the case — do not invent facts
 
 ⚠️ CRITICAL EXCLUSION RULE ⚠️
@@ -243,7 +243,7 @@ CASE STUDY CONTENT:
                         {"role": "user", "content": prompt}
                     ],
                     max_tokens=12000,
-                    temperature=0.2,
+                    temperature=0.3,
                 )
             )
             
@@ -261,39 +261,29 @@ CASE STUDY CONTENT:
                     logger.info(f"[FILTER] Filtering out student role '{student_role}' from key_figures")
                     original_count = len(result["key_figures"])
                     
+                    # Extract only the name portion of student_role (strip parenthetical title).
+                    # We match by name only — matching by role causes false positives because
+                    # common titles like "CEO" or "Director" appear as substrings in many
+                    # student_role strings and would incorrectly filter out legitimate NPCs.
+                    student_role_parts = re.match(r'([^(]+)', student_role)
+                    student_name = student_role_parts.group(1).strip().lower() if student_role_parts else ""
+
                     filtered_figures = []
                     for figure in result["key_figures"]:
-                        figure_name = (figure.get("name") or "").lower()
-                        figure_role = (figure.get("role") or "").lower()
-                        
-                        # Check if this figure matches the student role
+                        figure_name = (figure.get("name") or "").lower().strip()
                         is_student_role = False
-                        
-                        # Extract name from student_role if it's in format "Name (Title)"
-                        student_role_parts = re.match(r'([^(]+)(?:\s*\(([^)]+)\))?', student_role)
-                        if student_role_parts:
-                            student_name = student_role_parts.group(1).strip().lower()
-                            student_title = (student_role_parts.group(2) or "").strip().lower()
-                            
-                            # Check if figure name matches student name or student title
-                            if student_name and (student_name in figure_name or figure_name in student_name):
-                                is_student_role = True
-                                logger.info(f"[FILTER] Filtering out '{figure.get('name')}' - matches student name '{student_name}'")
-                            elif student_title and (student_title in figure_role or figure_role in student_title):
-                                is_student_role = True
-                                logger.info(f"[FILTER] Filtering out '{figure.get('name')}' - role '{figure_role}' matches student title '{student_title}'")
-                        
-                        # Check for exact or partial matches with student_role
-                        if student_role in figure_name or figure_name in student_role:
-                            is_student_role = True
-                        elif student_role in figure_role or figure_role in student_role:
-                            is_student_role = True
-                        
-                        # Check is_main_character flag
+
+                        # Primary: model explicitly flagged this figure as the protagonist
                         if figure.get("is_main_character"):
                             is_student_role = True
                             logger.info(f"[FILTER] Filtering out '{figure.get('name')}' - marked as main character")
-                        
+
+                        # Secondary: name overlap (require at least 4 chars to avoid short false matches)
+                        if not is_student_role and student_name and len(student_name) >= 4:
+                            if student_name in figure_name or figure_name in student_name:
+                                is_student_role = True
+                                logger.info(f"[FILTER] Filtering out '{figure.get('name')}' - name matches student '{student_name}'")
+
                         if not is_student_role:
                             filtered_figures.append(figure)
                     
@@ -307,15 +297,15 @@ CASE STUDY CONTENT:
                         {
                             "name": "Business Manager",
                             "role": "Manager",
-                            "correlation": "Key stakeholder in the business scenario",
+                            "correlation": "Key stakeholder the student will need to work with",
                             "background": "Experienced business professional involved in the case study.",
+                            "current_context": "Currently navigating the central challenge described in the case.",
                             "primary_goals": ["Achieve business objectives", "Make informed decisions", "Drive results"],
+                            "knowledge_areas": ["General business operations", "Industry best practices"],
+                            "communication_style": "Professional and direct.",
                             "personality_traits": {
-                                "analytical": 7,
-                                "creative": 5,
-                                "assertive": 6,
-                                "collaborative": 7,
-                                "detail_oriented": 8
+                                "openness": 6, "conscientiousness": 7,
+                                "extraversion": 5, "agreeableness": 6, "neuroticism": 4
                             },
                             "is_main_character": False
                         }

--- a/backend/modules/simulation/agents/persona_agent.py
+++ b/backend/modules/simulation/agents/persona_agent.py
@@ -463,7 +463,7 @@ your patience, your confidence, and your emotional responses without calling att
 
 OFF-TOPIC OR IRRELEVANT QUESTIONS:
 - If the student asks something that has no connection to the situation — trivia, politics, meta questions about the simulation, random topics — do NOT answer it literally.
-- React the way this person actually would: a flash of confusion, mild impatience, or a pointed redirect. Something like "I'm sorry — what does that have to do with what we're looking at right now?" or just a beat of silence expressed as "...right." before moving on. Stay in the scene.
+- React in a realistic way such as: a flash of confusion, mild impatience, or a pointed redirect. Stay in the scene.
 
 WRITING STYLE — FOLLOW STRICTLY:
 - Prose only. No bullet points, numbered lists, or headers in your responses. Ever.

--- a/backend/modules/simulation/handlers/chat_handler.py
+++ b/backend/modules/simulation/handlers/chat_handler.py
@@ -240,7 +240,22 @@ class ChatHandler:
                             agent = orchestrator.persona_agents[str(persona_simulation_id)]
                             stream_gen = agent.chat_stream(
                                 message=message,
-                                scene_context=current_scene,
+                                # Build the full nested structure that _get_system_prompt() expects.
+                                # Passing current_scene directly (flat dict) left both simulation_block
+                                # and scene_block empty — agents had no case study or scene context.
+                                scene_context={
+                                    'current_scene': {
+                                        'title': current_scene.get('title'),
+                                        'description': current_scene.get('description'),
+                                        'objectives': current_scene.get('objectives', []),
+                                    },
+                                    'simulation': {
+                                        'title': orchestrator.simulation.get('title'),
+                                        'description': orchestrator.simulation.get('description'),
+                                        'challenge': orchestrator.simulation.get('challenge'),
+                                        'student_role': orchestrator.simulation.get('student_role'),
+                                    },
+                                },
                                 user_progress_id=user_progress.id,
                                 scene_id=correct_scene_id,
                                 db=self.db

--- a/frontend/app/professor/simulation-builder/page.tsx
+++ b/frontend/app/professor/simulation-builder/page.tsx
@@ -32,6 +32,46 @@ interface RubricConfig {
   }>;
 }
 
+// ─── Persona mapping helper ───────────────────────────────────────────────────
+// Maps a raw key_figure object (from AI extraction API response) to the shape
+// that PersonaCard expects. Single source of truth — used by all three autofill
+// handlers so changes only need to be made here.
+function mapFigureToPersona(figure: any, index: number) {
+  const pt = figure.personality_traits || {};
+  // Format primary_goals as a bulleted string for display
+  let formattedGoals = "Goals not specified in the case study.";
+  if (Array.isArray(figure.primary_goals) && figure.primary_goals.length > 0) {
+    formattedGoals = figure.primary_goals.map((g: string) => `• ${g}`).join("\n");
+  } else if (typeof figure.primary_goals === "string" && figure.primary_goals.trim()) {
+    const parts = figure.primary_goals.split(/[;\n]/).map((g: string) => g.trim()).filter(Boolean);
+    formattedGoals = parts.length > 1
+      ? parts.map((g: string) => `• ${g}`).join("\n")
+      : `• ${figure.primary_goals}`;
+  }
+  return {
+    id: `persona-${Date.now()}-${index}`,
+    name: figure.name || `Person ${index + 1}`,
+    position: figure.role || "Unknown",
+    description: figure.background || "No background information available.",
+    currentContext: figure.current_context || "",
+    correlation: figure.correlation || "",
+    primaryGoals: formattedGoals,
+    traits: {
+      openness:          pt.openness          ?? 5,
+      conscientiousness: pt.conscientiousness ?? 5,
+      extraversion:      pt.extraversion      ?? 5,
+      agreeableness:     pt.agreeableness     ?? 5,
+      neuroticism:       pt.neuroticism       ?? 5,
+    },
+    defaultTraits: { openness: 5, conscientiousness: 5, extraversion: 5, agreeableness: 5, neuroticism: 5 },
+    knowledgeAreas: Array.isArray(figure.knowledge_areas) ? figure.knowledge_areas : [],
+    communicationStyle: figure.communication_style || "",
+    imageUrl: figure.image_url || figure.imageUrl || "",
+    systemPrompt: figure.system_prompt || "",
+  };
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 // Simple Modal component
 function Modal({ isOpen, onClose, children }: { isOpen: boolean; onClose: () => void; children: React.ReactNode }) {
  React.useEffect(() => {
@@ -1840,35 +1880,9 @@ const handleAddScene = () => {
             }
           }
           
-          return {
-            id: `persona-${Date.now()}-${index}`,
-            name: figure.name || `Person ${index + 1}`,
-            position: figure.role || 'Unknown',
-            description: formatDescription(figure.background || figure.correlation || 'No background information available.'),
-            primaryGoals: formattedGoals,
-            traits: {
-              analytical: figure.personality_traits?.analytical || 5,
-              creative: figure.personality_traits?.creative || 5,
-              assertive: figure.personality_traits?.assertive || 5,
-              collaborative: figure.personality_traits?.collaborative || 5,
-              detail_oriented: figure.personality_traits?.detail_oriented || 5,
-              risk_taking: figure.personality_traits?.risk_taking || 5,
-              empathetic: figure.personality_traits?.empathetic || 5,
-              decisive: figure.personality_traits?.decisive || 5
-            },
-            defaultTraits: {
-              analytical: 5,
-              creative: 5,
-              assertive: 5,
-              collaborative: 5,
-              detail_oriented: 5,
-              risk_taking: 5,
-              empathetic: 5,
-              decisive: 5
-            }
-          };
+          return mapFigureToPersona(figure, index);
         });
-        
+
         setPersonas(newPersonas);
       } else {
         setPersonas([]);
@@ -1942,76 +1956,14 @@ const handleFieldUpdate = (fieldName: string, fieldValue: any) => {
       markAsUnsaved();
       break;
     case 'personas':
-      // Filter out personas that match the student role
-      const currentStudentRole = studentRole.toLowerCase();
-      const filteredFigures = fieldValue.filter((figure: any) => {
-        const figureName = (figure.name || '').toLowerCase();
-        const figureRole = (figure.role || '').toLowerCase();
-        
-        // Skip if this figure matches the student role exactly
-        if (currentStudentRole && (figureName.includes(currentStudentRole) || figureRole.includes(currentStudentRole) || currentStudentRole.includes(figureName) || currentStudentRole.includes(figureRole))) {
-          return false;
-        }
-        
-        // Skip if this figure has a role that suggests they're the main protagonist
-        const protagonistRoles = ['protagonist', 'main character', 'lead', 'principal', 'central figure'];
-        if (protagonistRoles.some(role => figureRole.includes(role))) {
-          return false;
-        }
-        
-        // Skip if marked as main character
-        if (figure.is_main_character) {
-          return false;
-        }
-        
-        return true;
-      });
-      
-      const newPersonas = filteredFigures.map((figure: any, index: number) => {
-        // Format goals properly
-        let formattedGoals = 'Goals not specified in the case study.';
-        if (Array.isArray(figure.primary_goals) && figure.primary_goals.length > 0) {
-          formattedGoals = figure.primary_goals.map((goal: string) => `• ${goal}`).join('\n');
-        } else if (typeof figure.primary_goals === 'string' && figure.primary_goals.trim()) {
-          const goals = figure.primary_goals.split(/[;\n]/).map((goal: string) => goal.trim()).filter((goal: string) => goal.length > 0);
-          if (goals.length > 1) {
-            formattedGoals = goals.map((goal: string) => `• ${goal}`).join('\n');
-          } else {
-            formattedGoals = `• ${figure.primary_goals}`;
-          }
-        }
-        
-        return {
-          id: `persona-${Date.now()}-${index}`,
-          name: figure.name || `Persona ${index + 1}`,
-          position: figure.role || 'Unknown Role',  // Use 'position' not 'role'
-          description: formatDescription(figure.background || figure.correlation || 'Background not specified in the case study.'),  // Use 'description' not 'background'
-          primaryGoals: formattedGoals,  // Use 'primaryGoals' not 'goals'
-          traits: {  // Use 'traits' object, not 'personality' string
-            analytical: figure.personality_traits?.analytical || 5,
-            creative: figure.personality_traits?.creative || 5,
-            assertive: figure.personality_traits?.assertive || 5,
-            collaborative: figure.personality_traits?.collaborative || 5,
-            detail_oriented: figure.personality_traits?.detail_oriented || 5,
-            risk_taking: figure.personality_traits?.risk_taking || 5,
-            empathetic: figure.personality_traits?.empathetic || 5,
-            decisive: figure.personality_traits?.decisive || 5
-          },
-          defaultTraits: {  // Add defaultTraits for reset functionality
-            analytical: 5,
-            creative: 5,
-            assertive: 5,
-            collaborative: 5,
-            detail_oriented: 5,
-            risk_taking: 5,
-            empathetic: 5,
-            decisive: 5
-          },
-          systemPrompt: undefined,  // Initialize as undefined for Advanced Mode
-          imageUrl: figure.image_url || ''  // Map image_url from backend to imageUrl for frontend
-        };
-      });
-      
+      // The backend already filters out the student role (is_main_character flag + name overlap).
+      // Only drop any stragglers still tagged is_main_character to be safe.
+      // Use mapFigureToPersona as the single source of truth for field mapping — Big Five traits,
+      // current_context, knowledge_areas, communication_style, and correlation are all handled there.
+      const newPersonas = (Array.isArray(fieldValue) ? fieldValue : [])
+        .filter((figure: any) => !figure.is_main_character)
+        .map((figure: any, index: number) => mapFigureToPersona(figure, index));
+
       setPersonas(newPersonas);
       // Update database completion field
       setDbCompletionFields(prev => ({
@@ -2201,55 +2153,9 @@ const handleAutofill = async () => {
          
          debugLog(`After filtering: ${filteredFigures.length} figures remain out of ${aiData.key_figures.length} total`);
          
-         const newPersonas = filteredFigures
-           .map((figure: any, index: number) => {
+         const newPersonas = filteredFigures.map((figure: any, index: number) => {
              debugLog(`Processing key figure ${index + 1}:`, figure);
-             console.log(`[DEBUG] Personality traits for ${figure.name}:`, figure.personality_traits);
-             console.log(`[DEBUG] Primary goals for ${figure.name}:`, figure.primary_goals);
-             
-             // Format goals properly
-             let formattedGoals = 'Goals not specified in the case study.';
-             if (Array.isArray(figure.primary_goals) && figure.primary_goals.length > 0) {
-               formattedGoals = figure.primary_goals.map((goal: string) => `• ${goal}`).join('\n');
-             } else if (typeof figure.primary_goals === 'string' && figure.primary_goals.trim()) {
-               // If it's a string, try to split by common separators and bullet them
-               const goals = figure.primary_goals.split(/[;\n]/).map((goal: string) => goal.trim()).filter((goal: string) => goal.length > 0);
-               if (goals.length > 1) {
-                 formattedGoals = goals.map((goal: string) => `• ${goal}`).join('\n');
-               } else {
-                 formattedGoals = `• ${figure.primary_goals}`;
-               }
-             }
-             
-             console.log(`[DEBUG] Formatted goals for ${figure.name}:`, formattedGoals);
-             
-             return {
-               id: `persona-${Date.now()}-${index}`,
-               name: figure.name || `Person ${index + 1}`,
-               position: figure.role || 'Unknown',
-               description: formatDescription(figure.background || figure.correlation || 'No background information available.'),
-               primaryGoals: formattedGoals,
-               traits: {
-                analytical: figure.personality_traits?.analytical || 5,
-                creative: figure.personality_traits?.creative || 5,
-                assertive: figure.personality_traits?.assertive || 5,
-                collaborative: figure.personality_traits?.collaborative || 5,
-                detail_oriented: figure.personality_traits?.detail_oriented || 5,
-                risk_taking: figure.personality_traits?.risk_taking || 5,
-                empathetic: figure.personality_traits?.empathetic || 5,
-                decisive: figure.personality_traits?.decisive || 5
-               },
-               defaultTraits: {
-                analytical: 5,
-                creative: 5,
-                assertive: 5,
-                collaborative: 5,
-                detail_oriented: 5,
-                risk_taking: 5,
-                empathetic: 5,
-                decisive: 5
-               }
-             };
+             return mapFigureToPersona(figure, index);
            });
          
          console.log("=== FINAL PERSONAS ===");
@@ -2455,55 +2361,9 @@ const handleAutofillWithTeachingNotes = async () => {
         
         debugLog(`After filtering: ${filteredFigures.length} figures remain out of ${aiData.key_figures.length} total`);
         
-        const newPersonas = filteredFigures
-          .map((figure: any, index: number) => {
+        const newPersonas = filteredFigures.map((figure: any, index: number) => {
             debugLog(`Processing key figure ${index + 1}:`, figure);
-            console.log(`[DEBUG] Personality traits for ${figure.name}:`, figure.personality_traits);
-            console.log(`[DEBUG] Primary goals for ${figure.name}:`, figure.primary_goals);
-            
-            // Format goals properly
-            let formattedGoals = 'Goals not specified in the case study.';
-            if (Array.isArray(figure.primary_goals) && figure.primary_goals.length > 0) {
-              formattedGoals = figure.primary_goals.map((goal: string) => `• ${goal}`).join('\n');
-            } else if (typeof figure.primary_goals === 'string' && figure.primary_goals.trim()) {
-              // If it's a string, try to split by common separators and bullet them
-              const goals = figure.primary_goals.split(/[;\n]/).map((goal: string) => goal.trim()).filter((goal: string) => goal.length > 0);
-              if (goals.length > 1) {
-                formattedGoals = goals.map((goal: string) => `• ${goal}`).join('\n');
-              } else {
-                formattedGoals = `• ${figure.primary_goals}`;
-              }
-            }
-            
-            console.log(`[DEBUG] Formatted goals for ${figure.name}:`, formattedGoals);
-            
-            return {
-              id: `persona-${Date.now()}-${index}`,
-              name: figure.name || `Person ${index + 1}`,
-              position: figure.role || 'Unknown',
-              description: formatDescription(figure.background || figure.correlation || 'No background information available.'),
-              primaryGoals: formattedGoals,
-              traits: {
-                analytical: figure.personality_traits?.analytical || 5,
-                creative: figure.personality_traits?.creative || 5,
-                assertive: figure.personality_traits?.assertive || 5,
-                collaborative: figure.personality_traits?.collaborative || 5,
-                detail_oriented: figure.personality_traits?.detail_oriented || 5,
-                risk_taking: figure.personality_traits?.risk_taking || 5,
-                empathetic: figure.personality_traits?.empathetic || 5,
-                decisive: figure.personality_traits?.decisive || 5
-              },
-              defaultTraits: {
-                analytical: 5,
-                creative: 5,
-                assertive: 5,
-                collaborative: 5,
-                detail_oriented: 5,
-                risk_taking: 5,
-                empathetic: 5,
-                decisive: 5
-              }
-            };
+            return mapFigureToPersona(figure, index);
           });
         
         console.log("=== FINAL PERSONAS (Teaching Notes) ===");


### PR DESCRIPTION
## Summary

### Backend — Extraction (`ai_extraction_service.py`)
- Prompt now explicitly targets **4–6+ personas**; instructs the model to err on the side of including more
- **Fixed false-positive filtering**: student-role filter now matches by name only (strips parenthetical title, requires ≥4 char overlap) — previously, role-based substring matching silently dropped legitimate NPCs (e.g. a persona with title "CEO" when student_role contained "CEO")
- Primary filter is the model's own `is_main_character` flag; name matching is a secondary safety net only
- Temperature raised 0.2 → 0.3 for richer extraction output
- Fallback persona updated to include `current_context`, `knowledge_areas`, `communication_style`, and Big Five traits

### Backend — Chat Handler (`chat_handler.py`)
- **Fixed scene_context bug**: persona agents were receiving a flat `current_scene` dict; they now receive the correct nested structure `{current_scene: {...}, simulation: {...}}` that `_get_system_prompt()` expects — without this, agents had no case study or scene context at runtime

### Backend — Persona Agent (`persona_agent.py`)
- Simplified off-topic redirect instruction (removed hardcoded example dialogue lines)

### Frontend — Simulation Builder (`simulation-builder/page.tsx`)
- Extracted `mapFigureToPersona()` as a **single source of truth** for figure→persona field mapping
- All three autofill handlers (standard, teaching notes, WebSocket `personas` event) now call it
- Removes ~150 lines of duplicated mapping code
- Correctly maps Big Five traits, `currentContext`, `knowledgeAreas`, `communicationStyle`, `correlation`

### Docs
- `PERSONA_PROMPTING_REFERENCE.md`: expanded to full end-to-end architecture map
- `SCENE_SYSTEM_REFERENCE.md`: new reference doc for the scene generation system
- `architecture.md`: updated to reflect modular restructure

## Test plan

- [ ] Upload a PDF → verify **4–6+ personas** are extracted and none are incorrectly filtered out
- [ ] Confirm student role is excluded while other roles (e.g. "CEO", "Director") are preserved
- [ ] Start a simulation → personas respond with correct case study + scene context (not generic/empty)
- [ ] Run all three autofill paths → Big Five traits and new fields (`currentContext`, `knowledgeAreas`, `communicationStyle`) populate correctly on PersonaCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified persona extraction and a single frontend mapping for consistent Persona cards.
  * Expanded persona profiles: Big Five traits, current context, knowledge areas, communication style, images and system prompts.
  * Clarified stage flow and publish behavior (publish references DB rows in-place).

* **Bug Fixes**
  * Improved persona filtering to avoid including student role and ensure correct runtime persona data loading.

* **Documentation**
  * Major architecture and scene system reference updates covering end-to-end flows.

* **Chores**
  * Database migration to add enhanced persona fields and mapping/persistence updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->