### PR TITLE
fix: map SimulationFile.simulation_id to actual DB column scenario_id

### DIFF
--- a/backend/common/db/models/publishing/file.py
+++ b/backend/common/db/models/publishing/file.py
@@ -13,7 +13,7 @@ class SimulationFile(Base):
     __tablename__ = "scenario_files"  # Keep table name for DB compatibility
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    simulation_id: Mapped[int] = mapped_column(Integer, ForeignKey("simulations.id"), index=True)
+    simulation_id: Mapped[int] = mapped_column("scenario_id", Integer, ForeignKey("simulations.id"), index=True)
     filename: Mapped[str] = mapped_column(String)
     file_path: Mapped[str] = mapped_column(String)
     file_size: Mapped[int] = mapped_column(Integer, default=0)


### PR DESCRIPTION
## Summary
- The rename migration (`2025_12_13`) checked for table `simulation_files` but the table is still `scenario_files`, so the column rename from `scenario_id` → `simulation_id` never executed in the database
- This caused `get_case_study_url()` (from PR #292) to fail with `psycopg2.errors.UndefinedColumn: column scenario_files.simulation_id does not exist`
- Fix: add explicit column name `"scenario_id"` to `mapped_column()` so SQLAlchemy generates correct SQL while keeping `simulation_id` as the Python attribute name

## Test plan
- [ ] Start a simulation that was created from a PDF — should no longer throw 500 error
- [ ] Case Study tab should display the PDF (if one exists) or show empty state gracefully
- [ ] Verify publishing module still creates SimulationFile records correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal database schema mappings to improve code consistency and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->