### PR TITLE
fix: SandboxState comparison bug — str() returns wrong value

### DIFF
--- a/backend/common/services/sandbox_service.py
+++ b/backend/common/services/sandbox_service.py
@@ -127,10 +127,14 @@ class SandboxService:
           - "restarted": True if the sandbox was woken from stopped/error
         """
         sandbox = await self.daytona.get(sandbox_id)
-        state = str(sandbox.state) if sandbox.state else "unknown"
+
+        # SandboxState is a StrEnum whose __eq__ compares against plain strings
+        # (the SDK itself does `while self.state != "started"`).
+        # Do NOT use str(sandbox.state) — that returns "SandboxState.STARTED", not "started".
+        state = sandbox.state  # compare directly with string literals below
 
         if state == "started":
-            return {"sandbox": sandbox, "error": None, "sandbox_state": state, "restarted": False}
+            return {"sandbox": sandbox, "error": None, "sandbox_state": "started", "restarted": False}
 
         if state == "stopped":
             # Stopped sandboxes restart quickly (seconds) — safe to do inline
@@ -162,7 +166,7 @@ class SandboxService:
                 return {
                     "sandbox": None,
                     "error": "sandbox_error_unrecoverable",
-                    "sandbox_state": state,
+                    "sandbox_state": "error",
                     "restarted": False,
                 }
 
@@ -171,7 +175,7 @@ class SandboxService:
         return {
             "sandbox": None,
             "error": "sandbox_destroyed",
-            "sandbox_state": state,
+            "sandbox_state": "destroyed",
             "restarted": False,
         }
 
@@ -255,7 +259,7 @@ class SandboxService:
             return False
         try:
             sandbox = await self.daytona.get(sandbox_id)
-            if str(sandbox.state) not in ("started",):
+            if sandbox.state != "started":
                 logger.info(f"[DAYTONA] Background wake: starting sandbox {sandbox_id}")
                 await sandbox.start(timeout=300)
                 logger.info(f"[DAYTONA] Background wake: sandbox {sandbox_id} is ready")


### PR DESCRIPTION
## Summary

- `str(sandbox.state)` returns `'SandboxState.STARTED'` not `'started'`, causing every `execute-code` call to fall into the "destroyed" branch and return `sandbox_destroyed` to the frontend — even on a healthy, running sandbox.
- Fix: compare `sandbox.state` directly against string literals (the Daytona SDK itself does `while self.state != "started"`).
- Also fixes the same bug in `wake_sandbox()`.

## Root cause evidence (from logs)

```
[DAYTONA] Sandbox ... is 'SandboxState.STARTED' — cannot restart
```

## Test plan

- [ ] Run `hello = 3; print(hello)` — should execute and output `3`, no `sandbox_destroyed` error
- [ ] Logs should show no `SandboxState.STARTED` warning on healthy sandboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal sandbox state handling consistency and reliability, ensuring more predictable behavior during sandbox lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->