### PR TITLE
fix: restore save_message endpoint (was 400 for all callers)

### DIFF
--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -224,7 +224,8 @@ async def save_message(
             request.scene_id,
             request.sender_name,
             request.message_content,
-            request.message_type
+            request.message_type,
+            request.session_id
         )
     except ValueError as e:
         # session_id is required - fail loudly with clear error message

--- a/backend/modules/simulation/schemas/dto.py
+++ b/backend/modules/simulation/schemas/dto.py
@@ -33,6 +33,7 @@ class SaveMessageRequest(BaseModel):
     sender_name: str
     message_content: str
     message_type: str  # "system", "orchestrator", etc.
+    session_id: Optional[str] = None
 
 
 class CodeExecutionRequest(BaseModel):

--- a/backend/modules/simulation/service.py
+++ b/backend/modules/simulation/service.py
@@ -340,24 +340,31 @@ class SimulationService:
         scene_id: int,
         sender_name: str,
         message_content: str,
-        message_type: str
+        message_type: str,
+        session_id: str = None
     ) -> Dict[str, Any]:
         """Save a system message to conversation history."""
+        import secrets
         user_progress = self.repository.get_user_progress_by_id(user_progress_id)
         if not user_progress:
             raise NotFoundError("User progress not found")
-        
+
         if user_progress.user_id != user_id:
             raise ForbiddenError("Access denied: You can only save messages to your own simulation")
-        
+
         next_message_order = self.repository.get_next_message_order(user_progress_id)
-        
-        # session_id is required - caller must provide it
-        # This method should not be used directly for user conversations
-        # Use the streaming endpoint which has access to orchestrator.state.session_id
-        raise ValueError(
-            f"save_message requires session_id for proper isolation. "
-            f"user_progress_id={user_progress_id}, scene_id={scene_id}. "
-            f"Use the streaming chat endpoint which provides session_id from orchestrator, "
-            f"or update this method to accept session_id as a required parameter."
+
+        # Generate a session_id for system messages if not provided by caller
+        effective_session_id = session_id or f"system_{user_progress_id}_{scene_id}_{secrets.token_urlsafe(8)}"
+
+        log = self.repository.create_conversation_log(
+            user_progress_id=user_progress_id,
+            scene_id=scene_id,
+            message_type=message_type,
+            sender_name=sender_name,
+            message_content=message_content,
+            message_order=next_message_order,
+            session_id=effective_session_id
         )
+        self.repository.db.commit()
+        return {"id": log.id, "message_order": log.message_order, "status": "saved"}


### PR DESCRIPTION
## Summary

- **Root cause**: `save_message` in `SimulationService` was left permanently broken after a session-isolation refactor — it unconditionally raised `ValueError`, which the router caught and returned as a `400 Bad Request` to every caller.
- **Impact**: The frontend calls `POST /api/simulation/save-message` in 3 places to persist system messages (scene transition intro + simulation completion banner). All 3 calls were failing silently (`.catch(err => {})`) but the errors were visible in production logs and reported by users.
- **Fix**: Add optional `session_id` to `SaveMessageRequest`; pass it through the router; replace the always-raise block with real save logic that generates a `system_<upid>_<scene>_<token>` session_id when the caller omits one — matching the pattern already used by `lifecycle_service` for initial messages.

**Files changed:**
- `backend/modules/simulation/schemas/dto.py` — add `session_id: Optional[str] = None` to `SaveMessageRequest`
- `backend/modules/simulation/router.py` — pass `request.session_id` to service
- `backend/modules/simulation/service.py` — restore actual save logic, auto-generate session_id if not provided

## Test plan

- [ ] Start a simulation and advance through a scene transition — the scene intro system message should now save to DB (visible in professor review mode)
- [ ] Complete a simulation — the completion system message should now save to DB
- [ ] Confirm `POST /api/simulation/save-message` returns 200 instead of 400 in production logs
- [ ] Confirm existing streaming chat (`linear-chat-stream`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced message session tracking with optional session identifiers. The system now automatically generates session IDs when not explicitly provided, improving session isolation and message persistence reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->