### PR TITLE
revert: undo case_study_url changes (PRs #292, #295)

### DIFF
--- a/backend/common/db/models/publishing/file.py
+++ b/backend/common/db/models/publishing/file.py
@@ -13,7 +13,7 @@ class SimulationFile(Base):
     __tablename__ = "scenario_files"  # Keep table name for DB compatibility
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    simulation_id: Mapped[int] = mapped_column("scenario_id", Integer, ForeignKey("simulations.id"), index=True)
+    simulation_id: Mapped[int] = mapped_column(Integer, ForeignKey("simulations.id"), index=True)
     filename: Mapped[str] = mapped_column(String)
     file_path: Mapped[str] = mapped_column(String)
     file_size: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/modules/simulation/repository.py
+++ b/backend/modules/simulation/repository.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, desc, text
 from common.db.models import (
     Simulation, SimulationScene, SimulationPersona, UserProgress, SceneProgress,
     ConversationLog, AgentSessions, SessionMemory, ConversationSummaries,
-    StudentSimulationInstance, scene_personas, SimulationFile
+    StudentSimulationInstance, scene_personas
 )
 
 
@@ -369,14 +369,6 @@ class SimulationRepository:
             ConversationLog.sender_name == "System"
         ).first()
     
-    def get_case_study_url(self, simulation_id: int) -> Optional[str]:
-        """Get the S3 URL for a simulation's case study PDF."""
-        file = self.db.query(SimulationFile).filter(
-            SimulationFile.simulation_id == simulation_id,
-            SimulationFile.file_type == "application/pdf"
-        ).order_by(SimulationFile.uploaded_at.desc()).first()
-        return file.file_path if file else None
-
     def delete_all_user_progress_for_simulation(self, user_id: int, simulation_id: int) -> None:
         """Delete all user progress and related records for a user and simulation."""
         existing_progresses = self.get_user_progress_by_user_and_simulation(user_id, simulation_id)

--- a/backend/modules/simulation/services/lifecycle_service.py
+++ b/backend/modules/simulation/services/lifecycle_service.py
@@ -233,7 +233,7 @@ class LifecycleService:
         elif learning_objectives is None:
             learning_objectives = []
         
-        case_study_url = self.repository.get_case_study_url(simulation.id)
+        case_study_url = getattr(simulation, 'case_study_url', None)
         
         # Build simulation response
         simulation_response = {
@@ -448,7 +448,7 @@ class LifecycleService:
         elif learning_objectives is None:
             learning_objectives = []
         
-        case_study_url = self.repository.get_case_study_url(simulation.id)
+        case_study_url = getattr(simulation, 'case_study_url', None)
         
         # Build simulation response
         simulation_response = {


### PR DESCRIPTION
## Summary
- Reverts PR #292 (`get_case_study_url()` in repository + lifecycle_service changes)
- Reverts PR #295 (column mapping fix for SimulationFile model)
- The `scenario_files` table has a `scenario_id` column but the model defined `simulation_id` — the rename migration never ran. The fix needs more investigation before re-applying.

## What this restores
- `lifecycle_service.py`: goes back to `getattr(simulation, 'case_study_url', None)` (returns None, graceful empty state)
- `repository.py`: removes `get_case_study_url()` method
- `file.py`: reverts column mapping back to original

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal data access patterns in simulation-related functionality to improve code organization and reduce component coupling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->