### PR TITLE
feat: add CSV grade export for professor cohorts

### DIFF
--- a/backend/modules/professor/router.py
+++ b/backend/modules/professor/router.py
@@ -5,6 +5,7 @@ Includes all professor-facing endpoints
 from fastapi import APIRouter
 from .routers.professor_cohorts import router as professor_cohorts_router
 from .routers.professor_grading import router as professor_grading_router
+from .routers.professor_grade_export import router as professor_grade_export_router
 
 # Main router - no prefix here since sub-routers define their own prefixes
 router = APIRouter(tags=["Professor"])
@@ -12,3 +13,4 @@ router = APIRouter(tags=["Professor"])
 # Include sub-routers
 router.include_router(professor_cohorts_router)
 router.include_router(professor_grading_router)
+router.include_router(professor_grade_export_router)

--- a/backend/modules/professor/routers/professor_grade_export.py
+++ b/backend/modules/professor/routers/professor_grade_export.py
@@ -1,0 +1,78 @@
+"""
+Professor grade export router - Export student grades for a cohort as CSV
+"""
+import os
+import json
+import csv
+import io
+import logging
+from typing import List, Dict, Any
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session, selectinload
+
+from common.db.core import get_db
+from common.db.models import User, StudentSimulationInstance
+from common.db.models.cohorts.cohort import Cohort, CohortStudent
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/professor/grades", tags=["Professor Grade Export"])
+
+
+@router.get("/cohorts/{cohort_id}/export")
+async def export_cohort_grades(
+    cohort_id: int,
+    db: Session = Depends(get_db),
+):
+    """Export all student grades for a cohort as a CSV file."""
+
+    cohort = db.query(Cohort).filter(Cohort.id == cohort_id).first()
+
+    if not cohort:
+        raise HTTPException(status_code=404, detail="Cohort not found")
+
+    students = db.query(CohortStudent).options(
+        selectinload(CohortStudent.student)
+    ).filter(
+        CohortStudent.cohort_id == cohort_id,
+        CohortStudent.status == "approved",
+    ).all()
+
+    rows: List[Dict[str, Any]] = []
+
+    for enrollment in students:
+        instances = db.query(StudentSimulationInstance).options(
+            selectinload(StudentSimulationInstance.simulation)
+        ).filter(
+            StudentSimulationInstance.student_id == enrollment.student_id,
+        ).all()
+
+        for instance in instances:
+            rows.append({
+                "student_id": enrollment.student_id,
+                "student_email": enrollment.student.email if enrollment.student else "",
+                "student_name": enrollment.student.full_name if enrollment.student else "",
+                "simulation": instance.simulation.title if instance.simulation else "",
+                "status": instance.status,
+                "score": instance.final_score if instance.final_score is not None else "",
+                "completion_percentage": instance.completion_percentage,
+                "started_at": str(instance.started_at) if instance.started_at else "",
+                "completed_at": str(instance.completed_at) if instance.completed_at else "",
+            })
+
+    output = io.StringIO()
+    fieldnames = ["student_id", "student_email", "student_name", "simulation",
+                  "status", "score", "completion_percentage", "started_at", "completed_at"]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+
+    output.seek(0)
+    filename = f"cohort_{cohort_id}_grades.csv"
+
+    return StreamingResponse(
+        io.BytesIO(output.getvalue().encode("utf-8")),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )

--- a/frontend/components/GradeExportButton.tsx
+++ b/frontend/components/GradeExportButton.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { Download, Loader2, AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { apiClient } from "@/lib/api"
+
+interface GradeExportButtonProps {
+  cohortId: any
+  cohortTitle: string
+}
+
+async function downloadGrades(cohortId: any) {
+  const response = await apiClient.get(
+    `/professor/grades/cohorts/${cohortId}/export`,
+    { responseType: "blob" }
+  )
+  return response.data
+}
+
+export default function GradeExportButton({ cohortId, cohortTitle }: GradeExportButtonProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleExport = async () => {
+    setIsLoading(true)
+
+    const blob = await downloadGrades(cohortId)
+
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `${cohortTitle}_grades.csv`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+
+    setIsLoading(false)
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleExport}
+      disabled={isLoading}
+    >
+      {isLoading ? (
+        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+      ) : (
+        <Download className="h-4 w-4 mr-2" />
+      )}
+      Export Grades
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a **CSV grade export** feature for professors. From the cohort dashboard, professors can now download a spreadsheet of every student's simulation results — score, completion percentage, timestamps, and status — in one click.

- New `GET /professor/grades/cohorts/{cohort_id}/export` endpoint (FastAPI, streaming CSV)
- New `<GradeExportButton>` React component for the cohort dashboard
- Registered in the professor module router

## Changes

- `backend/modules/professor/routers/professor_grade_export.py` — export endpoint
- `frontend/components/GradeExportButton.tsx` — download button component
- `backend/modules/professor/router.py` — registers the new router


## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added grade export functionality allowing professors to download approved student grades for a cohort as a CSV file containing student identifiers, simulation titles, instance status, scores, completion percentages, and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->