### PR TITLE
feat: student simulation leaderboard

### DIFF
--- a/backend/modules/cohorts/schemas.py
+++ b/backend/modules/cohorts/schemas.py
@@ -173,3 +173,23 @@ class CohortCompletionSummaryResponse(BaseModel):
     cohort_id: int
     simulations: List[SimulationCompletionItem]
 
+
+# --- LEADERBOARD SCHEMAS ---
+
+class LeaderboardEntry(BaseModel):
+    """A single student's entry on the leaderboard"""
+    rank: int
+    display_name: str  # first name + last initial, e.g. "Jane D."
+    score: float       # ai_grade at time of completion (0-100)
+    completed_at: Optional[datetime] = None
+    is_current_user: bool = False
+
+
+class LeaderboardResponse(BaseModel):
+    """Top-20 leaderboard for a cohort simulation assignment"""
+    simulation_title: str
+    cohort_title: str
+    total_completed: int          # total who have completed (may exceed 20)
+    entries: List[LeaderboardEntry]
+    current_user_rank: Optional[int] = None   # None if user is outside top 20 or hasn't completed
+

--- a/backend/modules/student/routers/student_instances.py
+++ b/backend/modules/student/routers/student_instances.py
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/student-simulation-instances", tags=["Student Simulation Instances"])
 
+# Top-N cap and highlight threshold for the leaderboard
+_LEADERBOARD_LIMIT = 20
+
 
 def generate_instance_id() -> str:
     """Generate a short, user-friendly instance ID like SI-MAN8P1QS"""
@@ -1030,4 +1033,96 @@ async def reset_simulation_from_instance(
     except Exception as e:
         logger.error(f"Error in reset_simulation_from_instance: {e!r}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to reset simulation: {e!s}") from e
+
+
+@router.get("/{instance_unique_id}/leaderboard")
+async def get_simulation_leaderboard(
+    instance_unique_id: str,
+    current_user: User = Depends(require_student),
+    db: Session = Depends(get_db)
+):
+    """
+    Return the top-20 leaderboard for the cohort simulation this instance belongs to.
+    Score is the ai_grade awarded at completion time.
+    Only students who have completed (or been graded) and have an ai_grade are included.
+    """
+    from modules.cohorts.schemas import LeaderboardEntry, LeaderboardResponse
+
+    # 1. Resolve the requesting student's instance
+    instance = (
+        db.query(StudentSimulationInstance)
+        .filter(StudentSimulationInstance.unique_id == instance_unique_id)
+        .first()
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Simulation instance not found")
+    if instance.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorised to view this leaderboard")
+    if not instance.cohort_assignment_id:
+        raise HTTPException(status_code=400, detail="This instance is not part of a cohort assignment")
+
+    # 2. Load cohort assignment metadata for response labels
+    cohort_assignment = (
+        db.query(CohortSimulation)
+        .options(
+            selectinload(CohortSimulation.simulation),
+            selectinload(CohortSimulation.cohort),
+        )
+        .filter(CohortSimulation.id == instance.cohort_assignment_id)
+        .first()
+    )
+    simulation_title = (
+        cohort_assignment.simulation.title if cohort_assignment and cohort_assignment.simulation else "Simulation"
+    )
+    cohort_title = (
+        cohort_assignment.cohort.title if cohort_assignment and cohort_assignment.cohort else "Cohort"
+    )
+
+    # 3. Fetch all completed instances with an ai_grade for this assignment
+    peer_instances = (
+        db.query(StudentSimulationInstance, User)
+        .join(User, StudentSimulationInstance.student_id == User.id)
+        .filter(
+            StudentSimulationInstance.cohort_assignment_id == instance.cohort_assignment_id,
+            StudentSimulationInstance.status.in_(["completed", "graded"]),
+            StudentSimulationInstance.ai_grade.isnot(None),
+        )
+        .order_by(StudentSimulationInstance.ai_grade.desc())
+        .all()
+    )
+
+    total_completed = len(peer_instances)
+
+    # 4. Build top-20 entries
+    def _display_name(full_name: str) -> str:
+        parts = full_name.strip().split()
+        if len(parts) >= 2:
+            return f"{parts[0]} {parts[-1][0]}."
+        return parts[0] if parts else "Student"
+
+    current_user_rank: Optional[int] = None
+    entries: list[LeaderboardEntry] = []
+
+    for rank, (peer_instance, student) in enumerate(peer_instances, start=1):
+        is_me = peer_instance.student_id == current_user.id
+        if is_me:
+            current_user_rank = rank
+        if rank <= _LEADERBOARD_LIMIT:
+            entries.append(
+                LeaderboardEntry(
+                    rank=rank,
+                    display_name=_display_name(student.full_name),
+                    score=round(peer_instance.ai_grade, 1),
+                    completed_at=peer_instance.completed_at,
+                    is_current_user=is_me,
+                )
+            )
+
+    return LeaderboardResponse(
+        simulation_title=simulation_title,
+        cohort_title=cohort_title,
+        total_completed=total_completed,
+        entries=entries,
+        current_user_rank=current_user_rank,
+    )
 

--- a/backend/modules/student/routers/student_instances.py
+++ b/backend/modules/student/routers/student_instances.py
@@ -1062,8 +1062,11 @@ async def get_simulation_leaderboard(
         raise HTTPException(status_code=400, detail="This instance is not part of a cohort assignment")
 
     # 2. Load cohort assignment metadata for response labels
+    # Honor soft-deletion for Simulation and Cohort
     cohort_assignment = (
         db.query(CohortSimulation)
+        .outerjoin(Simulation, CohortSimulation.simulation_id == Simulation.id)
+        .outerjoin(Cohort, CohortSimulation.cohort_id == Cohort.id)
         .options(
             selectinload(CohortSimulation.simulation),
             selectinload(CohortSimulation.cohort),
@@ -1071,14 +1074,17 @@ async def get_simulation_leaderboard(
         .filter(CohortSimulation.id == instance.cohort_assignment_id)
         .first()
     )
-    simulation_title = (
-        cohort_assignment.simulation.title if cohort_assignment and cohort_assignment.simulation else "Simulation"
-    )
-    cohort_title = (
-        cohort_assignment.cohort.title if cohort_assignment and cohort_assignment.cohort else "Cohort"
-    )
+    # Only use title if simulation/cohort exists and is not soft-deleted
+    simulation_title = "Simulation"
+    cohort_title = "Cohort"
+    if cohort_assignment:
+        if cohort_assignment.simulation and cohort_assignment.simulation.deleted_at is None:
+            simulation_title = cohort_assignment.simulation.title
+        if cohort_assignment.cohort and cohort_assignment.cohort.deleted_at is None:
+            cohort_title = cohort_assignment.cohort.title
 
     # 3. Fetch all completed instances with an ai_grade for this assignment
+    # Use stable secondary sort (updated_at desc, then user id asc) for deterministic ordering
     peer_instances = (
         db.query(StudentSimulationInstance, User)
         .join(User, StudentSimulationInstance.student_id == User.id)
@@ -1087,14 +1093,20 @@ async def get_simulation_leaderboard(
             StudentSimulationInstance.status.in_(["completed", "graded"]),
             StudentSimulationInstance.ai_grade.isnot(None),
         )
-        .order_by(StudentSimulationInstance.ai_grade.desc())
+        .order_by(
+            StudentSimulationInstance.ai_grade.desc(),
+            StudentSimulationInstance.updated_at.desc(),
+            User.id.asc()
+        )
         .all()
     )
 
     total_completed = len(peer_instances)
 
     # 4. Build top-20 entries
-    def _display_name(full_name: str) -> str:
+    def _display_name(full_name: Optional[str]) -> str:
+        if not full_name:
+            return "Student"
         parts = full_name.strip().split()
         if len(parts) >= 2:
             return f"{parts[0]} {parts[-1][0]}."
@@ -1103,14 +1115,27 @@ async def get_simulation_leaderboard(
     current_user_rank: Optional[int] = None
     entries: list[LeaderboardEntry] = []
 
-    for rank, (peer_instance, student) in enumerate(peer_instances, start=1):
+    # Track for proper tie handling
+    prev_grade: Optional[float] = None
+    current_rank = 1
+
+    for position, (peer_instance, student) in enumerate(peer_instances, start=1):
+        # Assign same rank for equal ai_grade values
+        if prev_grade is not None and peer_instance.ai_grade == prev_grade:
+            # Same score as previous, keep the same rank
+            pass
+        else:
+            # New score, update rank to current position
+            current_rank = position
+            prev_grade = peer_instance.ai_grade
+
         is_me = peer_instance.student_id == current_user.id
         if is_me:
-            current_user_rank = rank
-        if rank <= _LEADERBOARD_LIMIT:
+            current_user_rank = current_rank
+        if current_rank <= _LEADERBOARD_LIMIT:
             entries.append(
                 LeaderboardEntry(
-                    rank=rank,
+                    rank=current_rank,
                     display_name=_display_name(student.full_name),
                     score=round(peer_instance.ai_grade, 1),
                     completed_at=peer_instance.completed_at,
@@ -1125,4 +1150,3 @@ async def get_simulation_leaderboard(
         entries=entries,
         current_user_rank=current_user_rank,
     )
-

--- a/frontend/app/api/canny-sso/route.ts
+++ b/frontend/app/api/canny-sso/route.ts
@@ -1,15 +1,17 @@
 import { NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
 
-// Require CANNY_PRIVATE_KEY to be set - fail explicitly if missing
+// Get CANNY_PRIVATE_KEY - check at runtime, not at build time
 const PRIVATE_KEY = process.env.CANNY_PRIVATE_KEY;
-
-if (!PRIVATE_KEY) {
-  throw new Error('CANNY_PRIVATE_KEY environment variable is required but not set');
-} 
 
 export async function POST(request: Request) {
   try {
+    // Check for private key at runtime (not at build time)
+    if (!PRIVATE_KEY) {
+      console.error('CANNY_PRIVATE_KEY environment variable is required but not set');
+      return NextResponse.json({ error: 'Canny SSO not configured' }, { status: 500 });
+    }
+
     const body = await request.json();
     const { user } = body;
 
@@ -32,4 +34,3 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }
-

--- a/frontend/app/student/leaderboard/[instanceId]/page.tsx
+++ b/frontend/app/student/leaderboard/[instanceId]/page.tsx
@@ -1,0 +1,355 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter, useParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Trophy,
+  Medal,
+  ArrowLeft,
+  Star,
+  Users,
+  Crown,
+} from "lucide-react"
+import RoleBasedSidebar from "@/components/RoleBasedSidebar"
+import { useAuth } from "@/lib/auth-context"
+import { apiClient } from "@/lib/api"
+
+interface LeaderboardEntry {
+  rank: number
+  display_name: string
+  score: number
+  completed_at: string | null
+  is_current_user: boolean
+}
+
+interface LeaderboardData {
+  simulation_title: string
+  cohort_title: string
+  total_completed: number
+  entries: LeaderboardEntry[]
+  current_user_rank: number | null
+}
+
+const MEDAL_COLOURS = [
+  // rank 1 — gold
+  {
+    border: "border-yellow-400",
+    bg: "bg-gradient-to-br from-yellow-50 to-amber-50",
+    badge: "bg-yellow-400 text-yellow-900",
+    icon: <Crown className="h-5 w-5 text-yellow-500" />,
+    ring: "ring-2 ring-yellow-300",
+  },
+  // rank 2 — silver
+  {
+    border: "border-gray-400",
+    bg: "bg-gradient-to-br from-gray-50 to-slate-100",
+    badge: "bg-gray-400 text-gray-900",
+    icon: <Medal className="h-5 w-5 text-gray-400" />,
+    ring: "ring-2 ring-gray-300",
+  },
+  // rank 3 — bronze
+  {
+    border: "border-orange-400",
+    bg: "bg-gradient-to-br from-orange-50 to-amber-50",
+    badge: "bg-orange-400 text-orange-900",
+    icon: <Medal className="h-5 w-5 text-orange-400" />,
+    ring: "ring-2 ring-orange-300",
+  },
+]
+
+function PodiumCard({ entry }: { entry: LeaderboardEntry }) {
+  const colours = MEDAL_COLOURS[entry.rank - 1]
+  const isFirst = entry.rank === 1
+
+  return (
+    <Card
+      className={`card-elevated border-2 ${colours.border} ${colours.bg} ${colours.ring} ${
+        entry.is_current_user ? "ring-4 ring-blue-400" : ""
+      } transition-all`}
+    >
+      <CardContent className={`p-5 ${isFirst ? "pt-6" : ""}`}>
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-bold ${colours.badge}`}
+            >
+              {entry.rank}
+            </span>
+            {colours.icon}
+            {entry.is_current_user && (
+              <span className="text-xs font-semibold text-blue-600 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5">
+                You
+              </span>
+            )}
+          </div>
+          <span className={`text-2xl font-black ${isFirst ? "text-yellow-600" : "text-gray-700"}`}>
+            {entry.score}%
+          </span>
+        </div>
+        <p className="font-semibold text-gray-900 text-base truncate">{entry.display_name}</p>
+        {entry.completed_at && (
+          <p className="text-xs text-gray-500 mt-1">
+            {new Date(entry.completed_at).toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+            })}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function HighlightCard({ entry }: { entry: LeaderboardEntry }) {
+  return (
+    <Card
+      className={`card-elevated border border-amber-200 bg-amber-50/60 ${
+        entry.is_current_user ? "ring-2 ring-blue-400" : ""
+      }`}
+    >
+      <CardContent className="px-5 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-200 text-amber-800 text-sm font-bold">
+              {entry.rank}
+            </span>
+            <div>
+              <p className="font-semibold text-gray-900 flex items-center gap-2">
+                {entry.display_name}
+                {entry.is_current_user && (
+                  <span className="text-xs font-semibold text-blue-600 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5">
+                    You
+                  </span>
+                )}
+              </p>
+              {entry.completed_at && (
+                <p className="text-xs text-gray-500">
+                  {new Date(entry.completed_at).toLocaleDateString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </p>
+              )}
+            </div>
+          </div>
+          <span className="text-xl font-bold text-amber-700">{entry.score}%</span>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function ListRow({ entry }: { entry: LeaderboardEntry }) {
+  return (
+    <div
+      className={`flex items-center justify-between px-5 py-3 rounded-xl bg-white/90 border ${
+        entry.is_current_user
+          ? "border-blue-300 border-l-4 border-l-blue-500"
+          : "border-gray-200/60"
+      } shadow-sm`}
+    >
+      <div className="flex items-center gap-4">
+        <span className="w-7 text-center text-sm font-semibold text-gray-500">{entry.rank}</span>
+        <div>
+          <p className="font-medium text-gray-900 flex items-center gap-2">
+            {entry.display_name}
+            {entry.is_current_user && (
+              <span className="text-xs font-semibold text-blue-600 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5">
+                You
+              </span>
+            )}
+          </p>
+          {entry.completed_at && (
+            <p className="text-xs text-gray-400">
+              {new Date(entry.completed_at).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              })}
+            </p>
+          )}
+        </div>
+      </div>
+      <span className="text-base font-bold text-gray-800">{entry.score}%</span>
+    </div>
+  )
+}
+
+export default function LeaderboardPage() {
+  const router = useRouter()
+  const params = useParams()
+  const instanceId = params.instanceId as string
+  const { user, isLoading: authLoading } = useAuth()
+
+  const [data, setData] = useState<LeaderboardData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!authLoading && !user) router.push("/")
+    else if (!authLoading && user && user.role !== "student" && user.role !== "admin")
+      router.push("/professor/dashboard")
+  }, [user, authLoading, router])
+
+  useEffect(() => {
+    if (!instanceId || !user) return
+    const fetch = async () => {
+      try {
+        setLoading(true)
+        const result = await apiClient.getSimulationLeaderboard(instanceId)
+        setData(result)
+      } catch {
+        setError("Could not load leaderboard. Try again later.")
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetch()
+  }, [instanceId, user])
+
+  if (authLoading || (!user && !authLoading)) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-black" />
+      </div>
+    )
+  }
+
+  const podium = data?.entries.filter((e) => e.rank <= 3) ?? []
+  const highlighted = data?.entries.filter((e) => e.rank >= 4 && e.rank <= 5) ?? []
+  const rest = data?.entries.filter((e) => e.rank > 5) ?? []
+
+  const outsideTop20 =
+    data && data.current_user_rank !== null && data.current_user_rank > 20
+
+  return (
+    <div className="min-h-screen bg-atmospheric relative pattern-dots">
+      <RoleBasedSidebar currentPath="/student/simulations" />
+
+      <div className="ml-20 relative">
+        <div className="p-8 animate-page-enter max-w-2xl mx-auto">
+          {/* Back button */}
+          <button
+            onClick={() => router.push("/student/simulations")}
+            className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800 mb-8 transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Simulations
+          </button>
+
+          {/* Header */}
+          <div className="mb-8 stagger-1 animate-fade-scale">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-10 h-10 bg-gradient-to-br from-yellow-400 to-amber-500 rounded-xl flex items-center justify-center shadow-md">
+                <Trophy className="h-5 w-5 text-white" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-black tracking-tight">Leaderboard</h1>
+              </div>
+            </div>
+            {data && (
+              <div className="mt-3 pl-1">
+                <p className="text-gray-800 font-semibold text-lg">{data.simulation_title}</p>
+                <p className="text-gray-500 text-sm">{data.cohort_title}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Stats bar */}
+          {data && (
+            <div className="flex items-center gap-2 mb-8 stagger-2 animate-fade-scale">
+              <Users className="h-4 w-4 text-gray-400" />
+              <span className="text-sm text-gray-500">
+                <span className="font-semibold text-gray-700">{data.total_completed}</span> student
+                {data.total_completed !== 1 ? "s" : ""} completed · showing top{" "}
+                {data.entries.length}
+              </span>
+            </div>
+          )}
+
+          {loading && (
+            <div className="text-center py-16">
+              <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-black mx-auto mb-4" />
+              <p className="text-gray-500">Loading leaderboard…</p>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-center py-16 text-gray-500">
+              <Trophy className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+              <p>{error}</p>
+              <Button variant="outline" className="mt-4" onClick={() => router.push("/student/simulations")}>
+                Back to Simulations
+              </Button>
+            </div>
+          )}
+
+          {!loading && !error && data && data.entries.length === 0 && (
+            <div className="text-center py-16 text-gray-500">
+              <Star className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+              <p className="text-lg font-medium mb-1">No scores yet</p>
+              <p className="text-sm">Be the first to complete this simulation!</p>
+            </div>
+          )}
+
+          {!loading && !error && data && data.entries.length > 0 && (
+            <div className="space-y-8">
+              {/* Podium — top 3 */}
+              {podium.length > 0 && (
+                <div className="stagger-3 animate-fade-scale">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">
+                    Top performers
+                  </p>
+                  <div className="grid grid-cols-1 gap-3">
+                    {podium.map((entry) => (
+                      <PodiumCard key={entry.rank} entry={entry} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Ranks 4–5 */}
+              {highlighted.length > 0 && (
+                <div className="stagger-4 animate-fade-scale">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">
+                    Honourable mentions
+                  </p>
+                  <div className="space-y-2">
+                    {highlighted.map((entry) => (
+                      <HighlightCard key={entry.rank} entry={entry} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Ranks 6–20 */}
+              {rest.length > 0 && (
+                <div className="stagger-5 animate-fade-scale">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">
+                    Rankings
+                  </p>
+                  <div className="space-y-2">
+                    {rest.map((entry) => (
+                      <ListRow key={entry.rank} entry={entry} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Out-of-top-20 footer */}
+              {outsideTop20 && (
+                <div className="stagger-6 animate-fade-scale border-t border-gray-200 pt-5 flex items-center justify-between px-1">
+                  <span className="text-sm text-gray-500">Your position</span>
+                  <span className="text-sm font-semibold text-gray-700">
+                    #{data.current_user_rank} of {data.total_completed}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/student/leaderboard/[instanceId]/page.tsx
+++ b/frontend/app/student/leaderboard/[instanceId]/page.tsx
@@ -188,12 +188,14 @@ export default function LeaderboardPage() {
 
   useEffect(() => {
     if (!authLoading && !user) router.push("/")
-    else if (!authLoading && user && user.role !== "student" && user.role !== "admin")
+    else if (!authLoading && user && user.role !== "student")
       router.push("/professor/dashboard")
   }, [user, authLoading, router])
 
   useEffect(() => {
     if (!instanceId || !user) return
+    // Only fetch if user is a student (backend requires student role)
+    if (user.role !== "student") return
     const fetch = async () => {
       try {
         setLoading(true)

--- a/frontend/app/student/simulations/page.tsx
+++ b/frontend/app/student/simulations/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { 
+import {
   Search,
   Filter,
   BookOpen,
@@ -18,7 +18,8 @@ import {
   CheckCircle,
   AlertCircle,
   TrendingUp,
-  RefreshCw
+  RefreshCw,
+  BarChart2
 } from "lucide-react"
 import RoleBasedSidebar from "@/components/RoleBasedSidebar"
 import { useAuth } from "@/lib/auth-context"
@@ -559,11 +560,22 @@ export default function StudentSimulations() {
                               <p className="text-sm text-green-600">Completed</p>
                             </div>
                           </div>
-                          <div className="text-right">
+                          <div className="flex items-center gap-3">
                             {simulation.completed_at && (
                               <p className="text-sm text-green-600 font-medium">
                                 Completed {new Date(simulation.completed_at).toLocaleDateString()}
                               </p>
+                            )}
+                            {simulation.unique_id && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="border-green-400 text-green-700 hover:bg-green-100 gap-1.5"
+                                onClick={() => router.push(`/student/leaderboard/${simulation.unique_id}`)}
+                              >
+                                <BarChart2 className="h-3.5 w-3.5" />
+                                Leaderboard
+                              </Button>
                             )}
                           </div>
                         </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -672,6 +672,12 @@ export const apiClient = {
     return response.json()
   },
 
+  getSimulationLeaderboard: async (instanceUniqueId: string): Promise<any> => {
+    const response = await apiRequest(`/student-simulation-instances/${instanceUniqueId}/leaderboard`, { method: 'GET' })
+    if (!response.ok) throw new Error('Failed to get leaderboard')
+    return response.json()
+  },
+
   completeSimulationInstance: async (instanceId: number): Promise<any> => {
     const response = await apiRequest(`/student-simulation-instances/${instanceId}/complete`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Adds a top-20 leaderboard per cohort simulation, ranked by AI-awarded score at completion time
- Top 3 get gold/silver/bronze podium cards; ranks 4–5 amber highlight; 6–20 clean list
- Current user's row always highlighted in blue; students outside top 20 see their rank in a footer note
- Leaderboard button added to completed simulations on the student simulations page

## Changes
- \`backend/modules/cohorts/schemas.py\` — \`LeaderboardEntry\` + \`LeaderboardResponse\` schemas
- \`backend/modules/student/routers/student_instances.py\` — \`GET /{instance_unique_id}/leaderboard\` endpoint
- \`frontend/lib/api.ts\` — \`getSimulationLeaderboard()\` method
- \`frontend/app/student/leaderboard/[instanceId]/page.tsx\` — new leaderboard page
- \`frontend/app/student/simulations/page.tsx\` — Leaderboard button on completed sims

## Test plan
- [ ] Complete a simulation as two different students in the same cohort
- [ ] Click Leaderboard button — confirm top 20 shown, current user highlighted
- [ ] Confirm top 5 are visually distinct from the rest
- [ ] Confirm students without \`ai_grade\` are excluded
- [ ] Confirm \`GET /student-simulation-instances/{id}/leaderboard\` returns 403 for another student's instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leaderboard view for completed simulations with ranks, scores, completion times, and highlighted top performers (podium).
  * Access leaderboards from your simulations list via a new button; page shows cohort/simulation headers, stats, and segmented rank sections.
  * Shows your personal rank even when outside the top-20 and an “out-of-top-20” footer.

* **Chores**
  * Improved runtime error handling for an external SSO route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->