### PR TITLE
fix: sandbox.state.value in polling endpoint (str() returns enum repr)

### DIFF
--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -359,7 +359,7 @@ async def get_sandbox_state(
         sandbox = await sandbox_service.daytona.get(user_progress.sandbox_id)
         await sandbox.refresh_data()
         return SandboxStateResponse(
-            sandbox_state=str(sandbox.state) if sandbox.state else "unknown",
+            sandbox_state=sandbox.state.value if sandbox.state else "unknown",
             sandbox_id=user_progress.sandbox_id,
         )
     except Exception as e:


### PR DESCRIPTION
## Summary

The `/sandbox-state` polling endpoint was returning `"SandboxState.STARTED"` instead of `"started"` because of `str(sandbox.state)`. The frontend polling loop checks `data.sandbox_state === 'started'` so it would **never stop polling** — the "waking up" banner would spin indefinitely even after the sandbox had restarted.

Fix: use `sandbox.state.value` which returns the normalised string literal.

## Test plan
- [ ] Trigger archived sandbox path → "Waking up" banner should disappear and code auto-run once sandbox is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the format of sandbox state values returned by the simulation API to use the proper underlying value representation instead of string conversion, ensuring more accurate state reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->