### PR TITLE
feat: forgot password flow with email token reset

### DIFF
--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -71,6 +71,14 @@ class Settings(BaseSettings):
     daytona_api_url: Optional[str] = None
     daytona_target: Optional[str] = "us"
 
+    # SMTP / Email Configuration
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    email_from_address: str = ""
+    email_from_name: str = "n-aible"
+
     @property
     def worker_id(self) -> str:
         """

--- a/backend/common/services/cache_service.py
+++ b/backend/common/services/cache_service.py
@@ -129,6 +129,69 @@ class RedisManager:
         except RedisError as e:
             logger.error(f"[REDIS] Error deleting key {key}: {e}")
             return False
+
+    def getdel(self, key: str) -> Optional[Any]:
+        """Atomically get and delete a key using Redis GETDEL command.
+
+        This is an atomic operation that retrieves the value and deletes the key
+        in a single Redis command, preventing race conditions where multiple
+        clients could read the same value before any of them delete it.
+
+        Returns the value (parsed as JSON if possible) or None if key doesn't exist.
+        """
+        if not self._ensure_connected():
+            return None
+        try:
+            # GETDEL is available in Redis 6.2.0+
+            # It atomically gets the value and deletes the key
+            value = self.redis.getdel(key)
+            if value is None:
+                return None
+            # Try to parse as JSON, fallback to string
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return value
+        except AttributeError:
+            # Fallback for older Redis versions: use Lua script for atomicity
+            logger.warning(f"[REDIS] GETDEL not available, using Lua script fallback for {key}")
+            lua_script = """
+            local value = redis.call('GET', KEYS[1])
+            if value then
+                redis.call('DEL', KEYS[1])
+            end
+            return value
+            """
+            try:
+                value = self.redis.eval(lua_script, 1, key)
+                if value is None:
+                    return None
+                try:
+                    return json.loads(value)
+                except (json.JSONDecodeError, TypeError):
+                    return value
+            except RedisError as lua_error:
+                logger.error(f"[REDIS] Error in Lua script getdel for {key}: {lua_error}")
+                return None
+        except (ConnectionError, RedisError) as e:
+            logger.warning(f"[REDIS] Connection error in getdel for {key}: {e}, attempting reconnect...")
+            self._connect()
+            if self.redis is None:
+                return None
+            try:
+                value = self.redis.getdel(key)
+                if value is None:
+                    return None
+                try:
+                    return json.loads(value)
+                except (json.JSONDecodeError, TypeError):
+                    return value
+            except RedisError as retry_error:
+                logger.error(f"[REDIS] Error in getdel for {key} after reconnect: {retry_error}")
+                return None
+        except RedisError as e:
+            logger.error(f"[REDIS] Error in getdel for {key}: {e}")
+            return None
     
     def exists(self, key: str) -> bool:
         """Check if key exists."""

--- a/backend/common/services/email_service.py
+++ b/backend/common/services/email_service.py
@@ -1,1 +1,124 @@
-"""Placeholder for outbound email helpers (SMTP, templates)."""
+"""Outbound email helpers — async SMTP delivery with inline templates."""
+
+import logging
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Optional
+
+import aiosmtplib
+
+from common.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def send_email(
+    recipient_email: str,
+    subject: str,
+    html_body: str,
+    plain_body: Optional[str] = None,
+) -> bool:
+    """Send an email via SMTP.
+
+    Returns True on success, False on failure (never raises — callers should
+    not crash because an email failed to send).
+    """
+    settings = get_settings()
+
+    if not settings.smtp_host or not settings.email_from_address:
+        logger.warning(
+            "Email sending skipped: SMTP_SERVER / EMAIL_FROM_ADDRESS not configured."
+        )
+        return False
+
+    message = MIMEMultipart("alternative")
+    message["Subject"] = subject
+    message["From"] = f"{settings.email_from_name} <{settings.email_from_address}>"
+    message["To"] = recipient_email
+
+    if plain_body:
+        message.attach(MIMEText(plain_body, "plain"))
+    message.attach(MIMEText(html_body, "html"))
+
+    try:
+        await aiosmtplib.send(
+            message,
+            hostname=settings.smtp_host,
+            port=settings.smtp_port,
+            username=settings.smtp_username or None,
+            password=settings.smtp_password or None,
+            start_tls=True,
+        )
+        logger.info("Email sent to %s — subject: %s", recipient_email, subject)
+        return True
+    except Exception as exc:
+        logger.error(
+            "Failed to send email to %s: %s", recipient_email, exc, exc_info=True
+        )
+        return False
+
+
+async def send_password_reset_email(
+    recipient_email: str,
+    user_name: str,
+    reset_url: str,
+) -> bool:
+    """Send a password reset email with an inline HTML template."""
+    subject = "Reset your n-aible password"
+
+    html_body = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+    <body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0f0f0f;color:#ffffff;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="background:#0f0f0f;padding:40px 20px;">
+        <tr>
+          <td align="center">
+            <table width="100%" style="max-width:520px;background:#1a1a1a;border-radius:12px;border:1px solid #2a2a2a;overflow:hidden;">
+              <tr>
+                <td style="padding:32px 40px;border-bottom:1px solid #2a2a2a;">
+                  <p style="margin:0;font-size:22px;font-weight:700;color:#ffffff;">n-aible</p>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:40px;">
+                  <h1 style="margin:0 0 8px;font-size:24px;font-weight:700;color:#ffffff;">Reset your password</h1>
+                  <p style="margin:0 0 24px;font-size:15px;color:#9ca3af;">Hi {user_name},</p>
+                  <p style="margin:0 0 32px;font-size:15px;color:#9ca3af;line-height:1.6;">
+                    We received a request to reset the password for your n-aible account.
+                    Click the button below to choose a new password. This link expires in
+                    <strong style="color:#ffffff;">15 minutes</strong>.
+                  </p>
+                  <a href="{reset_url}"
+                     style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#3b82f6,#8b5cf6);color:#ffffff;text-decoration:none;border-radius:8px;font-size:15px;font-weight:600;">
+                    Reset password
+                  </a>
+                  <p style="margin:32px 0 0;font-size:13px;color:#6b7280;line-height:1.6;">
+                    If you didn't request this, you can safely ignore this email — your
+                    password won't change.<br><br>
+                    Or copy this link into your browser:<br>
+                    <span style="color:#9ca3af;word-break:break-all;">{reset_url}</span>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:24px 40px;border-top:1px solid #2a2a2a;">
+                  <p style="margin:0;font-size:12px;color:#6b7280;">© n-aible — AI-powered education platform</p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+    </html>
+    """
+
+    plain_body = (
+        f"Hi {user_name},\n\n"
+        "We received a request to reset your n-aible password.\n\n"
+        f"Reset your password here (expires in 15 minutes):\n{reset_url}\n\n"
+        "If you didn't request this, you can ignore this email."
+    )
+
+    return await send_email(recipient_email, subject, html_body, plain_body)

--- a/backend/common/services/email_service.py
+++ b/backend/common/services/email_service.py
@@ -1,5 +1,6 @@
 """Outbound email helpers — async SMTP delivery with inline templates."""
 
+import html
 import logging
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -10,6 +11,13 @@ import aiosmtplib
 from common.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _mask_email(email: str) -> str:
+    local, _, domain = email.partition("@")
+    if not domain:
+        return "***"
+    return f"{local[:1]}***@{domain}"
 
 
 async def send_email(
@@ -49,11 +57,11 @@ async def send_email(
             password=settings.smtp_password or None,
             start_tls=True,
         )
-        logger.info("Email sent to %s — subject: %s", recipient_email, subject)
+        logger.info("Email sent to %s — subject: %s", _mask_email(recipient_email), subject)
         return True
     except Exception as exc:
         logger.error(
-            "Failed to send email to %s: %s", recipient_email, exc, exc_info=True
+            "Failed to send email to %s: %s", _mask_email(recipient_email), exc, exc_info=True
         )
         return False
 
@@ -65,6 +73,9 @@ async def send_password_reset_email(
 ) -> bool:
     """Send a password reset email with an inline HTML template."""
     subject = "Reset your n-aible password"
+
+    safe_user_name = html.escape(user_name, quote=True)
+    safe_reset_url = html.escape(reset_url, quote=True)
 
     html_body = f"""
     <!DOCTYPE html>
@@ -83,13 +94,13 @@ async def send_password_reset_email(
               <tr>
                 <td style="padding:40px;">
                   <h1 style="margin:0 0 8px;font-size:24px;font-weight:700;color:#ffffff;">Reset your password</h1>
-                  <p style="margin:0 0 24px;font-size:15px;color:#9ca3af;">Hi {user_name},</p>
+                  <p style="margin:0 0 24px;font-size:15px;color:#9ca3af;">Hi {safe_user_name},</p>
                   <p style="margin:0 0 32px;font-size:15px;color:#9ca3af;line-height:1.6;">
                     We received a request to reset the password for your n-aible account.
                     Click the button below to choose a new password. This link expires in
                     <strong style="color:#ffffff;">15 minutes</strong>.
                   </p>
-                  <a href="{reset_url}"
+                  <a href="{safe_reset_url}"
                      style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#3b82f6,#8b5cf6);color:#ffffff;text-decoration:none;border-radius:8px;font-size:15px;font-weight:600;">
                     Reset password
                   </a>
@@ -97,7 +108,7 @@ async def send_password_reset_email(
                     If you didn't request this, you can safely ignore this email — your
                     password won't change.<br><br>
                     Or copy this link into your browser:<br>
-                    <span style="color:#9ca3af;word-break:break-all;">{reset_url}</span>
+                    <span style="color:#9ca3af;word-break:break-all;">{safe_reset_url}</span>
                   </p>
                 </td>
               </tr>

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -1,6 +1,7 @@
 """
 Authentication router - Login, register, token refresh, OAuth endpoints
 """
+import asyncio
 import os
 import logging
 import urllib.parse
@@ -211,14 +212,18 @@ async def forgot_password(request: PasswordReset, db: Session = Depends(get_db))
     normalized_email = request.email.strip().lower()
     user = db.query(User).filter(func.lower(User.email) == normalized_email).first()
 
-    # Always return the same response to prevent user enumeration
+    # Always return the same response to prevent user enumeration.
+    # Email is sent via create_task so both branches (user found / not found)
+    # return immediately with the same latency profile.
     if user and (not user.provider or user.provider == "password"):
         token = auth_service.generate_password_reset_token(user.id)
         reset_url = f"{settings.frontend_url}/reset-password?token={token}"
-        await send_password_reset_email(
-            recipient_email=user.email,
-            user_name=user.full_name or user.username,
-            reset_url=reset_url,
+        asyncio.create_task(
+            send_password_reset_email(
+                recipient_email=user.email,
+                user_name=user.full_name or user.username,
+                reset_url=reset_url,
+            )
         )
 
     return {"message": "If an account exists for that email, a reset link has been sent."}
@@ -227,7 +232,9 @@ async def forgot_password(request: PasswordReset, db: Session = Depends(get_db))
 @router.post("/reset-password")
 async def reset_password(request: PasswordResetConfirm, db: Session = Depends(get_db)):
     """Complete a password reset using a token from the reset email."""
-    user_id = auth_service.validate_password_reset_token(request.token)
+    # consume_and_validate atomically deletes the token before the DB write,
+    # preventing two concurrent requests with the same token from both succeeding.
+    user_id = auth_service.consume_and_validate_password_reset_token(request.token)
     if not user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -238,15 +245,13 @@ async def reset_password(request: PasswordResetConfirm, db: Session = Depends(ge
     if not user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="User not found.",
+            detail="Reset link is invalid or has expired. Please request a new one.",
         )
 
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
     user.updated_at = datetime.utcnow()
     db.add(user)
     db.commit()
-
-    auth_service.consume_password_reset_token(request.token)
 
     return {"message": "Password updated successfully. You can now log in."}
 

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -21,6 +21,7 @@ from common.db.models import User
 from common.db.schemas import UserResponse
 from modules.auth.schemas import (
     UserRegister, UserLogin, UserLoginResponse, PasswordResetRequest,
+    PasswordReset, PasswordResetConfirm,
     AccountLinkingRequest, RoleSelectionRequest, OAuthUserData
 )
 from modules.auth.service import auth_service
@@ -203,31 +204,51 @@ async def logout_user(response: Response):
 
 
 @router.post("/forgot-password")
-async def forgot_password(request: PasswordResetRequest, db: Session = Depends(get_db)):
-    """Reset a user's password after confirming email"""
-    normalized_email = request.email.strip().lower()
+async def forgot_password(request: PasswordReset, db: Session = Depends(get_db)):
+    """Initiate a password reset — sends a token email if the account exists."""
+    from common.services.email_service import send_password_reset_email
 
+    normalized_email = request.email.strip().lower()
     user = db.query(User).filter(func.lower(User.email) == normalized_email).first()
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No account found with that email address"
+
+    # Always return the same response to prevent user enumeration
+    if user and (not user.provider or user.provider == "password"):
+        token = auth_service.generate_password_reset_token(user.id)
+        reset_url = f"{settings.frontend_url}/reset-password?token={token}"
+        await send_password_reset_email(
+            recipient_email=user.email,
+            user_name=user.full_name or user.username,
+            reset_url=reset_url,
         )
 
-    if user.provider and user.provider != "password":
+    return {"message": "If an account exists for that email, a reset link has been sent."}
+
+
+@router.post("/reset-password")
+async def reset_password(request: PasswordResetConfirm, db: Session = Depends(get_db)):
+    """Complete a password reset using a token from the reset email."""
+    user_id = auth_service.validate_password_reset_token(request.token)
+    if not user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This account uses Google sign-in. Please login with Google to manage your password."
+            detail="Reset link is invalid or has expired. Please request a new one.",
         )
 
-    # Use async password hashing to avoid blocking the event loop
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User not found.",
+        )
+
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
     user.updated_at = datetime.utcnow()
-
     db.add(user)
     db.commit()
 
-    return {"message": "Password updated successfully"}
+    auth_service.consume_password_reset_token(request.token)
+
+    return {"message": "Password updated successfully. You can now log in."}
 
 
 @router.post("/check-email")

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -232,8 +232,8 @@ async def forgot_password(request: PasswordReset, db: Session = Depends(get_db))
 @router.post("/reset-password")
 async def reset_password(request: PasswordResetConfirm, db: Session = Depends(get_db)):
     """Complete a password reset using a token from the reset email."""
-    # consume_and_validate atomically deletes the token before the DB write,
-    # preventing two concurrent requests with the same token from both succeeding.
+    # Atomically consume and validate the token using Redis GETDEL.
+    # This prevents race conditions - only one request can successfully consume the token.
     user_id = auth_service.consume_and_validate_password_reset_token(request.token)
     if not user_id:
         raise HTTPException(
@@ -241,6 +241,7 @@ async def reset_password(request: PasswordResetConfirm, db: Session = Depends(ge
             detail="Reset link is invalid or has expired. Please request a new one.",
         )
 
+    # Fetch user and update password in a single DB transaction
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(
@@ -248,6 +249,7 @@ async def reset_password(request: PasswordResetConfirm, db: Session = Depends(ge
             detail="Reset link is invalid or has expired. Please request a new one.",
         )
 
+    # Hash the new password asynchronously to avoid blocking
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
     user.updated_at = datetime.utcnow()
     db.add(user)
@@ -682,4 +684,3 @@ async def get_auth_status(
             "error": str(e),
             "status_code": 500
         }
-

--- a/backend/modules/auth/schemas.py
+++ b/backend/modules/auth/schemas.py
@@ -44,11 +44,19 @@ class PasswordResetRequest(BaseModel):
         return self
 
 class PasswordReset(BaseModel):
+    """Used by POST /forgot-password — only email required."""
     email: str
 
 class PasswordResetConfirm(BaseModel):
+    """Used by POST /reset-password — token from email + new password."""
     token: str
     new_password: str
+
+    @model_validator(mode="after")
+    def validate_password(self):
+        if len(self.new_password) < 6:
+            raise ValueError("New password must be at least 6 characters long")
+        return self
 
 # OAuth schemas
 class GoogleOAuthRequest(BaseModel):

--- a/backend/modules/auth/service.py
+++ b/backend/modules/auth/service.py
@@ -1,7 +1,9 @@
 """
 Authentication service - Business logic for authentication
 """
+import json
 import os
+import secrets
 from datetime import timedelta
 from typing import Optional
 from fastapi import HTTPException, status, Request, Response
@@ -183,6 +185,42 @@ class AuthService:
         
         return db_user
     
+    # ------------------------------------------------------------------
+    # Password-reset token helpers (Redis-backed, 15-minute TTL)
+    # ------------------------------------------------------------------
+
+    _PW_RESET_PREFIX = "pw_reset:"
+    _PW_RESET_TTL = 15 * 60  # 15 minutes in seconds
+
+    def generate_password_reset_token(self, user_id: int) -> str:
+        """Generate a single-use password reset token stored in Redis."""
+        from common.services.cache_service import redis_manager
+
+        token = secrets.token_urlsafe(32)
+        key = f"{self._PW_RESET_PREFIX}{token}"
+        redis_manager.set(key, json.dumps({"user_id": user_id}), ttl=self._PW_RESET_TTL)
+        return token
+
+    def validate_password_reset_token(self, token: str) -> Optional[int]:
+        """Return user_id if the token is valid, None otherwise."""
+        from common.services.cache_service import redis_manager
+
+        key = f"{self._PW_RESET_PREFIX}{token}"
+        raw = redis_manager.get(key)
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw) if isinstance(raw, str) else raw
+            return int(data["user_id"])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    def consume_password_reset_token(self, token: str) -> None:
+        """Delete the token from Redis (single-use enforcement)."""
+        from common.services.cache_service import redis_manager
+
+        redis_manager.delete(f"{self._PW_RESET_PREFIX}{token}")
+
     def set_auth_cookie(self, response: Response, access_token: str):
         """Set authentication cookie with proper security settings"""
         

--- a/backend/modules/auth/service.py
+++ b/backend/modules/auth/service.py
@@ -224,19 +224,20 @@ class AuthService:
     def consume_and_validate_password_reset_token(self, token: str) -> Optional[int]:
         """Atomically consume and validate a reset token.
 
-        Gets the stored value then immediately deletes it so that concurrent
-        requests with the same token cannot both succeed — the first caller
-        wins, the second gets None.  Returns user_id on success, None if the
-        token is missing or malformed.
+        Uses Redis GETDEL to atomically retrieve and delete the token in a single
+        operation, preventing race conditions where concurrent requests with the
+        same token could both succeed. The first caller wins, subsequent callers
+        get None. Returns user_id on success, None if the token is missing or malformed.
         """
         from common.services.cache_service import redis_manager
 
         key = f"{self._PW_RESET_PREFIX}{token}"
-        raw = redis_manager.get(key)
+        # Use atomic getdel operation instead of separate get + delete
+        raw = redis_manager.getdel(key)
         if not raw:
             return None
-        redis_manager.delete(key)
         try:
+            # Parse the data (getdel already handles JSON parsing, but handle both cases)
             data = json.loads(raw) if isinstance(raw, str) else raw
             return int(data["user_id"])
         except (KeyError, ValueError, TypeError):

--- a/backend/modules/auth/service.py
+++ b/backend/modules/auth/service.py
@@ -221,6 +221,27 @@ class AuthService:
 
         redis_manager.delete(f"{self._PW_RESET_PREFIX}{token}")
 
+    def consume_and_validate_password_reset_token(self, token: str) -> Optional[int]:
+        """Atomically consume and validate a reset token.
+
+        Gets the stored value then immediately deletes it so that concurrent
+        requests with the same token cannot both succeed — the first caller
+        wins, the second gets None.  Returns user_id on success, None if the
+        token is missing or malformed.
+        """
+        from common.services.cache_service import redis_manager
+
+        key = f"{self._PW_RESET_PREFIX}{token}"
+        raw = redis_manager.get(key)
+        if not raw:
+            return None
+        redis_manager.delete(key)
+        try:
+            data = json.loads(raw) if isinstance(raw, str) else raw
+            return int(data["user_id"])
+        except (KeyError, ValueError, TypeError):
+            return None
+
     def set_auth_cookie(self, response: Response, access_token: str):
         """Set authentication cookie with proper security settings"""
         

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "scikit-learn>=1.7.0,<2.0.0",
     "daytona-sdk>=0.10.0",
     "openpyxl>=3.1.0",
+    "aiosmtplib>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -153,6 +153,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosmtplib"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ad/240a7ce4e50713b111dff8b781a898d8d4770e5d6ad4899103f84c86005c/aiosmtplib-5.1.0.tar.gz", hash = "sha256:2504a23b2b63c9de6bc4ea719559a38996dba68f73f6af4eb97be20ee4c5e6c4", size = 66176, upload-time = "2026-01-25T01:51:11.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/70f2c452acd7ed18c558c8ace9a8cf4fdcc70eae9a41749b5bdc53eb6f45/aiosmtplib-5.1.0-py3-none-any.whl", hash = "sha256:368029440645b486b69db7029208a7a78c6691b90d24a5332ddba35d9109d55b", size = 27778, upload-time = "2026-01-25T01:51:10.026Z" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2081,6 +2090,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "aiosmtplib" },
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "boto3" },
@@ -2130,6 +2140,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.12.0" },
+    { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "alembic", specifier = "==1.16.2" },
     { name = "bcrypt", specifier = ">=3.2.0,<4.0.0" },
     { name = "boto3", specifier = ">=1.34.0" },

--- a/frontend/app/api/auth/forgot-password/route.ts
+++ b/frontend/app/api/auth/forgot-password/route.ts
@@ -4,7 +4,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    const backendUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL
     if (!backendUrl) {
       return NextResponse.json(
         { error: 'Backend server configuration is missing.' },
@@ -20,6 +20,7 @@ export async function POST(request: NextRequest) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10000),
       })
     } catch (fetchError) {
       console.error('forgot-password route: network error:', fetchError)

--- a/frontend/app/api/auth/forgot-password/route.ts
+++ b/frontend/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!backendUrl) {
+      return NextResponse.json(
+        { error: 'Backend server configuration is missing.' },
+        { status: 500 }
+      )
+    }
+
+    const endpoint = `${backendUrl.replace(/\/$/, '')}/api/auth/users/forgot-password`
+
+    let response: Response
+    try {
+      response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    } catch (fetchError) {
+      console.error('forgot-password route: network error:', fetchError)
+      return NextResponse.json(
+        { error: 'Backend server is unavailable. Please try again.' },
+        { status: 503 }
+      )
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      const errorMessage = data.detail || data.error || data.message || 'Request failed'
+      return NextResponse.json({ error: errorMessage }, { status: response.status })
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error('forgot-password route: unexpected error:', error)
+    return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 })
+  }
+}

--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!backendUrl) {
+      return NextResponse.json(
+        { error: 'Backend server configuration is missing.' },
+        { status: 500 }
+      )
+    }
+
+    const endpoint = `${backendUrl.replace(/\/$/, '')}/api/auth/users/reset-password`
+
+    let response: Response
+    try {
+      response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    } catch (fetchError) {
+      console.error('reset-password route: network error:', fetchError)
+      return NextResponse.json(
+        { error: 'Backend server is unavailable. Please try again.' },
+        { status: 503 }
+      )
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      const errorMessage = data.detail || data.error || data.message || 'Request failed'
+      return NextResponse.json({ error: errorMessage }, { status: response.status })
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error('reset-password route: unexpected error:', error)
+    return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 })
+  }
+}

--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -4,7 +4,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    const backendUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL
     if (!backendUrl) {
       return NextResponse.json(
         { error: 'Backend server configuration is missing.' },
@@ -20,6 +20,7 @@ export async function POST(request: NextRequest) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10000),
       })
     } catch (fetchError) {
       console.error('reset-password route: network error:', fetchError)

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -2,16 +2,12 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 export default function ForgotPasswordPage() {
-  const router = useRouter()
   const [email, setEmail] = useState("")
-  const [confirmEmail, setConfirmEmail] = useState("")
-  const [newPassword, setNewPassword] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
@@ -21,18 +17,8 @@ export default function ForgotPasswordPage() {
     setError(null)
     setSuccess(null)
 
-    if (!email.trim() || !confirmEmail.trim() || !newPassword.trim()) {
-      setError("Please complete all fields.")
-      return
-    }
-
-    if (email.trim().toLowerCase() !== confirmEmail.trim().toLowerCase()) {
-      setError("Emails do not match.")
-      return
-    }
-
-    if (newPassword.trim().length < 6) {
-      setError("New password must be at least 6 characters long.")
+    if (!email.trim()) {
+      setError("Please enter your email address.")
       return
     }
 
@@ -40,34 +26,20 @@ export default function ForgotPasswordPage() {
     try {
       const response = await fetch("/api/auth/forgot-password", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          email,
-          confirm_email: confirmEmail,
-          new_password: newPassword,
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
       })
 
       const data = await response.json()
 
       if (!response.ok) {
-        throw new Error(data.detail || data.message || "Failed to reset password.")
+        throw new Error(data.error || data.detail || "Something went wrong.")
       }
 
-      setSuccess("Password updated successfully! You can now log in with your new password.")
+      setSuccess("If an account exists for that email, a reset link has been sent. Check your inbox.")
       setEmail("")
-      setConfirmEmail("")
-      setNewPassword("")
-      // Redirect back to login after a short delay
-      setTimeout(() => router.push("/"), 3000)
     } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message)
-      } else {
-        setError("Failed to reset password. Please try again.")
-      }
+      setError(err instanceof Error ? err.message : "Failed to send reset email. Please try again.")
     } finally {
       setLoading(false)
     }
@@ -85,9 +57,9 @@ export default function ForgotPasswordPage() {
           <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
             <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Reset your password</h1>
+          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Forgot your password?</h1>
           <p className="text-gray-400 text-sm">
-            Confirm your email and set a new password for your account.
+            Enter your email and we&apos;ll send you a reset link.
           </p>
         </div>
 
@@ -100,30 +72,6 @@ export default function ForgotPasswordPage() {
               placeholder="Enter your email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
-            />
-          </div>
-
-          <div className="space-y-3">
-            <Label htmlFor="confirmEmail" className="text-white font-medium">Confirm Email</Label>
-            <Input
-              id="confirmEmail"
-              type="email"
-              placeholder="Retype your email"
-              value={confirmEmail}
-              onChange={(event) => setConfirmEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
-            />
-          </div>
-
-          <div className="space-y-3">
-            <Label htmlFor="newPassword" className="text-white font-medium">New Password</Label>
-            <Input
-              id="newPassword"
-              type="password"
-              placeholder="Create a new password"
-              value={newPassword}
-              onChange={(event) => setNewPassword(event.target.value)}
               className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
             />
           </div>
@@ -145,7 +93,7 @@ export default function ForgotPasswordPage() {
             className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] font-semibold"
             disabled={loading}
           >
-            {loading ? "Updating password..." : "Update password"}
+            {loading ? "Sending reset link..." : "Send reset link"}
           </Button>
         </form>
 
@@ -159,4 +107,3 @@ export default function ForgotPasswordPage() {
     </div>
   )
 }
-

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -17,7 +17,8 @@ export default function ForgotPasswordPage() {
     setError(null)
     setSuccess(null)
 
-    if (!email.trim()) {
+    const normalizedEmail = email.trim().toLowerCase()
+    if (!normalizedEmail) {
       setError("Please enter your email address.")
       return
     }
@@ -27,7 +28,7 @@ export default function ForgotPasswordPage() {
       const response = await fetch("/api/auth/forgot-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email: normalizedEmail }),
       })
 
       const data = await response.json()

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -125,7 +125,7 @@ function ResetPasswordForm() {
           {error && (
             <div className="bg-red-900/20 border border-red-500/50 rounded-md p-3">
               <p className="text-red-400 text-sm font-medium">{error}</p>
-              {(error.includes("invalid") || error.includes("expired")) && (
+              {(error.toLowerCase().includes("invalid") || error.toLowerCase().includes("expired")) && (
                 <p className="text-red-400/70 text-xs mt-1">
                   <Link href="/forgot-password" className="underline hover:text-red-300">
                     Request a new reset link

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useState, useEffect, Suspense } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+function ResetPasswordForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token")
+
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    if (!token) {
+      setError("No reset token found. Please request a new password reset link.")
+    }
+  }, [token])
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    if (!newPassword || !confirmPassword) {
+      setError("Please fill in both password fields.")
+      return
+    }
+
+    if (newPassword.length < 6) {
+      setError("Password must be at least 6 characters long.")
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match.")
+      return
+    }
+
+    if (!token) {
+      setError("Invalid reset link. Please request a new one.")
+      return
+    }
+
+    setLoading(true)
+    try {
+      const response = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, new_password: newPassword }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || data.detail || "Failed to reset password.")
+      }
+
+      setSuccess(true)
+      setTimeout(() => router.push("/"), 3000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to reset password. Please try again.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md relative z-10 animate-fade-scale">
+      <div className="text-center mb-8">
+        <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
+          <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
+        </div>
+        <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Set a new password</h1>
+        <p className="text-gray-400 text-sm">
+          Choose a new password for your account.
+        </p>
+      </div>
+
+      {success ? (
+        <div className="space-y-5">
+          <div className="bg-emerald-900/20 border border-emerald-500/50 rounded-md p-4">
+            <p className="text-emerald-400 text-sm font-medium">
+              Password updated successfully! Redirecting you to login…
+            </p>
+          </div>
+          <div className="text-center">
+            <Link href="/" className="text-white hover:underline text-sm">
+              Go to login now
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+          <div className="space-y-3">
+            <Label htmlFor="newPassword" className="text-white font-medium">New password</Label>
+            <Input
+              id="newPassword"
+              type="password"
+              placeholder="At least 6 characters"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+            />
+          </div>
+
+          <div className="space-y-3">
+            <Label htmlFor="confirmPassword" className="text-white font-medium">Confirm new password</Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              placeholder="Repeat your new password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-900/20 border border-red-500/50 rounded-md p-3">
+              <p className="text-red-400 text-sm font-medium">{error}</p>
+              {(error.includes("invalid") || error.includes("expired")) && (
+                <p className="text-red-400/70 text-xs mt-1">
+                  <Link href="/forgot-password" className="underline hover:text-red-300">
+                    Request a new reset link
+                  </Link>
+                </p>
+              )}
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] font-semibold"
+            disabled={loading || !token}
+          >
+            {loading ? "Updating password..." : "Update password"}
+          </Button>
+        </form>
+      )}
+
+      <div className="text-center mt-6">
+        <span className="text-gray-400">Remembered your password? </span>
+        <Link href="/" className="text-white hover:underline">
+          Return to login
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse" />
+        <div className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }} />
+      </div>
+      <Suspense fallback={<div className="text-gray-400">Loading…</div>}>
+        <ResetPasswordForm />
+      </Suspense>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Email service**: New `email_service.py` with async SMTP delivery via `aiosmtplib`; includes inline HTML password reset email template; silently logs failures instead of crashing requests
- **Config**: Added SMTP fields to `Settings` (`smtp_host`, `smtp_port`, `smtp_username`, `smtp_password`, `email_from_address`, `email_from_name`) — all default to empty strings so dev environments work without email configured
- **Token management**: Added `generate_password_reset_token`, `validate_password_reset_token`, and `consume_password_reset_token` to `AuthService` — Redis-backed with 15-minute TTL and single-use enforcement
- **Backend endpoints**: `/forgot-password` now accepts email only, sends reset link, and always returns a generic message (prevents user enumeration); new `/reset-password` endpoint validates token, updates password hash, and consumes the token
- **Schemas**: `PasswordReset` simplified to email only; `PasswordResetConfirm` gains a min-length validator on `new_password`
- **Frontend proxy routes**: New `app/api/auth/forgot-password/route.ts` and `app/api/auth/reset-password/route.ts` following the existing proxy pattern
- **Forgot password page**: Stripped to email-only form; success message updated to "check your inbox" with no redirect-on-success
- **Reset password page**: New `app/reset-password/page.tsx` — reads `?token` from URL, validates passwords match, submits to proxy, shows success + redirects to login after 3s; shows "request new link" hint on invalid/expired token errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end password reset: request a reset, receive an email, and set a new password via a dedicated reset page.
  * Outbound SMTP email delivery for reset links.

* **Bug Fixes / UX**
  * Unified, generic messages and improved error handling across reset flows.
  * Frontend simplified forgot-password form; reset page adds client-side password validation and clearer success/error flows.

* **Chores**
  * New SMTP/email configuration options and Redis-backed single-use reset tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->