### PR TITLE
feat(ui): add dark mode toggle

### DIFF
--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import ThemeToggle from "@/components/ThemeToggle"
 
 export default function ForgotPasswordPage() {
   const router = useRouter()
@@ -15,6 +16,8 @@ export default function ForgotPasswordPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const authInputClassName =
+    "rounded-lg border-border/60 bg-background/70 text-foreground placeholder:text-muted-foreground shadow-sm backdrop-blur-sm transition-all focus-visible:ring-2 focus-visible:ring-blue-500/30 focus-visible:ring-offset-0"
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -74,69 +77,70 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+    <div className="auth-shell pattern-grid relative flex min-h-screen items-center justify-center overflow-hidden p-4 text-foreground">
+      <ThemeToggle className="fixed right-4 top-4 z-20" />
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse" />
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }} />
+        <div className="auth-glow-primary absolute top-0 left-0 h-96 w-96 rounded-full blur-3xl animate-pulse" />
+        <div className="auth-glow-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }} />
       </div>
 
-      <div className="w-full max-w-md relative z-10 animate-fade-scale">
+      <div className="relative z-10 w-full max-w-md animate-fade-scale rounded-[32px] border border-border/60 bg-background/70 p-8 shadow-2xl backdrop-blur-xl">
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
             <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Reset your password</h1>
-          <p className="text-gray-400 text-sm">
+          <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">Reset your password</h1>
+          <p className="text-sm text-muted-foreground">
             Confirm your email and set a new password for your account.
           </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-5" noValidate>
           <div className="space-y-3">
-            <Label htmlFor="email" className="text-white font-medium">Email</Label>
+            <Label htmlFor="email" className="font-medium text-foreground">Email</Label>
             <Input
               id="email"
               type="email"
               placeholder="Enter your email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+              className={authInputClassName}
             />
           </div>
 
           <div className="space-y-3">
-            <Label htmlFor="confirmEmail" className="text-white font-medium">Confirm Email</Label>
+            <Label htmlFor="confirmEmail" className="font-medium text-foreground">Confirm Email</Label>
             <Input
               id="confirmEmail"
               type="email"
               placeholder="Retype your email"
               value={confirmEmail}
               onChange={(event) => setConfirmEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+              className={authInputClassName}
             />
           </div>
 
           <div className="space-y-3">
-            <Label htmlFor="newPassword" className="text-white font-medium">New Password</Label>
+            <Label htmlFor="newPassword" className="font-medium text-foreground">New Password</Label>
             <Input
               id="newPassword"
               type="password"
               placeholder="Create a new password"
               value={newPassword}
               onChange={(event) => setNewPassword(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+              className={authInputClassName}
             />
           </div>
 
           {error && (
-            <div className="bg-red-900/20 border border-red-500/50 rounded-md p-3">
-              <p className="text-red-400 text-sm font-medium">{error}</p>
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3">
+              <p className="text-sm font-medium text-red-600 dark:text-red-200">{error}</p>
             </div>
           )}
 
           {success && (
-            <div className="bg-emerald-900/20 border border-emerald-500/50 rounded-md p-3">
-              <p className="text-emerald-400 text-sm font-medium">{success}</p>
+            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
+              <p className="text-sm font-medium text-emerald-700 dark:text-emerald-200">{success}</p>
             </div>
           )}
 
@@ -150,8 +154,8 @@ export default function ForgotPasswordPage() {
         </form>
 
         <div className="text-center mt-6">
-          <span className="text-gray-400">Remembered your password? </span>
-          <Link href="/" className="text-white hover:underline">
+          <span className="text-muted-foreground">Remembered your password? </span>
+          <Link href="/" className="text-foreground hover:underline">
             Return to login
           </Link>
         </div>
@@ -159,4 +163,3 @@ export default function ForgotPasswordPage() {
     </div>
   )
 }
-

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -6,6 +6,7 @@
 
 @layer base {
   :root {
+    color-scheme: light;
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
@@ -26,9 +27,16 @@
     --input: 240 5.9% 90%;
     --ring: 240 10% 3.9%;
     --radius: 0.5rem;
+    --pattern-grid-line: rgba(15, 23, 42, 0.06);
+    --pattern-dots-color: rgba(51, 65, 85, 0.16);
+    --auth-shell-background: linear-gradient(135deg, #eff6ff 0%, #f8fafc 48%, #e2e8f0 100%);
+    --auth-glow-primary: rgba(37, 99, 235, 0.14);
+    --auth-glow-secondary: rgba(16, 185, 129, 0.14);
+    --app-atmospheric-background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
   }
 
   .dark {
+    color-scheme: dark;
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;
@@ -48,6 +56,12 @@
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
+    --pattern-grid-line: rgba(255, 255, 255, 0.05);
+    --pattern-dots-color: rgba(148, 163, 184, 0.16);
+    --auth-shell-background: linear-gradient(135deg, #020617 0%, #0f172a 48%, #111827 100%);
+    --auth-glow-primary: rgba(59, 130, 246, 0.18);
+    --auth-glow-secondary: rgba(16, 185, 129, 0.14);
+    --app-atmospheric-background: linear-gradient(135deg, #020617 0%, #0f172a 50%, #111827 100%);
   }
 }
 
@@ -80,11 +94,23 @@
   right: 0;
   bottom: 0;
   background-image: 
-    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+    linear-gradient(var(--pattern-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--pattern-grid-line) 1px, transparent 1px);
   background-size: 32px 32px;
   pointer-events: none;
   opacity: 0.4;
+}
+
+.auth-shell {
+  background: var(--auth-shell-background);
+}
+
+.auth-glow-primary {
+  background: var(--auth-glow-primary);
+}
+
+.auth-glow-secondary {
+  background: var(--auth-glow-secondary);
 }
 
 .btn-gradient {
@@ -160,7 +186,7 @@
 
 /* Atmospheric background - light gradient background */
 .bg-atmospheric {
-  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+  background: var(--app-atmospheric-background);
 }
 
 /* Pattern dots overlay */
@@ -171,10 +197,65 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-image: radial-gradient(circle, rgba(148, 163, 184, 0.15) 1px, transparent 1px);
+  background-image: radial-gradient(circle, var(--pattern-dots-color) 1px, transparent 1px);
   background-size: 20px 20px;
   pointer-events: none;
   opacity: 0.4;
+}
+
+.dark [class*="bg-white/95"] {
+  background-color: rgba(15, 23, 42, 0.95);
+}
+
+.dark [class*="bg-white/90"] {
+  background-color: rgba(15, 23, 42, 0.9);
+}
+
+.dark [class*="bg-white/80"] {
+  background-color: rgba(15, 23, 42, 0.82);
+}
+
+.dark [class*="bg-white/50"] {
+  background-color: rgba(15, 23, 42, 0.66);
+}
+
+.dark [class~="bg-white"] {
+  background-color: rgb(15, 23, 42);
+}
+
+.dark [class*="bg-gray-50/80"],
+.dark [class*="bg-gray-50/50"],
+.dark [class*="bg-gray-50/30"] {
+  background-color: rgba(30, 41, 59, 0.72);
+}
+
+.dark [class~="bg-gray-50"] {
+  background-color: rgb(30, 41, 59);
+}
+
+.dark [class*="border-gray-200"],
+.dark [class*="border-gray-300"] {
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+.dark [class~="text-black"],
+.dark [class*="text-gray-900"] {
+  color: rgb(248, 250, 252);
+}
+
+.dark [class*="text-gray-700"] {
+  color: rgb(226, 232, 240);
+}
+
+.dark [class*="text-gray-600"],
+.dark [class*="text-gray-500"],
+.dark [class*="text-gray-400"] {
+  color: rgb(148, 163, 184);
+}
+
+.dark [class*="hover:bg-gray-50"]:hover,
+.dark [class*="hover:bg-white"]:hover {
+  background-color: rgba(51, 65, 85, 0.7);
 }
 
 /* Simulation panel gradient - dark theme for left panel */
@@ -236,4 +317,3 @@
   background: rgba(255, 255, 255, 0.15);
   border-radius: 2px;
 }
-

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { AuthProvider } from "@/lib/auth-context"
 import RoleBasedRedirect from "@/components/RoleBasedRedirect"
 import DraggableFeedback from "@/components/DraggableFeedback"
+import { ThemeProvider } from "@/components/theme-provider"
 import { SonnerToaster } from "@/components/ui/sonner"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -34,17 +35,18 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} ${crimsonText.variable} ${dmSans.variable}`}>
-        <AuthProvider>
-          <RoleBasedRedirect>
-            {children}
-          </RoleBasedRedirect>
-          <DraggableFeedback />
-        </AuthProvider>
-        <SonnerToaster />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <AuthProvider>
+            <RoleBasedRedirect>
+              {children}
+            </RoleBasedRedirect>
+            <DraggableFeedback />
+          </AuthProvider>
+          <SonnerToaster />
+        </ThemeProvider>
       </body>
     </html>
   )
 }
-

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import ThemeToggle from "@/components/ThemeToggle"
 import { useAuth } from "@/lib/auth-context"
 import { toast } from "sonner"
 import { GoogleOAuth } from "@/lib/google-oauth"
@@ -20,6 +21,10 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [isRedirecting, setIsRedirecting] = useState(false)
   const [error, setError] = useState("")
+  const authPanelClassName =
+    "w-full max-w-md relative z-10 animate-fade-scale rounded-[32px] border border-border/60 bg-background/70 p-8 shadow-2xl backdrop-blur-xl"
+  const authInputClassName =
+    "rounded-lg border-border/60 bg-background/70 text-foreground placeholder:text-muted-foreground shadow-sm backdrop-blur-sm transition-all focus-visible:ring-2 focus-visible:ring-blue-500/30 focus-visible:ring-offset-0"
 
   useEffect(() => {
     if (authLoading) return
@@ -83,13 +88,13 @@ export default function LoginPage() {
   // Show loading overlay during auth check, form submission, or redirect
   if (authLoading || isRedirecting) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 flex items-center justify-center">
+      <div className="auth-shell min-h-screen flex items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <div className="relative">
             <div className="w-16 h-16 border-4 border-blue-500/30 rounded-full"></div>
             <div className="absolute top-0 left-0 w-16 h-16 border-4 border-transparent border-t-blue-500 rounded-full animate-spin"></div>
           </div>
-          <p className="text-white/80 text-lg font-medium">
+          <p className="text-lg font-medium text-foreground/80">
             {isRedirecting ? "Signing you in..." : "Loading..."}
           </p>
         </div>
@@ -98,24 +103,25 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+    <div className="auth-shell pattern-grid relative flex min-h-screen items-center justify-center overflow-hidden p-4 text-foreground">
+      <ThemeToggle className="fixed right-4 top-4 z-20" />
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-green-500/10 rounded-full blur-3xl animate-pulse" style={{animationDelay: '1s'}}></div>
+        <div className="auth-glow-primary absolute top-0 left-0 h-96 w-96 rounded-full blur-3xl animate-pulse"></div>
+        <div className="auth-glow-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }}></div>
       </div>
       
-      <div className="w-full max-w-md relative z-10 animate-fade-scale">
+      <div className={authPanelClassName}>
         <div className="text-center mb-10">
           <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
             <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Log in to your account</h1>
-          <p className="text-gray-400 text-sm">Welcome back! Please enter your details.</p>
+          <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">Log in to your account</h1>
+          <p className="text-sm text-muted-foreground">Welcome back! Please enter your details.</p>
         </div>
 
         <form onSubmit={handleLogin} className="space-y-4">
           <div className="space-y-3">
-            <Label htmlFor="email" className="text-white font-medium">Email</Label>
+            <Label htmlFor="email" className="font-medium text-foreground">Email</Label>
             <Input
               id="email"
               type="email"
@@ -125,13 +131,13 @@ export default function LoginPage() {
                 setEmail(e.target.value)
                 if (error) setError("")
               }}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+              className={authInputClassName}
               required
             />
           </div>
           
           <div className="space-y-3">
-            <Label htmlFor="password" className="text-white font-medium">Password</Label>
+            <Label htmlFor="password" className="font-medium text-foreground">Password</Label>
             <Input
               id="password"
               type="password"
@@ -141,20 +147,20 @@ export default function LoginPage() {
                 setPassword(e.target.value)
                 if (error) setError("")
               }}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+              className={authInputClassName}
               required
             />
           </div>
 
           {error && error.length > 0 && (
-            <div className="bg-red-900/40 border-2 border-red-500 rounded-lg p-4 shadow-xl relative z-50 animate-in fade-in slide-in-from-top-2">
+            <div className="relative z-50 rounded-lg border border-red-500/30 bg-red-500/10 p-4 shadow-xl animate-in fade-in slide-in-from-top-2">
               <div className="flex items-start">
                 <svg className="w-5 h-5 text-red-400 mr-3 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
                 <div className="flex-1">
-                  <p className="text-red-300 text-sm font-semibold mb-1">Login Error</p>
-                  <p className="text-red-200 text-sm font-medium">{error}</p>
+                  <p className="mb-1 text-sm font-semibold text-red-500 dark:text-red-300">Login Error</p>
+                  <p className="text-sm font-medium text-red-600 dark:text-red-200">{error}</p>
                 </div>
               </div>
             </div>
@@ -171,10 +177,10 @@ export default function LoginPage() {
           {/* Divider */}
           <div className="relative my-6">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-700"></div>
+              <div className="w-full border-t border-border/70"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-4 bg-gradient-to-br from-gray-900 via-black to-gray-900 text-gray-400">or</span>
+              <span className="bg-background/85 px-4 text-muted-foreground">or</span>
             </div>
           </div>
 
@@ -182,7 +188,7 @@ export default function LoginPage() {
           <Button
             type="button"
             variant="outline"
-            className="w-full bg-white hover:bg-gray-100 text-gray-900 border-gray-300 font-medium h-11"
+            className="h-11 w-full border-border/70 bg-background/80 font-medium text-foreground shadow-sm hover:bg-background hover:text-foreground"
             onClick={handleGoogleLogin}
             disabled={loading}
           >
@@ -197,8 +203,8 @@ export default function LoginPage() {
         </form>
 
         <div className="text-center mt-6">
-          <span className="text-gray-400">Don't have an account yet? </span>
-          <Link href="/signup" className="text-white hover:underline">
+          <span className="text-muted-foreground">Don't have an account yet? </span>
+          <Link href="/signup" className="text-foreground hover:underline">
             Sign up now
           </Link>
         </div>
@@ -206,4 +212,3 @@ export default function LoginPage() {
     </div>
   )
 }
-

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import ThemeToggle from "@/components/ThemeToggle"
 import { useAuth } from "@/lib/auth-context"
 import { toast } from "sonner"
 import { GoogleOAuth } from "@/lib/google-oauth"
@@ -26,6 +27,12 @@ export default function SignupPage() {
     role: "" as "student" | "professor" | "",
   })
   const [error, setError] = useState("")
+  const authPanelClassName =
+    "relative z-10 w-full max-w-md rounded-[32px] border border-border/60 bg-background/70 p-8 shadow-2xl backdrop-blur-xl"
+  const authInputClassName =
+    "rounded-lg border-border/60 bg-background/70 text-foreground placeholder:text-muted-foreground shadow-sm backdrop-blur-sm transition-all focus-visible:ring-2 focus-visible:ring-blue-500/30 focus-visible:ring-offset-0"
+  const backButtonClassName =
+    "fixed left-4 top-4 z-20 inline-flex items-center gap-1.5 rounded-lg bg-background/70 px-3 py-2 text-base text-foreground/85 shadow-lg backdrop-blur-sm transition-colors hover:text-foreground focus:outline-none"
 
   // Debug: Log error state changes
   useEffect(() => {
@@ -73,7 +80,7 @@ export default function SignupPage() {
       return
     }
 
-    if (!formData.role || formData.role === "") {
+    if (!formData.role) {
       setError("Please select a role")
       setLoading(false)
       return
@@ -135,13 +142,13 @@ export default function SignupPage() {
   // Show loading overlay during auth check, form submission, or redirect
   if (authLoading || isRedirecting) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 flex items-center justify-center">
+      <div className="auth-shell min-h-screen flex items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <div className="relative">
             <div className="w-16 h-16 border-4 border-blue-500/30 rounded-full"></div>
             <div className="absolute top-0 left-0 w-16 h-16 border-4 border-transparent border-t-blue-500 rounded-full animate-spin"></div>
           </div>
-          <p className="text-white/80 text-lg font-medium">
+          <p className="text-lg font-medium text-foreground/80">
             {isRedirecting ? "Creating your account..." : "Loading..."}
           </p>
         </div>
@@ -151,28 +158,29 @@ export default function SignupPage() {
 
   if (step === 1) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+      <div className="auth-shell pattern-grid relative flex min-h-screen items-center justify-center overflow-hidden p-4 text-foreground">
+        <ThemeToggle className="fixed right-4 top-4 z-20" />
         <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-          <div className="absolute bottom-0 right-0 w-96 h-96 bg-green-500/10 rounded-full blur-3xl animate-pulse" style={{animationDelay: '1s'}}></div>
+          <div className="auth-glow-primary absolute top-0 left-0 h-96 w-96 rounded-full blur-3xl animate-pulse"></div>
+          <div className="auth-glow-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }}></div>
         </div>
 
         <button
           type="button"
           onClick={() => router.push('/login')}
-          className="fixed top-4 left-4 z-20 inline-flex items-center gap-1.5 text-base text-white/85 hover:text-white transition-colors focus:outline-none backdrop-blur-sm bg-black/20 px-3 py-2 rounded-lg"
+          className={backButtonClassName}
         >
           <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M12.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L8.414 9H17a1 1 0 110 2H8.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd"/></svg>
           <span>Back</span>
         </button>
 
-        <div className="w-full max-w-md relative z-10">
+        <div className={authPanelClassName}>
           <div className="text-center mb-6">
             <div className="inline-flex items-center justify-center mb-4">
               <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
             </div>
-            <h1 className="text-3xl font-bold text-white mb-2">Choose your role</h1>
-            <p className="text-gray-400 text-sm">Select how you'll use the platform</p>
+            <h1 className="mb-2 text-3xl font-bold text-foreground">Choose your role</h1>
+            <p className="text-sm text-muted-foreground">Select how you'll use the platform</p>
           </div>
 
           <div className="space-y-4">
@@ -182,11 +190,11 @@ export default function SignupPage() {
               className={`w-full p-6 rounded-lg border-2 transition-all ${
                 selectedRole === "student"
                   ? "border-blue-500 bg-blue-500/10"
-                  : "border-gray-700 bg-gray-900/50 hover:border-gray-600"
+                  : "border-border/60 bg-background/60 hover:border-blue-400/60 hover:bg-background/80"
               }`}
             >
               <h3 className="text-xl font-semibold mb-2">Student</h3>
-              <p className="text-gray-400 text-sm">Participate in simulations and learn</p>
+              <p className="text-sm text-muted-foreground">Participate in simulations and learn</p>
             </button>
 
             <button
@@ -195,11 +203,11 @@ export default function SignupPage() {
               className={`w-full p-6 rounded-lg border-2 transition-all ${
                 selectedRole === "professor"
                   ? "border-blue-500 bg-blue-500/10"
-                  : "border-gray-700 bg-gray-900/50 hover:border-gray-600"
+                  : "border-border/60 bg-background/60 hover:border-blue-400/60 hover:bg-background/80"
               }`}
             >
               <h3 className="text-xl font-semibold mb-2">Professor</h3>
-              <p className="text-gray-400 text-sm">Create and manage simulations</p>
+              <p className="text-sm text-muted-foreground">Create and manage simulations</p>
             </button>
           </div>
 
@@ -214,10 +222,10 @@ export default function SignupPage() {
           {/* Divider */}
           <div className="relative my-6">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-700"></div>
+              <div className="w-full border-t border-border/70"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-4 bg-gradient-to-br from-gray-900 via-black to-gray-900 text-gray-400">or</span>
+              <span className="bg-background/85 px-4 text-muted-foreground">or</span>
             </div>
           </div>
 
@@ -225,7 +233,7 @@ export default function SignupPage() {
           <Button
             type="button"
             variant="outline"
-            className="w-full bg-white hover:bg-gray-100 text-gray-900 border-gray-300 font-medium h-11"
+            className="h-11 w-full border-border/70 bg-background/80 font-medium text-foreground shadow-sm hover:bg-background hover:text-foreground"
             onClick={handleGoogleSignup}
             disabled={loading}
           >
@@ -239,8 +247,8 @@ export default function SignupPage() {
           </Button>
 
           <div className="text-center mt-4">
-            <span className="text-gray-400">Already have an account? </span>
-            <Link href="/login" className="text-white hover:underline">
+            <span className="text-muted-foreground">Already have an account? </span>
+            <Link href="/login" className="text-foreground hover:underline">
               Sign In
             </Link>
           </div>
@@ -250,45 +258,46 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+    <div className="auth-shell pattern-grid relative flex min-h-screen items-center justify-center overflow-hidden p-4 text-foreground">
+      <ThemeToggle className="fixed right-4 top-4 z-20" />
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-green-500/10 rounded-full blur-3xl animate-pulse" style={{animationDelay: '1s'}}></div>
+        <div className="auth-glow-primary absolute top-0 left-0 h-96 w-96 rounded-full blur-3xl animate-pulse"></div>
+        <div className="auth-glow-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }}></div>
       </div>
 
       <button
         type="button"
         onClick={() => setStep(1)}
-        className="fixed top-4 left-4 z-20 inline-flex items-center gap-1.5 text-base text-white/85 hover:text-white transition-colors focus:outline-none backdrop-blur-sm bg-black/20 px-3 py-2 rounded-lg"
+        className={backButtonClassName}
       >
         <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M12.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L8.414 9H17a1 1 0 110 2H8.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd"/></svg>
         <span>Back</span>
       </button>
 
-      <div className="w-full max-w-md relative z-10">
+      <div className={authPanelClassName}>
         <div className="text-center mb-6">
           <div className="inline-flex items-center justify-center mb-4">
             <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2">Create an account</h1>
-          <p className="text-gray-400 text-sm">Join us and start your learning journey</p>
+          <h1 className="mb-2 text-3xl font-bold text-foreground">Create an account</h1>
+          <p className="text-sm text-muted-foreground">Join us and start your learning journey</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="full_name" className="text-white font-medium">Full Name</Label>
+            <Label htmlFor="full_name" className="font-medium text-foreground">Full Name</Label>
             <Input 
               id="full_name" 
               type="text" 
               placeholder="Enter your full name" 
               value={formData.full_name} 
               onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))} 
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg" 
+              className={authInputClassName} 
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="email" className="text-white font-medium">Email</Label>
+            <Label htmlFor="email" className="font-medium text-foreground">Email</Label>
             <Input 
               id="email" 
               type="email" 
@@ -299,34 +308,34 @@ export default function SignupPage() {
                 // Clear error when user starts typing
                 if (error) setError("")
               }} 
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg" 
+              className={authInputClassName} 
               required 
             />
           </div>
           
           <div className="space-y-2">
-            <Label htmlFor="password" className="text-white font-medium">Password</Label>
+            <Label htmlFor="password" className="font-medium text-foreground">Password</Label>
             <Input 
               id="password" 
               type="password" 
               placeholder="Create a password" 
               value={formData.password} 
               onChange={(e) => setFormData(prev => ({ ...prev, password: e.target.value }))} 
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg" 
+              className={authInputClassName} 
               required 
             />
-            <p className="text-sm text-gray-400">Password must be at least 8 characters</p>
+            <p className="text-sm text-muted-foreground">Password must be at least 8 characters</p>
           </div>
 
           {error && error.length > 0 && (
-            <div className="bg-red-900/40 border-2 border-red-500 rounded-lg p-4 shadow-xl relative z-50 animate-in fade-in slide-in-from-top-2">
+            <div className="relative z-50 rounded-lg border border-red-500/30 bg-red-500/10 p-4 shadow-xl animate-in fade-in slide-in-from-top-2">
               <div className="flex items-start">
                 <svg className="w-5 h-5 text-red-400 mr-3 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
                 <div className="flex-1">
-                  <p className="text-red-300 text-sm font-semibold mb-1">Registration Error</p>
-                  <p className="text-red-200 text-sm font-medium">{error}</p>
+                  <p className="mb-1 text-sm font-semibold text-red-500 dark:text-red-300">Registration Error</p>
+                  <p className="text-sm font-medium text-red-600 dark:text-red-200">{error}</p>
                 </div>
               </div>
             </div>
@@ -342,11 +351,10 @@ export default function SignupPage() {
         </form>
 
         <div className="text-center mt-4">
-          <span className="text-gray-400">Already have an account? </span>
-          <Link href="/login" className="text-white hover:underline font-medium">Sign In</Link>
+          <span className="text-muted-foreground">Already have an account? </span>
+          <Link href="/login" className="font-medium text-foreground hover:underline">Sign In</Link>
         </div>
       </div>
     </div>
   )
 }
-

--- a/frontend/components/RoleBasedSidebar.tsx
+++ b/frontend/components/RoleBasedSidebar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { useAuth } from "@/lib/auth-context"
 import { apiClient } from "@/lib/api"
+import ThemeToggle from "@/components/ThemeToggle"
 import { 
   Home, 
   FileText, 
@@ -11,8 +12,6 @@ import {
   Play,
   BookOpen,
   Bell,
-  Settings,
-  MessageCircle,
   MessageSquare,
   Megaphone
 } from "lucide-react"
@@ -127,7 +126,7 @@ export default function RoleBasedSidebar({ currentPath = "/dashboard" }: RoleBas
     if (user?.full_name) {
       return user.full_name
         .split(" ")
-        .map((part) => part.charAt(0).toUpperCase())
+        .map((part: string) => part.charAt(0).toUpperCase())
         .slice(0, 2)
         .join("") || "U"
     }
@@ -140,7 +139,7 @@ export default function RoleBasedSidebar({ currentPath = "/dashboard" }: RoleBas
   }, [user])
 
   return (
-    <div className="w-20 bg-gradient-to-b from-gray-900 via-black to-gray-900 flex flex-col items-center py-6 fixed left-0 top-0 h-full z-40 border-r border-gray-800/50 shadow-2xl">
+    <div className="fixed left-0 top-0 z-40 flex h-full w-20 flex-col items-center border-r border-border/70 bg-background/85 py-6 shadow-2xl backdrop-blur-xl">
       {/* Logo */}
       <div className="mb-8 animate-scale-in">
         <img src="/n-aiblelogo.png" alt="Logo" className="w-18 h-10 opacity-90 hover:opacity-100 transition-opacity" />
@@ -158,14 +157,14 @@ export default function RoleBasedSidebar({ currentPath = "/dashboard" }: RoleBas
             <Link 
               key={item.href}
               href={item.href} 
-              className={`p-3 rounded-xl transition-all duration-300 group relative ${
+              className={`group relative rounded-xl p-3 transition-all duration-300 ${
                 isActive 
                   ? "bg-gradient-to-br from-blue-600 to-blue-700 shadow-lg shadow-blue-500/30 scale-105" 
-                  : "hover:bg-gray-800/80 hover:scale-105"
+                  : "hover:bg-accent hover:scale-105"
               }`}
               title={item.label}
             >
-              <Icon className={`h-6 w-6 transition-all ${isActive ? "text-white" : "text-gray-300 group-hover:text-white"}`} />
+              <Icon className={`h-6 w-6 transition-all ${isActive ? "text-white" : "text-muted-foreground group-hover:text-foreground"}`} />
               
               {/* Unread Notification Badge */}
               {showBadge && (
@@ -175,7 +174,7 @@ export default function RoleBasedSidebar({ currentPath = "/dashboard" }: RoleBas
               )}
               
               {/* Enhanced Tooltip */}
-              <div className="absolute left-full ml-3 px-3 py-2 bg-gray-900/95 backdrop-blur-sm text-white text-xs font-medium rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-300 pointer-events-none whitespace-nowrap z-[999] shadow-xl border border-gray-700">
+              <div className="pointer-events-none absolute left-full z-[999] ml-3 whitespace-nowrap rounded-lg border border-border/70 bg-card/95 px-3 py-2 text-xs font-medium text-card-foreground opacity-0 shadow-xl transition-all duration-300 group-hover:opacity-100">
                 {item.label}
               </div>
             </Link>
@@ -184,22 +183,26 @@ export default function RoleBasedSidebar({ currentPath = "/dashboard" }: RoleBas
       </nav>
       
       {/* Changelog Section */}
-      <div className="mt-auto mb-4">
+      <div className="mt-auto mb-3">
         {/* Changelog Button */}
         <button
           data-canny-changelog
-          className="p-3 hover:bg-gray-800 rounded-lg transition-all duration-300 group relative block"
+          className="group relative block rounded-lg p-3 transition-all duration-300 hover:bg-accent"
           title="What's New"
         >
           <div className="relative">
-            <Megaphone className="h-6 w-6 text-white" />
+            <Megaphone className="h-6 w-6 text-muted-foreground transition-colors group-hover:text-foreground" />
           </div>
           
           {/* Tooltip */}
-          <div className="absolute left-full ml-3 px-3 py-2 bg-gray-900/95 backdrop-blur-sm text-white text-xs font-medium rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-300 pointer-events-none whitespace-nowrap z-[999] shadow-xl border border-gray-700">
+          <div className="pointer-events-none absolute left-full z-[999] ml-3 whitespace-nowrap rounded-lg border border-border/70 bg-card/95 px-3 py-2 text-xs font-medium text-card-foreground opacity-0 shadow-xl transition-all duration-300 group-hover:opacity-100">
             What's New
           </div>
         </button>
+      </div>
+
+      <div className="mb-4">
+        <ThemeToggle compact />
       </div>
 
       

--- a/frontend/components/RoleChooser.tsx
+++ b/frontend/components/RoleChooser.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState } from "react"
 import { Button } from "@/components/ui/button"
+import ThemeToggle from "@/components/ThemeToggle"
 
 export interface RoleChooserProps {
   selectedRole: "student" | "professor" | null
@@ -28,14 +28,15 @@ export default function RoleChooser({
   const titleSize = isDetailed ? "text-2xl" : "text-xl"
 
   return (
-    <div className={`min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden ${className}`}>
+    <div className={`auth-shell pattern-grid relative flex min-h-screen items-center justify-center overflow-hidden p-4 text-foreground ${className}`}>
+      <ThemeToggle className="fixed right-4 top-4 z-20" />
       {/* Animated background elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse" style={{animationDelay: '1s'}}></div>
+        <div className="auth-glow-primary absolute top-0 left-0 h-96 w-96 rounded-full blur-3xl animate-pulse"></div>
+        <div className="auth-glow-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }}></div>
       </div>
       
-      <div className={`w-full ${maxWidth} relative z-10 animate-fade-scale pb-20 mt-15`}>
+      <div className={`relative z-10 mt-15 w-full ${maxWidth} animate-fade-scale rounded-[36px] border border-border/60 bg-background/70 px-6 pb-20 pt-10 shadow-2xl backdrop-blur-xl md:px-10`}>
         {/* Logo */}
         <div className="text-center mb-6">
           <div className="inline-flex items-center justify-center mb-4 animate-scale-in">
@@ -45,8 +46,8 @@ export default function RoleChooser({
               className="h-16 w-auto opacity-95 object-contain" 
             />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Choose Your Role</h1>
-          <p className="text-gray-400">How will you be using the platform?</p>
+          <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">Choose Your Role</h1>
+          <p className="text-muted-foreground">How will you be using the platform?</p>
         </div>
 
         {/* Role Selection Cards */}
@@ -56,7 +57,7 @@ export default function RoleChooser({
             className={`card-elevated cursor-pointer px-8 py-12 rounded-xl border-2 transition-all duration-300 backdrop-blur-sm overflow-hidden ${
               selectedRole === "student" 
                 ? "border-blue-500 bg-gradient-to-br from-blue-900/40 to-blue-800/20 shadow-lg shadow-blue-500/20" 
-                : "border-gray-600/60 bg-gray-900/30 hover:border-blue-400/60 hover:bg-gray-800/40"
+                : "border-border/60 bg-background/60 hover:border-blue-400/60 hover:bg-background/80"
             }`}
             onClick={() => onRoleSelect("student")}
           >
@@ -68,7 +69,7 @@ export default function RoleChooser({
                 </svg>
                 <h3 className={`${titleSize} font-bold text-blue-100 tracking-tight absolute left-1/2 -translate-x-1/2`}>Student</h3>
               </div>
-              <p className={`text-gray-300 ${isDetailed ? "mb-4 text-base" : "text-sm"}`}>
+              <p className={`text-muted-foreground ${isDetailed ? "mb-4 text-base" : "text-sm"}`}>
                 Join cohorts and participate in simulations
               </p>
               
@@ -76,15 +77,15 @@ export default function RoleChooser({
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-blue-400 rounded-full shadow-lg shadow-blue-400/50"></div>
-                    <span className="text-gray-200">Access assigned simulations</span>
+                    <span className="text-foreground/90">Access assigned simulations</span>
                   </div>
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-blue-400 rounded-full shadow-lg shadow-blue-400/50"></div>
-                    <span className="text-gray-200">Track your progress</span>
+                    <span className="text-foreground/90">Track your progress</span>
                   </div>
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-blue-400 rounded-full shadow-lg shadow-blue-400/50"></div>
-                    <span className="text-gray-200">Receive notifications</span>
+                    <span className="text-foreground/90">Receive notifications</span>
                   </div>
                 </div>
               )}
@@ -96,7 +97,7 @@ export default function RoleChooser({
             className={`card-elevated cursor-pointer px-8 py-12 rounded-xl border-2 transition-all duration-300 backdrop-blur-sm overflow-hidden ${
               selectedRole === "professor" 
                 ? "border-purple-500 bg-gradient-to-br from-purple-900/40 to-purple-800/20 shadow-lg shadow-purple-500/20" 
-                : "border-gray-600/60 bg-gray-900/30 hover:border-purple-400/60 hover:bg-gray-800/40"
+                : "border-border/60 bg-background/60 hover:border-purple-400/60 hover:bg-background/80"
             }`}
             onClick={() => onRoleSelect("professor")}
           >
@@ -107,7 +108,7 @@ export default function RoleChooser({
                 </svg>
                 <h3 className={`${titleSize} font-bold text-purple-100 tracking-tight absolute left-1/2 -translate-x-1/2`}>Professor</h3>
               </div>
-              <p className={`text-gray-300 ${isDetailed ? "mb-4 text-base" : "text-sm"}`}>
+              <p className={`text-muted-foreground ${isDetailed ? "mb-4 text-base" : "text-sm"}`}>
                 Create simulations and manage cohorts
               </p>
               
@@ -115,15 +116,15 @@ export default function RoleChooser({
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-purple-400 rounded-full shadow-lg shadow-purple-400/50"></div>
-                    <span className="text-gray-200">Build custom simulations</span>
+                    <span className="text-foreground/90">Build custom simulations</span>
                   </div>
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-purple-400 rounded-full shadow-lg shadow-purple-400/50"></div>
-                    <span className="text-gray-200">Manage student cohorts</span>
+                    <span className="text-foreground/90">Manage student cohorts</span>
                   </div>
                   <div className="flex items-center space-x-3">
                     <div className="w-2 h-2 bg-purple-400 rounded-full shadow-lg shadow-purple-400/50"></div>
-                    <span className="text-gray-200">Track learning analytics</span>
+                    <span className="text-foreground/90">Track learning analytics</span>
                   </div>
                 </div>
               )}

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { MoonStar, SunMedium } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { cn } from "@/lib/utils"
+
+interface ThemeToggleProps {
+  className?: string
+  compact?: boolean
+}
+
+export default function ThemeToggle({
+  className,
+  compact = false,
+}: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const isDark = mounted ? resolvedTheme === "dark" : true
+  const nextTheme = isDark ? "light" : "dark"
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(nextTheme)}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-3 py-2 text-sm font-medium text-foreground shadow-lg backdrop-blur-md transition-all hover:bg-background",
+        compact && "h-12 w-12 justify-center p-0",
+        className
+      )}
+      aria-label={mounted ? `Switch to ${nextTheme} mode` : "Toggle theme"}
+      title={mounted ? `Switch to ${nextTheme} mode` : "Toggle theme"}
+    >
+      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-foreground/10">
+        {isDark ? <SunMedium className="h-4 w-4" /> : <MoonStar className="h-4 w-4" />}
+      </span>
+      {!compact && (
+        <span>{mounted ? (isDark ? "Light mode" : "Dark mode") : "Theme"}</span>
+      )}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable persisted dark mode toggle using `next-themes`
- wire theme support into the app layout and sidebar shell
- update auth and role selection screens to respect light and dark themes
- add global dark-mode fallback styling for existing light surfaces

## Verification
- targeted `tsc --noEmit` grep for changed files passed
- full `next lint` is blocked because this repo has no ESLint config and Next opens the interactive setup prompt
- full `tsc --noEmit` and `npm run build` still fail on pre-existing repo issues and offline font/dependency fetches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added theme toggle to switch between light and dark modes throughout the application.

* **UI Updates**
  * Implemented theme-aware styling across all authentication pages, sidebar, and form components.
  * Enhanced visual consistency with improved contrast and color adaptation based on selected theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->