### PR TITLE
fix: resolve case_study_url always returning null

### DIFF
--- a/backend/modules/simulation/repository.py
+++ b/backend/modules/simulation/repository.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, desc, text
 from common.db.models import (
     Simulation, SimulationScene, SimulationPersona, UserProgress, SceneProgress,
     ConversationLog, AgentSessions, SessionMemory, ConversationSummaries,
-    StudentSimulationInstance, scene_personas
+    StudentSimulationInstance, scene_personas, SimulationFile
 )
 
 
@@ -369,6 +369,14 @@ class SimulationRepository:
             ConversationLog.sender_name == "System"
         ).first()
     
+    def get_case_study_url(self, simulation_id: int) -> Optional[str]:
+        """Get the S3 URL for a simulation's case study PDF."""
+        file = self.db.query(SimulationFile).filter(
+            SimulationFile.simulation_id == simulation_id,
+            SimulationFile.file_type == "application/pdf"
+        ).order_by(SimulationFile.uploaded_at.desc()).first()
+        return file.file_path if file else None
+
     def delete_all_user_progress_for_simulation(self, user_id: int, simulation_id: int) -> None:
         """Delete all user progress and related records for a user and simulation."""
         existing_progresses = self.get_user_progress_by_user_and_simulation(user_id, simulation_id)

--- a/backend/modules/simulation/services/lifecycle_service.py
+++ b/backend/modules/simulation/services/lifecycle_service.py
@@ -233,7 +233,7 @@ class LifecycleService:
         elif learning_objectives is None:
             learning_objectives = []
         
-        case_study_url = getattr(simulation, 'case_study_url', None)
+        case_study_url = self.repository.get_case_study_url(simulation.id)
         
         # Build simulation response
         simulation_response = {
@@ -448,7 +448,7 @@ class LifecycleService:
         elif learning_objectives is None:
             learning_objectives = []
         
-        case_study_url = getattr(simulation, 'case_study_url', None)
+        case_study_url = self.repository.get_case_study_url(simulation.id)
         
         # Build simulation response
         simulation_response = {


### PR DESCRIPTION
## Summary
- **Root cause:** `case_study_url` was fetched via `getattr(simulation, 'case_study_url', None)` but `case_study_url` is not a column on the Simulation model — it was only ever set transiently via `setattr()` during publishing, never persisted to the DB
- Added `get_case_study_url()` method to `SimulationRepository` that queries the `SimulationFile` table (`scenario_files`) for the most recent PDF by `simulation_id`
- Replaced both broken `getattr()` calls in `LifecycleService` (`start_simulation` and `resume_simulation`) with the new repository method

## Changes
- `backend/modules/simulation/repository.py` — added `SimulationFile` import + `get_case_study_url()` method
- `backend/modules/simulation/services/lifecycle_service.py` — replaced 2x `getattr(simulation, 'case_study_url', None)` with `self.repository.get_case_study_url(simulation.id)`

## Test plan
- [ ] Start a simulation created from a PDF — Case Study tab should render the PDF in an iframe
- [ ] Start a simulation without a PDF — tab should show "No case study PDF available"
- [ ] Test on both professor test-simulations and student run-simulation pages
- [ ] Click "Open in New Tab" — should open S3 URL directly in browser
- [ ] No database migrations required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case study PDF retrieval capability for simulations.

* **Bug Fixes**
  * Enhanced user progress cleanup logic to ensure all records are properly deleted during removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->