### PR TITLE
fix: auto-restart Daytona sandbox after idle timeout (fixes student HTTP 400 on Run)

### DIFF
--- a/backend/common/services/sandbox_service.py
+++ b/backend/common/services/sandbox_service.py
@@ -116,25 +116,94 @@ class SandboxService:
             logger.error(f"[DAYTONA] Sandbox creation failed: {e}")
             return None
 
+    async def _ensure_sandbox_running(self, sandbox_id: str) -> Dict[str, Any]:
+        """
+        Fetch the sandbox and ensure it is in the 'started' state before use.
+
+        Returns a dict with keys:
+          - "sandbox": the AsyncSandbox object (if ready), or None
+          - "error": error string if the sandbox cannot be made ready, or None
+          - "sandbox_state": the current state string (useful for frontend UX)
+          - "restarted": True if the sandbox was woken from stopped/error
+        """
+        sandbox = await self.daytona.get(sandbox_id)
+        state = str(sandbox.state) if sandbox.state else "unknown"
+
+        if state == "started":
+            return {"sandbox": sandbox, "error": None, "sandbox_state": state, "restarted": False}
+
+        if state == "stopped":
+            # Stopped sandboxes restart quickly (seconds) — safe to do inline
+            logger.info(f"[DAYTONA] Sandbox {sandbox_id} is stopped — starting inline")
+            await sandbox.start(timeout=90)
+            logger.info(f"[DAYTONA] Sandbox {sandbox_id} started successfully")
+            return {"sandbox": sandbox, "error": None, "sandbox_state": "started", "restarted": True}
+
+        if state == "archived":
+            # Archived sandboxes can take minutes to restore from object storage.
+            # Return immediately so the caller can fire a background task and let
+            # the frontend poll /sandbox-state until it's ready.
+            logger.info(f"[DAYTONA] Sandbox {sandbox_id} is archived — needs async start")
+            return {
+                "sandbox": None,
+                "error": "sandbox_archived",
+                "sandbox_state": "archived",
+                "restarted": False,
+            }
+
+        if state == "error":
+            if sandbox.recoverable:
+                logger.info(f"[DAYTONA] Sandbox {sandbox_id} in recoverable error — recovering")
+                await sandbox.recover(timeout=90)
+                logger.info(f"[DAYTONA] Sandbox {sandbox_id} recovered successfully")
+                return {"sandbox": sandbox, "error": None, "sandbox_state": "started", "restarted": True}
+            else:
+                logger.error(f"[DAYTONA] Sandbox {sandbox_id} in non-recoverable error: {sandbox.error_reason}")
+                return {
+                    "sandbox": None,
+                    "error": "sandbox_error_unrecoverable",
+                    "sandbox_state": state,
+                    "restarted": False,
+                }
+
+        # destroyed / deleted / unknown — must recreate
+        logger.warning(f"[DAYTONA] Sandbox {sandbox_id} is '{state}' — cannot restart")
+        return {
+            "sandbox": None,
+            "error": "sandbox_destroyed",
+            "sandbox_state": state,
+            "restarted": False,
+        }
+
     async def execute_code(self, sandbox_id: str, code: str) -> Dict[str, Any]:
         """
         Execute Python code in a sandbox using the stateful code interpreter.
 
-        Returns {"success": bool, "output": str, "error": str | None}
+        Returns {"success": bool, "output": str, "error": str | None, "sandbox_state": str | None}
 
-        Uses sandbox.code_interpreter.run_code() which runs in a shared
-        default context — variables, imports, and functions persist between
-        calls within the same sandbox. Output is truncated to MAX_OUTPUT_LENGTH chars.
+        If the sandbox is stopped or archived it is automatically restarted before
+        execution. Uses sandbox.code_interpreter.run_code() which runs in a shared
+        default context — variables, imports, and functions persist between calls
+        within the same sandbox. Output is truncated to MAX_OUTPUT_LENGTH chars.
         """
         if not self.enabled:
             return {
                 "success": False,
                 "output": "",
                 "error": "Code execution service is not available",
+                "sandbox_state": None,
             }
 
         try:
-            sandbox = await self.daytona.get(sandbox_id)
+            wake = await self._ensure_sandbox_running(sandbox_id)
+            if wake["error"]:
+                return {
+                    "success": False,
+                    "output": "",
+                    "error": wake["error"],
+                    "sandbox_state": wake["sandbox_state"],
+                }
+            sandbox = wake["sandbox"]
             result = await sandbox.code_interpreter.run_code(code)
 
             stdout = result.stdout or ""
@@ -152,6 +221,7 @@ class SandboxService:
                     "success": False,
                     "output": stdout,
                     "error": error_text,
+                    "sandbox_state": "started",
                 }
 
             output_text = stdout
@@ -163,6 +233,7 @@ class SandboxService:
                 "success": True,
                 "output": output_text,
                 "error": None,
+                "sandbox_state": "started",
             }
         except Exception as e:
             logger.error(f"[DAYTONA] Code execution failed in sandbox {sandbox_id}: {e}")
@@ -170,7 +241,28 @@ class SandboxService:
                 "success": False,
                 "output": "",
                 "error": str(e),
+                "sandbox_state": None,
             }
+
+    async def wake_sandbox(self, sandbox_id: str) -> bool:
+        """
+        Start an archived or stopped sandbox in the background.
+
+        Called as a FastAPI BackgroundTask when execute_code detects the sandbox
+        is archived and cannot be restarted inline. Returns True on success.
+        """
+        if not self.enabled:
+            return False
+        try:
+            sandbox = await self.daytona.get(sandbox_id)
+            if str(sandbox.state) not in ("started",):
+                logger.info(f"[DAYTONA] Background wake: starting sandbox {sandbox_id}")
+                await sandbox.start(timeout=300)
+                logger.info(f"[DAYTONA] Background wake: sandbox {sandbox_id} is ready")
+            return True
+        except Exception as e:
+            logger.error(f"[DAYTONA] Background wake failed for sandbox {sandbox_id}: {e}")
+            return False
 
     async def upload_file(
         self, sandbox_id: str, file_path: str, content: bytes

--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -5,7 +5,7 @@ HTTP endpoints for simulation operations.
 """
 
 import uuid
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse, JSONResponse
 from sqlalchemy.orm import Session
 
@@ -18,7 +18,8 @@ from modules.simulation.schemas.dto import (
     SimulationStartRequest, SimulationStartResponse,
     SimulationChatRequest, SimulationChatResponse,
     UserProgressResponse, SimulationSceneResponse,
-    SaveMessageRequest, CodeExecutionRequest, CodeExecutionResponse
+    SaveMessageRequest, CodeExecutionRequest, CodeExecutionResponse,
+    SandboxStateResponse,
 )
 from common.services.simulation_queue_service import (
     enqueue_simulation_request,
@@ -239,6 +240,7 @@ async def save_message(
 @router.post("/execute-code", response_model=CodeExecutionResponse)
 async def execute_code(
     request: CodeExecutionRequest,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -271,6 +273,10 @@ async def execute_code(
         request.code,
     )
 
+    # Archived sandbox: fire background task to start it while the frontend polls
+    if result.get("error") == "sandbox_archived":
+        background_tasks.add_task(sandbox_service.wake_sandbox, user_progress.sandbox_id)
+
     # Log the code execution as a conversation entry
     import secrets
     max_order = db.query(ConversationLog.message_order).filter_by(
@@ -300,7 +306,48 @@ async def execute_code(
         success=result["success"],
         output=result.get("output", ""),
         error=result.get("error"),
+        sandbox_state=result.get("sandbox_state"),
     )
+
+
+@router.get("/sandbox-state", response_model=SandboxStateResponse)
+async def get_sandbox_state(
+    user_progress_id: int = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Poll the current Daytona sandbox state for a simulation session.
+
+    Used by the frontend to track sandbox wake-up progress after receiving
+    a sandbox_destroyed or sandbox_error response from /execute-code.
+    """
+    from common.db.models.simulation.user_progress import UserProgress
+    from common.services.sandbox_service import sandbox_service
+
+    user_progress = db.query(UserProgress).filter_by(
+        id=user_progress_id,
+        user_id=current_user.id,
+    ).first()
+
+    if not user_progress:
+        raise HTTPException(404, "User progress not found")
+    if not user_progress.sandbox_id:
+        raise HTTPException(404, "No sandbox for this session")
+
+    if not sandbox_service.enabled:
+        raise HTTPException(503, "Sandbox service is not available")
+
+    try:
+        sandbox = await sandbox_service.daytona.get(user_progress.sandbox_id)
+        await sandbox.refresh_data()
+        return SandboxStateResponse(
+            sandbox_state=str(sandbox.state) if sandbox.state else "unknown",
+            sandbox_id=user_progress.sandbox_id,
+        )
+    except Exception as e:
+        logger.error(f"[DAYTONA] Failed to get sandbox state for progress {user_progress_id}: {e}")
+        raise HTTPException(503, "Could not retrieve sandbox state")
 
 
 @router.get("/grade")

--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -288,7 +288,7 @@ async def execute_code(
     # return early too — no code ran, nothing to log.
     if result.get("sandbox_state") != "started":
         return CodeExecutionResponse(
-            success=result["success"],
+            success=result.get("success", False),
             output=result.get("output", ""),
             error=result.get("error"),
             sandbox_state=result.get("sandbox_state"),
@@ -320,7 +320,7 @@ async def execute_code(
     db.commit()
 
     return CodeExecutionResponse(
-        success=result["success"],
+        success=result.get("success", False),
         output=result.get("output", ""),
         error=result.get("error"),
         sandbox_state=result.get("sandbox_state"),
@@ -364,7 +364,7 @@ async def get_sandbox_state(
         )
     except Exception as e:
         logger.error(f"[DAYTONA] Failed to get sandbox state for progress {user_progress_id}: {e}")
-        raise HTTPException(503, "Could not retrieve sandbox state")
+        raise HTTPException(503, "Could not retrieve sandbox state") from e
 
 
 @router.get("/grade")

--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -273,11 +273,28 @@ async def execute_code(
         request.code,
     )
 
-    # Archived sandbox: fire background task to start it while the frontend polls
+    # Archived sandbox: fire background task to start it while the frontend polls.
+    # Return immediately — code never ran so there is nothing to log.
     if result.get("error") == "sandbox_archived":
         background_tasks.add_task(sandbox_service.wake_sandbox, user_progress.sandbox_id)
+        return CodeExecutionResponse(
+            success=False,
+            output="",
+            error=result.get("error"),
+            sandbox_state=result.get("sandbox_state"),
+        )
 
-    # Log the code execution as a conversation entry
+    # For any other non-started outcome (destroyed, unrecoverable error, etc.)
+    # return early too — no code ran, nothing to log.
+    if result.get("sandbox_state") != "started":
+        return CodeExecutionResponse(
+            success=result["success"],
+            output=result.get("output", ""),
+            error=result.get("error"),
+            sandbox_state=result.get("sandbox_state"),
+        )
+
+    # Code actually executed — log it as a conversation entry
     import secrets
     max_order = db.query(ConversationLog.message_order).filter_by(
         user_progress_id=request.user_progress_id,

--- a/backend/modules/simulation/schemas/dto.py
+++ b/backend/modules/simulation/schemas/dto.py
@@ -48,6 +48,13 @@ class CodeExecutionResponse(BaseModel):
     success: bool
     output: str
     error: Optional[str] = None
+    sandbox_state: Optional[str] = None
+
+
+class SandboxStateResponse(BaseModel):
+    """Response model for sandbox state polling."""
+    sandbox_state: str
+    sandbox_id: Optional[str] = None
 
 
 # Response Models

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -4,7 +4,9 @@ import React, { useState, useCallback, useRef, useEffect } from 'react'
 import CodeMirror from '@uiw/react-codemirror'
 import { python } from '@codemirror/lang-python'
 import { oneDark } from '@codemirror/theme-one-dark'
-import { Play, Send, Loader2, ChevronDown, Users, User } from 'lucide-react'
+import { Play, Send, Loader2, ChevronDown, Users, User, RefreshCw } from 'lucide-react'
+
+type SandboxStatus = 'ready' | 'waking' | 'destroyed' | 'error'
 
 interface SubmitTarget {
   type: 'all' | 'persona'
@@ -47,6 +49,8 @@ export default function CodeEditor({
   const [output, setOutput] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isRunning, setIsRunning] = useState(false)
+  const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus>('ready')
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Reset uncontrolled editor content when the scene or starter code changes
   useEffect(() => {
@@ -87,10 +91,65 @@ export default function CodeEditor({
     })),
   ]
 
+  // Stop polling for sandbox state
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+    }
+  }, [])
+
+  // Poll /sandbox-state until the sandbox is started, then re-run code
+  const startPollingAndRetry = useCallback((pendingCode: string) => {
+    setSandboxStatus('waking')
+    stopPolling()
+
+    pollIntervalRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(
+          `/api/proxy/api/simulation/sandbox-state?user_progress_id=${userProgressId}`,
+          { credentials: 'include' }
+        )
+        if (!res.ok) return
+        const data = await res.json()
+        if (data.sandbox_state === 'started') {
+          stopPolling()
+          setSandboxStatus('ready')
+          // Sandbox is up — automatically re-execute the code
+          setIsRunning(true)
+          setError(null)
+          try {
+            const execRes = await fetch('/api/proxy/api/simulation/execute-code', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({ user_progress_id: userProgressId, code: pendingCode, scene_id: sceneId }),
+            })
+            const execResult = await execRes.json()
+            if (execResult.success) {
+              setOutput(execResult.output)
+            } else {
+              setError(execResult.error || 'Unknown error')
+              if (execResult.output) setOutput(execResult.output)
+            }
+          } finally {
+            setIsRunning(false)
+          }
+        }
+      } catch {
+        // Polling errors are non-fatal — keep trying
+      }
+    }, 5000)
+  }, [userProgressId, sceneId, stopPolling])
+
+  // Clean up polling on unmount
+  useEffect(() => () => stopPolling(), [stopPolling])
+
   const runCode = useCallback(async () => {
     setIsRunning(true)
     setError(null)
     setOutput('')
+    setSandboxStatus('ready')
 
     try {
       const response = await fetch('/api/proxy/api/simulation/execute-code', {
@@ -109,15 +168,24 @@ export default function CodeEditor({
       if (result.success) {
         setOutput(result.output)
       } else {
-        setError(result.error || 'Unknown error')
-        if (result.output) setOutput(result.output)
+        const state: string | undefined = result.sandbox_state
+        if (state === 'destroyed' || state === 'error_unrecoverable') {
+          setSandboxStatus('destroyed')
+          setError(null)
+        } else if (state === 'archived' || state === 'stopped') {
+          // Backend couldn't restart inline (archived) — start polling
+          startPollingAndRetry(code)
+        } else {
+          setError(result.error || 'Unknown error')
+          if (result.output) setOutput(result.output)
+        }
       }
     } catch {
       setError('Failed to connect to code execution service')
     } finally {
       setIsRunning(false)
     }
-  }, [code, userProgressId, sceneId])
+  }, [code, userProgressId, sceneId, startPollingAndRetry])
 
   const submitToChat = useCallback(() => {
     const mention = `@${submitTarget.mentionId}`
@@ -144,12 +212,18 @@ export default function CodeEditor({
         <div className="flex gap-2">
           <button
             onClick={runCode}
-            disabled={isRunning || isDisabled || !code.trim()}
-            title={isDisabled ? 'Code execution is temporarily unavailable' : undefined}
+            disabled={isRunning || isDisabled || !code.trim() || sandboxStatus === 'waking'}
+            title={
+              isDisabled
+                ? 'Code execution is temporarily unavailable'
+                : sandboxStatus === 'waking'
+                ? 'Sandbox is starting up — your code will run automatically'
+                : undefined
+            }
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-green-600 hover:bg-green-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-md transition-colors"
           >
-            {isRunning ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
-            {isRunning ? 'Running...' : 'Run'}
+            {isRunning || sandboxStatus === 'waking' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+            {sandboxStatus === 'waking' ? 'Starting...' : isRunning ? 'Running...' : 'Run'}
           </button>
 
           {/* Submit & Discuss split button */}
@@ -217,6 +291,28 @@ export default function CodeEditor({
         </div>
       )}
 
+      {/* Sandbox waking up banner */}
+      {sandboxStatus === 'waking' && (
+        <div className="px-4 py-2 bg-blue-900/60 text-blue-200 text-xs border-b border-blue-800 flex-shrink-0 flex items-center gap-2">
+          <Loader2 className="w-3.5 h-3.5 animate-spin flex-shrink-0" />
+          Your sandbox is waking up after being idle — your code will run automatically once it&apos;s ready (usually under 30s).
+        </div>
+      )}
+
+      {/* Sandbox destroyed / expired banner */}
+      {sandboxStatus === 'destroyed' && (
+        <div className="px-4 py-2 bg-red-900/60 text-red-200 text-xs border-b border-red-800 flex-shrink-0 flex items-center justify-between gap-2">
+          <span>Your sandbox session has expired. Please reload the page to start a fresh session.</span>
+          <button
+            onClick={() => window.location.reload()}
+            className="flex items-center gap-1 px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs text-white flex-shrink-0"
+          >
+            <RefreshCw className="w-3 h-3" />
+            Reload
+          </button>
+        </div>
+      )}
+
       {/* Code Editor */}
       <div className="flex-1 overflow-auto min-h-0">
         <CodeMirror
@@ -241,7 +337,13 @@ export default function CodeEditor({
           </span>
         </div>
         <div className="p-4 font-mono text-sm">
-          {isRunning && (
+          {sandboxStatus === 'waking' && !isRunning && (
+            <span className="text-blue-400 flex items-center gap-2">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Waiting for sandbox to start...
+            </span>
+          )}
+          {isRunning && sandboxStatus !== 'waking' && (
             <span className="text-yellow-400">Running code...</span>
           )}
           {output && (
@@ -250,7 +352,7 @@ export default function CodeEditor({
           {error && (
             <pre className="text-red-400 whitespace-pre-wrap">{error}</pre>
           )}
-          {!isRunning && !output && !error && (
+          {!isRunning && !output && !error && sandboxStatus === 'ready' && (
             <span className="text-gray-500">Run your code to see output here</span>
           )}
         </div>

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -5,6 +5,8 @@ import CodeMirror from '@uiw/react-codemirror'
 import { python } from '@codemirror/lang-python'
 import { oneDark } from '@codemirror/theme-one-dark'
 import { Play, Send, Loader2, ChevronDown, Users, User, RefreshCw } from 'lucide-react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 
 type SandboxStatus = 'ready' | 'waking' | 'destroyed' | 'error'
 
@@ -104,6 +106,8 @@ export default function CodeEditor({
     setSandboxStatus('waking')
     stopPolling()
 
+    const TERMINAL_STATES = new Set(['sandbox_destroyed', 'sandbox_error_unrecoverable', 'destroyed', 'error'])
+
     pollIntervalRef.current = setInterval(async () => {
       try {
         const res = await fetch(
@@ -112,6 +116,14 @@ export default function CodeEditor({
         )
         if (!res.ok) return
         const data = await res.json()
+
+        // Terminal error — stop polling and surface the error
+        if (TERMINAL_STATES.has(data.sandbox_state) || TERMINAL_STATES.has(data.error)) {
+          stopPolling()
+          setSandboxStatus('destroyed')
+          return
+        }
+
         if (data.sandbox_state === 'started') {
           stopPolling()
           setSandboxStatus('ready')
@@ -293,23 +305,33 @@ export default function CodeEditor({
 
       {/* Sandbox waking up banner */}
       {sandboxStatus === 'waking' && (
-        <div className="px-4 py-2 bg-blue-900/60 text-blue-200 text-xs border-b border-blue-800 flex-shrink-0 flex items-center gap-2">
-          <Loader2 className="w-3.5 h-3.5 animate-spin flex-shrink-0" />
-          Your sandbox is waking up after being idle — your code will run automatically once it&apos;s ready (usually under 30s).
+        <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
+          <Alert className="py-2 bg-blue-950/60 border-blue-800 text-blue-200">
+            <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
+            <AlertDescription className="text-xs text-blue-200">
+              Your sandbox is waking up after being idle — your code will run automatically once it&apos;s ready (usually under 30s).
+            </AlertDescription>
+          </Alert>
         </div>
       )}
 
       {/* Sandbox destroyed / expired banner */}
       {sandboxStatus === 'destroyed' && (
-        <div className="px-4 py-2 bg-red-900/60 text-red-200 text-xs border-b border-red-800 flex-shrink-0 flex items-center justify-between gap-2">
-          <span>Your sandbox session has expired. Please reload the page to start a fresh session.</span>
-          <button
-            onClick={() => window.location.reload()}
-            className="flex items-center gap-1 px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs text-white flex-shrink-0"
-          >
-            <RefreshCw className="w-3 h-3" />
-            Reload
-          </button>
+        <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
+          <Alert variant="destructive" className="py-2 flex items-center justify-between gap-2">
+            <AlertDescription className="text-xs">
+              Your sandbox session has expired. Please reload the page to start a fresh session.
+            </AlertDescription>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs flex-shrink-0"
+              onClick={() => window.location.reload()}
+            >
+              <RefreshCw className="w-3 h-3 mr-1" />
+              Reload
+            </Button>
+          </Alert>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **Root cause**: Daytona sandboxes auto-stop after 60 min idle. When a student clicks Run after a break, the backend called `code_interpreter.run_code()` on a stopped sandbox, causing the Daytona SDK to throw `server rejected WebSocket connection: HTTP 400` — surfaced raw to the student.
- **Stopped sandboxes** (idle 60 min – 2h): `_ensure_sandbox_running()` now calls `sandbox.start(timeout=90)` inline before executing code. Restart takes ~10–15s and is transparent — student just sees "Running..." a bit longer.
- **Archived sandboxes** (idle 2h – 24h): returns `sandbox_state: "archived"` immediately and fires a `BackgroundTask(wake_sandbox)` so the restore begins. Frontend shows a blue "Waking up your sandbox…" banner, polls `/sandbox-state` every 5s, then auto-retries the code once ready.
- **Destroyed sandboxes** (idle >24h): returns `sandbox_state: "destroyed"`. Frontend shows a red "Session expired — reload the page" banner with a Reload button.
- **Recoverable error state**: `sandbox.recover()` called inline.
- New `GET /simulation/sandbox-state` polling endpoint added.
- `sandbox_state` field added to `CodeExecutionResponse` and new `SandboxStateResponse` DTO.

## Test plan

- [ ] Start a simulation with a code scene, let it sit >60 min, click Run — should auto-restart and execute without error
- [ ] Verify "Waking up" banner appears for archived state (mock `sandbox.state = "archived"` in dev)
- [ ] Verify "Session expired" + Reload button for destroyed state
- [ ] Verify normal code execution still works when sandbox is already started
- [ ] Check backend logs for `[DAYTONA] Sandbox ... is stopped — starting inline` on restart
- [ ] Hit `GET /api/simulation/sandbox-state?user_progress_id=X` directly and confirm it returns `{"sandbox_state": "started", ...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background sandbox wake/start for non-running sandboxes and a new sandbox-state API for polling.
  * Responses include sandbox state; execution may early-return when sandbox isn't started.
* **UX Improvements**
  * Automatic retry: pending executions resume once sandbox becomes ready.
  * Run button shows “Starting...” with spinner and is disabled while waking.
  * Informational banners for waking and expired/destroyed sandboxes; reload option for expired sessions.
* **Observability**
  * Client-side polling for sandbox state to resume pending runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->