### PR TITLE
feat: add CodeRabbit custom finishing touch recipes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,6 +27,59 @@ reviews:
       enabled: true
     hadolint:
       enabled: true
+  finishing_touches:
+    custom:
+      - name: "cleanup stale imports"
+        enabled: true
+        instructions: |
+          Scan all changed Python and TypeScript files for unused import statements and remove them.
+          For Python: remove any `import` or `from ... import` statements whose symbols are never
+          referenced in the file body. Do not reorder remaining imports; only delete stale lines.
+          For TypeScript/TSX: remove any `import` statements whose bindings are never used.
+          Preserve imports that are only referenced in type positions (e.g. `type Foo`).
+          Do not touch files that were not modified in this PR.
+
+      - name: "tighten TypeScript types"
+        enabled: true
+        instructions: |
+          In the changed TypeScript and TSX files, replace `any` types with the most specific
+          correct type given the surrounding context. Prefer existing project types and interfaces
+          from `@/lib` or the same file before reaching for generic alternatives like `unknown`.
+          Add explicit return types to exported functions and React components that are missing them.
+          Do not alter runtime logic; only improve type annotations.
+
+      - name: "enforce soft deletion queries"
+        enabled: true
+        instructions: |
+          Audit every SQLAlchemy query in the changed Python files.
+          Any query against the Scenario, ScenarioPersona, ScenarioScene, or related models
+          must include a `.filter(ModelName.deleted_at.is_(None))` clause.
+          If a query is missing this filter, add it.
+          Do not change queries that intentionally operate on deleted records
+          (e.g. admin restore endpoints or audit logs where the intent is explicit).
+
+      - name: "enforce FastAPI error handling"
+        enabled: true
+        instructions: |
+          Review every new or modified FastAPI endpoint function in the changed Python files.
+          Ensure that database operations, external service calls (OpenAI, Redis, S3/Wasabi),
+          and file I/O are wrapped in try/except blocks.
+          Caught exceptions should raise an `HTTPException` with an appropriate status code and
+          a user-safe detail message. Never expose raw exception messages or tracebacks to the
+          HTTP response. Use the existing `debug_log()` utility to log the underlying error before
+          raising. Do not add redundant try/except around code that is already protected.
+
+      - name: "enforce role-based access on endpoints"
+        enabled: true
+        instructions: |
+          Inspect every new FastAPI route added or modified in this PR.
+          Ensure that routes which operate on user-specific or privileged data declare the
+          appropriate dependency: `get_current_user` for authenticated routes,
+          `require_admin` for admin-only routes, or the relevant professor/student guard.
+          Flag any route that accepts a `user_id` path/query parameter but does not validate
+          that the requesting user is authorized to access that resource.
+          Do not modify existing routes that already have the correct dependency declared.
+
 chat:
   auto_reply: true
 knowledge_base:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,6 +48,17 @@ reviews:
           Add explicit return types to exported functions and React components that are missing them.
           Do not alter runtime logic; only improve type annotations.
 
+      - name: "enforce role-based access on endpoints"
+        enabled: true
+        instructions: |
+          Inspect every new FastAPI route added or modified in this PR.
+          Ensure that routes which operate on user-specific or privileged data declare the
+          appropriate dependency: `get_current_user` for authenticated routes,
+          `require_admin` for admin-only routes, or the relevant professor/student guard.
+          Flag any route that accepts a `user_id` path/query parameter but does not validate
+          that the requesting user is authorized to access that resource.
+          Do not modify existing routes that already have the correct dependency declared.
+
       - name: "enforce soft deletion queries"
         enabled: true
         instructions: |
@@ -68,17 +79,6 @@ reviews:
           a user-safe detail message. Never expose raw exception messages or tracebacks to the
           HTTP response. Use the existing `debug_log()` utility to log the underlying error before
           raising. Do not add redundant try/except around code that is already protected.
-
-      - name: "enforce role-based access on endpoints"
-        enabled: true
-        instructions: |
-          Inspect every new FastAPI route added or modified in this PR.
-          Ensure that routes which operate on user-specific or privileged data declare the
-          appropriate dependency: `get_current_user` for authenticated routes,
-          `require_admin` for admin-only routes, or the relevant professor/student guard.
-          Flag any route that accepts a `user_id` path/query parameter but does not validate
-          that the requesting user is authorized to access that resource.
-          Do not modify existing routes that already have the correct dependency declared.
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary

Adds 5 project-tailored **custom finishing touch recipes** to `.coderabbit.yaml`, leveraging the new CodeRabbit agentic recipes feature (open beta, Pro plan).

Each recipe can be triggered via `@coderabbitai run <recipe name>` on any PR, or will appear as checkboxes in the CodeRabbit Walkthrough section.

### Recipes added

| Recipe | Scope | What it enforces |
|---|---|---|
| `cleanup stale imports` | Python + TypeScript | Removes unused imports without reordering |
| `tighten TypeScript types` | TypeScript/TSX | Replaces `any`, adds missing return types on exports |
| `enforce soft deletion queries` | Python/SQLAlchemy | Ensures `deleted_at.is_(None)` filter on all relevant model queries |
| `enforce FastAPI error handling` | Python/FastAPI | Wraps DB/external calls in `try/except → HTTPException` using `debug_log()` |
| `enforce role-based access on endpoints` | Python/FastAPI | Validates `get_current_user` / `require_admin` dependency on new routes |

The last two recipes are intentionally specific to this codebase's conventions (`debug_log`, soft deletion pattern, role guards), making them more useful than generic alternatives.

## Test plan

- [ ] Verify `.coderabbit.yaml` parses without errors (schema validation at top of file)
- [ ] Open a test PR and confirm the 5 recipes appear as checkboxes in the CodeRabbit Walkthrough
- [ ] Trigger one recipe manually: comment `@coderabbitai run cleanup stale imports` on a PR with known unused imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration to add automated checks that remove unused imports, encourage stricter TypeScript typing and explicit return types, enforce route authorization checks, ensure soft-deleted records are properly filtered in queries, and require safe error handling with logging for endpoints.

**Note:** This release contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->