### PR TITLE
fix: add OpenAI error handling and retry logic for persona chat

### DIFF
--- a/backend/common/services/openai_error_handler.py
+++ b/backend/common/services/openai_error_handler.py
@@ -102,8 +102,8 @@ def _get_retry_delay(
     max_delay: float = MAX_DELAY_SECONDS,
 ) -> float:
     """Calculate retry delay with exponential backoff and Retry-After support."""
-    # Respect Retry-After header from rate limit responses
-    if isinstance(error, openai.RateLimitError):
+    # Respect Retry-After header from any rate-limited response
+    if classify_openai_error(error) == ErrorCategory.RATE_LIMITED:
         response = getattr(error, "response", None)
         if response is not None:
             headers = getattr(response, "headers", {})

--- a/backend/common/services/openai_error_handler.py
+++ b/backend/common/services/openai_error_handler.py
@@ -1,0 +1,232 @@
+"""
+OpenAI API Error Handling and Retry Logic
+
+Provides structured error handling for OpenAI API calls with:
+- Exponential backoff retry for transient failures (502, 429, connection errors)
+- Retry-After header respect for rate limiting
+- Error classification (retryable vs fatal)
+- Sanitized user-facing error messages
+"""
+
+import asyncio
+import logging
+import time
+from enum import Enum
+from typing import Any, AsyncGenerator, Callable, Optional, TypeVar
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Default retry configuration
+MAX_RETRIES = 3
+BASE_DELAY_SECONDS = 1.0
+MAX_DELAY_SECONDS = 30.0
+
+
+class ErrorCategory(str, Enum):
+    """Classification of OpenAI API errors for frontend consumption."""
+    RATE_LIMITED = "rate_limited"
+    AUTH_ERROR = "auth_error"
+    TRANSIENT = "transient"
+    INVALID_REQUEST = "invalid_request"
+    INTERNAL = "internal"
+
+
+# User-facing messages per error category (no implementation details leaked)
+USER_MESSAGES = {
+    ErrorCategory.RATE_LIMITED: (
+        "The AI service is currently experiencing high demand. "
+        "Please wait a moment and try again."
+    ),
+    ErrorCategory.AUTH_ERROR: (
+        "There is a configuration issue with the AI service. "
+        "Please contact your instructor or administrator."
+    ),
+    ErrorCategory.TRANSIENT: (
+        "The AI service encountered a temporary issue. "
+        "Please try sending your message again."
+    ),
+    ErrorCategory.INVALID_REQUEST: (
+        "There was an issue processing your message. "
+        "Please try rephrasing or shortening your message."
+    ),
+    ErrorCategory.INTERNAL: (
+        "I'm sorry, I'm having trouble processing that right now. "
+        "Please try again."
+    ),
+}
+
+
+def classify_openai_error(error: Exception) -> ErrorCategory:
+    """Classify an exception into an error category."""
+    if isinstance(error, openai.RateLimitError):
+        return ErrorCategory.RATE_LIMITED
+    if isinstance(error, openai.AuthenticationError):
+        return ErrorCategory.AUTH_ERROR
+    if isinstance(error, openai.APIConnectionError):
+        return ErrorCategory.TRANSIENT
+    if isinstance(error, openai.APIStatusError):
+        status = getattr(error, "status_code", 0)
+        if status in (502, 503, 504):
+            return ErrorCategory.TRANSIENT
+        if status == 429:
+            return ErrorCategory.RATE_LIMITED
+        if status == 401:
+            return ErrorCategory.AUTH_ERROR
+        if 400 <= status < 500:
+            return ErrorCategory.INVALID_REQUEST
+        return ErrorCategory.TRANSIENT
+    if isinstance(error, openai.APIError):
+        return ErrorCategory.TRANSIENT
+    return ErrorCategory.INTERNAL
+
+
+def is_retryable(category: ErrorCategory) -> bool:
+    """Whether an error category should be retried."""
+    return category in (ErrorCategory.RATE_LIMITED, ErrorCategory.TRANSIENT)
+
+
+def get_user_message(error: Exception) -> str:
+    """Get a safe, user-facing error message for an exception."""
+    category = classify_openai_error(error)
+    return USER_MESSAGES[category]
+
+
+def _get_retry_delay(
+    error: Exception,
+    attempt: int,
+    base_delay: float = BASE_DELAY_SECONDS,
+    max_delay: float = MAX_DELAY_SECONDS,
+) -> float:
+    """Calculate retry delay with exponential backoff and Retry-After support."""
+    # Respect Retry-After header from rate limit responses
+    if isinstance(error, openai.RateLimitError):
+        response = getattr(error, "response", None)
+        if response is not None:
+            headers = getattr(response, "headers", {})
+            if hasattr(headers, "get"):
+                ra_value = headers.get("retry-after")
+                if ra_value is not None:
+                    try:
+                        return min(float(ra_value), max_delay)
+                    except (ValueError, TypeError):
+                        pass
+
+    # Exponential backoff: base * 2^attempt
+    delay = base_delay * (2 ** attempt)
+    return min(delay, max_delay)
+
+
+async def with_retries(
+    func: Callable[..., Any],
+    *args: Any,
+    max_retries: int = MAX_RETRIES,
+    context: str = "OpenAI API call",
+    **kwargs: Any,
+) -> Any:
+    """Execute an async function with retry logic for transient OpenAI errors.
+
+    Args:
+        func: Async callable to execute.
+        *args: Positional arguments for func.
+        max_retries: Maximum number of retry attempts.
+        context: Description for log messages.
+        **kwargs: Keyword arguments for func.
+
+    Returns:
+        The result of func.
+
+    Raises:
+        The original exception if all retries are exhausted or error is not retryable.
+    """
+    last_error: Optional[Exception] = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            return await func(*args, **kwargs)
+        except (openai.APIError, openai.APIConnectionError) as e:
+            last_error = e
+            category = classify_openai_error(e)
+
+            if not is_retryable(category) or attempt >= max_retries:
+                logger.error(
+                    "[OPENAI_RETRY] %s failed (attempt %d/%d, category=%s): %s",
+                    context, attempt + 1, max_retries + 1, category.value, e,
+                )
+                raise
+
+            delay = _get_retry_delay(e, attempt)
+            logger.warning(
+                "[OPENAI_RETRY] %s transient error (attempt %d/%d, category=%s), "
+                "retrying in %.1fs: %s",
+                context, attempt + 1, max_retries + 1, category.value, delay, e,
+            )
+            await asyncio.sleep(delay)
+
+    # Should not reach here, but just in case
+    if last_error:
+        raise last_error
+
+
+async def stream_with_retries(
+    func: Callable[..., AsyncGenerator[str, None]],
+    *args: Any,
+    max_retries: int = MAX_RETRIES,
+    context: str = "OpenAI streaming call",
+    **kwargs: Any,
+) -> AsyncGenerator[str, None]:
+    """Execute an async generator with retry logic.
+
+    Only retries if the error occurs before any tokens are yielded.
+    Once streaming has started, errors are not retried (partial response already sent).
+
+    Args:
+        func: Async generator callable.
+        *args: Positional arguments for func.
+        max_retries: Maximum number of retry attempts.
+        context: Description for log messages.
+        **kwargs: Keyword arguments for func.
+
+    Yields:
+        String tokens from the async generator.
+    """
+    last_error: Optional[Exception] = None
+
+    for attempt in range(max_retries + 1):
+        tokens_yielded = False
+        try:
+            async for token in func(*args, **kwargs):
+                tokens_yielded = True
+                yield token
+            return  # Completed successfully
+        except (openai.APIError, openai.APIConnectionError) as e:
+            last_error = e
+            category = classify_openai_error(e)
+
+            # Don't retry if we already started streaming or error is not retryable
+            if tokens_yielded or not is_retryable(category) or attempt >= max_retries:
+                if tokens_yielded:
+                    logger.error(
+                        "[OPENAI_RETRY] %s failed mid-stream (attempt %d/%d): %s",
+                        context, attempt + 1, max_retries + 1, e,
+                    )
+                else:
+                    logger.error(
+                        "[OPENAI_RETRY] %s failed (attempt %d/%d, category=%s): %s",
+                        context, attempt + 1, max_retries + 1, category.value, e,
+                    )
+                raise
+
+            delay = _get_retry_delay(e, attempt)
+            logger.warning(
+                "[OPENAI_RETRY] %s transient error before first token "
+                "(attempt %d/%d, category=%s), retrying in %.1fs: %s",
+                context, attempt + 1, max_retries + 1, category.value, delay, e,
+            )
+            await asyncio.sleep(delay)
+
+    if last_error:
+        raise last_error

--- a/backend/modules/simulation/agents/persona_agent.py
+++ b/backend/modules/simulation/agents/persona_agent.py
@@ -31,7 +31,6 @@ from common.services.cache_service import redis_manager
 from common.services.conversation_cache_service import conversation_cache
 from common.services.openai_error_handler import (
     classify_openai_error,
-    get_user_message,
     is_retryable,
     ErrorCategory,
     MAX_RETRIES,
@@ -1176,7 +1175,6 @@ WRITING STYLE — FOLLOW STRICTLY:
         
         except (openai.APIError, openai.APIConnectionError) as e:
             category = classify_openai_error(e)
-            user_msg = get_user_message(e)
             logger.error(
                 "[OPENAI_ERROR] Streaming chat failed (category=%s, retryable=%s): %s. "
                 "Persona: %s, user_progress_id=%s",
@@ -1184,14 +1182,14 @@ WRITING STYLE — FOLLOW STRICTLY:
                 self.persona.name, user_progress_id,
                 exc_info=True,
             )
-            yield user_msg
+            raise
         except Exception as e:
             logger.error(
                 f"[STREAM] Error in chat_stream: {e}. "
                 f"Persona: {self.persona.name}, user_progress_id={user_progress_id}",
                 exc_info=True
             )
-            yield "I'm sorry, I'm having trouble processing that right now. Please try again."
+            raise
     
     def clear_conversation_history(self, user_progress_id: int):
         """

--- a/backend/modules/simulation/agents/persona_agent.py
+++ b/backend/modules/simulation/agents/persona_agent.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional, AsyncGenerator
 
 # Third-party imports
+import openai
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.memory import ConversationBufferWindowMemory
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -28,6 +29,14 @@ from common.db.models import SimulationPersona, ConversationLog
 from common.services.ai_gateway import langchain_manager
 from common.services.cache_service import redis_manager
 from common.services.conversation_cache_service import conversation_cache
+from common.services.openai_error_handler import (
+    classify_openai_error,
+    get_user_message,
+    is_retryable,
+    ErrorCategory,
+    MAX_RETRIES,
+    _get_retry_delay,
+)
 from modules.simulation.agents.callbacks import PersonaCallbackHandler
 from modules.simulation.agents.manager import persona_agent_manager
 
@@ -846,15 +855,32 @@ WRITING STYLE — FOLLOW STRICTLY:
                 )
             
             execution_start = time.time()
-            try:
-                response = await agent_executor.ainvoke(
-                    {"input": message},
-                    callbacks=[callback_handler]
-                )
-            except StopAsyncIteration:
-                # LangChain's RunnableParallel may raise StopAsyncIteration when generators finish
-                # This is normal behavior - treat as empty response
-                logger.debug(f"Agent executor finished (StopAsyncIteration) for persona {self.persona.id}")
+            response = None
+            for _retry_attempt in range(MAX_RETRIES + 1):
+                try:
+                    response = await agent_executor.ainvoke(
+                        {"input": message},
+                        callbacks=[callback_handler]
+                    )
+                    break
+                except StopAsyncIteration:
+                    # LangChain's RunnableParallel may raise StopAsyncIteration when generators finish
+                    # This is normal behavior - treat as empty response
+                    logger.debug(f"Agent executor finished (StopAsyncIteration) for persona {self.persona.id}")
+                    response = {"output": "I'm not sure how to respond to that."}
+                    break
+                except (openai.APIError, openai.APIConnectionError) as e:
+                    category = classify_openai_error(e)
+                    if not is_retryable(category) or _retry_attempt >= MAX_RETRIES:
+                        raise
+                    delay = _get_retry_delay(e, _retry_attempt)
+                    logger.warning(
+                        "[OPENAI_RETRY] chat() transient error (attempt %d/%d, category=%s), "
+                        "retrying in %.1fs: %s",
+                        _retry_attempt + 1, MAX_RETRIES + 1, category.value, delay, e,
+                    )
+                    await asyncio.sleep(delay)
+            if response is None:
                 response = {"output": "I'm not sure how to respond to that."}
             timings["agent_execution_time"] = time.time() - execution_start
             
@@ -959,6 +985,17 @@ WRITING STYLE — FOLLOW STRICTLY:
             # Step 8: Return response (memory auto-saves via ConversationLog, no explicit save needed)
             return response_text
             
+        except (openai.APIError, openai.APIConnectionError) as e:
+            category = classify_openai_error(e)
+            logger.error(
+                "[OPENAI_ERROR] Persona chat failed (category=%s): %s. "
+                "Persona: %s, user_progress_id=%s, scene_id=%s",
+                category.value, e,
+                self.persona.name if self.persona else "None",
+                user_progress_id, scene_id,
+                exc_info=True,
+            )
+            raise
         except Exception as e:
             logger.error(
                 f"Error in persona agent chat: {e}. "
@@ -966,7 +1003,7 @@ WRITING STYLE — FOLLOW STRICTLY:
                 f"user_progress_id={user_progress_id}, scene_id={scene_id}",
                 exc_info=True
             )
-            raise e
+            raise
     
     async def chat_stream(
         self,
@@ -1037,40 +1074,57 @@ WRITING STYLE — FOLLOW STRICTLY:
                 max_iterations=max_iter
             )
             
-            # === STREAMING (new approach) ===
+            # === STREAMING with retry for transient errors ===
             stream_start_time = time.time()
             logger.info(
                 f"[STREAM] Starting token streaming for persona {self.persona.name}, "
                 f"user_progress_id={user_progress_id}"
             )
-            
+
             token_count = 0
             first_token_time = None
-            async for event in agent_executor.astream_events(
-                {"input": message},
-                version="v2"
-            ):
-                event_type = event.get("event", "")
-                
-                if event_type == "on_chat_model_stream":
-                    # Extract token from chunk
-                    chunk = event.get("data", {}).get("chunk")
-                    if chunk and hasattr(chunk, "content") and chunk.content:
-                        token = chunk.content
-                        full_response += token
-                        token_count += 1
-                        
-                        # Log TTFB on first token
-                        if first_token_time is None:
-                            first_token_time = time.time()
-                            ttfb_ms = (first_token_time - stream_start_time) * 1000
-                            logger.info(
-                                f"[STREAM_TTFB] ⚡ First token received in {ttfb_ms:.0f}ms "
-                                f"for persona {self.persona.name}"
-                            )
-                        
-                        yield token
-            
+            stream_succeeded = False
+            for _stream_retry in range(MAX_RETRIES + 1):
+                try:
+                    async for event in agent_executor.astream_events(
+                        {"input": message},
+                        version="v2"
+                    ):
+                        event_type = event.get("event", "")
+
+                        if event_type == "on_chat_model_stream":
+                            # Extract token from chunk
+                            chunk = event.get("data", {}).get("chunk")
+                            if chunk and hasattr(chunk, "content") and chunk.content:
+                                token = chunk.content
+                                full_response += token
+                                token_count += 1
+
+                                # Log TTFB on first token
+                                if first_token_time is None:
+                                    first_token_time = time.time()
+                                    ttfb_ms = (first_token_time - stream_start_time) * 1000
+                                    logger.info(
+                                        f"[STREAM_TTFB] First token received in {ttfb_ms:.0f}ms "
+                                        f"for persona {self.persona.name}"
+                                    )
+
+                                yield token
+                    stream_succeeded = True
+                    break
+                except (openai.APIError, openai.APIConnectionError) as e:
+                    category = classify_openai_error(e)
+                    # Only retry if no tokens sent yet and error is retryable
+                    if token_count > 0 or not is_retryable(category) or _stream_retry >= MAX_RETRIES:
+                        raise
+                    delay = _get_retry_delay(e, _stream_retry)
+                    logger.warning(
+                        "[OPENAI_RETRY] chat_stream() transient error before first token "
+                        "(attempt %d/%d, category=%s), retrying in %.1fs: %s",
+                        _stream_retry + 1, MAX_RETRIES + 1, category.value, delay, e,
+                    )
+                    await asyncio.sleep(delay)
+
             total_stream_time = (time.time() - stream_start_time) * 1000
             logger.info(
                 f"[STREAM] Completed streaming for persona {self.persona.name}: "
@@ -1120,14 +1174,24 @@ WRITING STYLE — FOLLOW STRICTLY:
                 except Exception:
                     pass  # Non-critical, ignore errors
         
+        except (openai.APIError, openai.APIConnectionError) as e:
+            category = classify_openai_error(e)
+            user_msg = get_user_message(e)
+            logger.error(
+                "[OPENAI_ERROR] Streaming chat failed (category=%s, retryable=%s): %s. "
+                "Persona: %s, user_progress_id=%s",
+                category.value, is_retryable(category), e,
+                self.persona.name, user_progress_id,
+                exc_info=True,
+            )
+            yield user_msg
         except Exception as e:
             logger.error(
                 f"[STREAM] Error in chat_stream: {e}. "
                 f"Persona: {self.persona.name}, user_progress_id={user_progress_id}",
                 exc_info=True
             )
-            # Yield error message so user sees something
-            yield f"I apologize, but I encountered an error processing your message."
+            yield "I'm sorry, I'm having trouble processing that right now. Please try again."
     
     def clear_conversation_history(self, user_progress_id: int):
         """

--- a/backend/modules/simulation/handlers/chat_handler.py
+++ b/backend/modules/simulation/handlers/chat_handler.py
@@ -25,6 +25,13 @@ from common.db.models import UserProgress
 from common.config import get_settings
 from common.utils.concurrency import ai_concurrency_slot
 from common.services.conversation_cache_service import conversation_cache
+from common.services.openai_error_handler import (
+    classify_openai_error,
+    get_user_message,
+    is_retryable,
+    ErrorCategory,
+)
+import openai
 
 settings = get_settings()
 _is_dev = settings.environment != "production"
@@ -527,6 +534,16 @@ class ChatHandler:
 
                                 logger.info(f"[MULTI_MENTION] Persona {p_name} streamed {token_count} tokens, {len(full_response_multi)} chars")
 
+                            except (openai.APIError, openai.APIConnectionError) as e:
+                                category = classify_openai_error(e)
+                                logger.error(
+                                    "[OPENAI_ERROR] Multi-mention streaming error for %s (category=%s): %s",
+                                    p_name, category.value, e, exc_info=True,
+                                )
+                                error_msg = get_user_message(e)
+                                for char in error_msg:
+                                    full_response_multi += char
+                                    yield f"data: {json.dumps({'content': char, 'done': False, 'persona_name': p_name, 'persona_id': str(p_db_id) if p_db_id else None})}\n\n"
                             except Exception as e:
                                 logger.error(f"[MULTI_MENTION] Error streaming persona {p_name}: {e}", exc_info=True)
                                 error_msg = "I'm sorry, I'm having trouble processing that right now."
@@ -789,12 +806,25 @@ class ChatHandler:
                                             
                                             # CRITICAL: Return early for single @mention (matching @all behavior)
                                             return
+                                        except (openai.APIError, openai.APIConnectionError) as e:
+                                            category = classify_openai_error(e)
+                                            ai_response = get_user_message(e)
+                                            logger.error(
+                                                "[OPENAI_ERROR] Persona chat error for %s "
+                                                "(persona_id=%s, category=%s, retryable=%s): %s",
+                                                persona_name, persona_id,
+                                                category.value, is_retryable(category), e,
+                                                exc_info=True,
+                                            )
+                                            for char in ai_response:
+                                                full_response += char
+                                                yield f"data: {json.dumps({'content': char, 'done': False, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None})}\n\n"
+                                                await asyncio.sleep(0.03)
                                         except Exception as e:
                                             import traceback
-                                            error_msg = str(e)
                                             logger.error(
                                                 f"[PERSONA_CHAT] Error in persona chat for {persona_name} "
-                                                f"(persona_id={persona_id}), user_progress_id={user_progress_id}: {error_msg}",
+                                                f"(persona_id={persona_id}), user_progress_id={user_progress_id}: {e}",
                                                 exc_info=True
                                             )
                                             if _is_dev:
@@ -810,26 +840,33 @@ class ChatHandler:
                                     full_response += char
                                     yield f"data: {json.dumps({'content': char, 'done': False, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None})}\n\n"
                                     await asyncio.sleep(0.03)
-                        except Exception as e:
-                            import traceback
-                            error_msg = str(e)
+                        except (openai.APIError, openai.APIConnectionError) as e:
+                            category = classify_openai_error(e)
                             persona_id_str = str(persona_simulation_id) if 'persona_simulation_id' in locals() else 'unknown'
-                            
-                            # persona_name and persona_id are already set before the try block
-                            # so they should be available here. If for some reason they're not set,
-                            # fall back to ChatOrchestrator
                             if not persona_name or persona_name == "ChatOrchestrator":
                                 persona_name = "ChatOrchestrator"
                                 persona_id = None
-                            
+                            logger.error(
+                                "[OPENAI_ERROR] Streaming persona error for %s "
+                                "(persona_id=%s, category=%s): %s",
+                                persona_name, persona_id_str,
+                                category.value, e, exc_info=True,
+                            )
+                            ai_response = get_user_message(e)
+                        except Exception as e:
+                            import traceback
+                            persona_id_str = str(persona_simulation_id) if 'persona_simulation_id' in locals() else 'unknown'
+                            if not persona_name or persona_name == "ChatOrchestrator":
+                                persona_name = "ChatOrchestrator"
+                                persona_id = None
                             logger.error(
                                 f"Error streaming persona response for persona {persona_id_str} "
-                                f"(persona_name={persona_name}, persona_id={persona_id}): {error_msg}",
+                                f"(persona_name={persona_name}, persona_id={persona_id}): {e}",
                                 exc_info=True
                             )
                             if _is_dev:
                                 traceback.print_exc()
-                            ai_response = f"I'm sorry, I'm having trouble processing that right now. Please try again or ask the orchestrator for help."
+                            ai_response = "I'm sorry, I'm having trouble processing that right now. Please try again or ask the orchestrator for help."
                             for char in ai_response:
                                 full_response += char
                                 yield f"data: {json.dumps({'content': char, 'done': False, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None})}\n\n"
@@ -1040,9 +1077,18 @@ class ChatHandler:
             # Send final metadata (only for orchestrator messages)
             yield f"data: {json.dumps({'done': True, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None, 'scene_completed': scene_completed, 'next_scene_id': next_scene_id, 'turn_count': orchestrator.state.turn_count, 'full_content': full_response})}\n\n"
             
+        except (openai.APIError, openai.APIConnectionError) as e:
+            category = classify_openai_error(e)
+            user_msg = get_user_message(e)
+            logger.error(
+                "[OPENAI_ERROR] Chat handler top-level error (category=%s): %s",
+                category.value, e, exc_info=True,
+            )
+            yield f"data: {json.dumps({'error': user_msg, 'error_category': category.value, 'retryable': is_retryable(category)})}\n\n"
         except Exception as e:
             # Note: Rollback handled by service layer
+            logger.error("[CHAT_HANDLER] Unexpected error: %s", e, exc_info=True)
             if _is_dev:
                 import traceback
                 traceback.print_exc()
-            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            yield f"data: {json.dumps({'error': 'An unexpected error occurred. Please try again.'})}\n\n"

--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -14,6 +14,12 @@ from app.dependencies import get_current_user
 from common.db.models import User
 from modules.simulation.service import SimulationService
 from common.exceptions import NotFoundError, ForbiddenError
+from common.services.openai_error_handler import (
+    classify_openai_error,
+    get_user_message,
+    is_retryable,
+)
+import openai
 from modules.simulation.schemas.dto import (
     SimulationStartRequest, SimulationStartResponse,
     SimulationChatRequest, SimulationChatResponse,
@@ -145,6 +151,17 @@ async def linear_chat_stream(
                     f"user_id={current_user.id}, user_progress_id={request.user_progress_id}"
                 )
                 yield f"data: {json.dumps({'error': 'Streaming requires ChatOrchestrator implementation'})}\n\n"
+            except (openai.APIError, openai.APIConnectionError) as e:
+                category = classify_openai_error(e)
+                user_msg = get_user_message(e)
+                logger.error(
+                    "[OPENAI_ERROR] Streaming failed (category=%s): session_id=%s, "
+                    "user_id=%s, user_progress_id=%s, scene_id=%s",
+                    category.value, session_id, current_user.id,
+                    request.user_progress_id, request.scene_id,
+                    exc_info=True,
+                )
+                yield f"data: {json.dumps({'error': user_msg, 'error_category': category.value, 'retryable': is_retryable(category)})}\n\n"
             except Exception as e:
                 logger.exception(
                     f"[SIMULATION_ROUTER] Streaming chat message failed: session_id={session_id}, "
@@ -152,7 +169,7 @@ async def linear_chat_stream(
                     f"scene_id={request.scene_id}",
                     exc_info=True
                 )
-                yield f"data: {json.dumps({'error': 'Internal server error'})}\n\n"
+                yield f"data: {json.dumps({'error': 'An unexpected error occurred. Please try again.'})}\n\n"
         
         return StreamingResponse(
             generate_stream(), 

--- a/backend/tests/modules/simulation/test_openai_error_handler.py
+++ b/backend/tests/modules/simulation/test_openai_error_handler.py
@@ -201,6 +201,18 @@ class TestGetRetryDelay:
         d = _get_retry_delay(err, 0, max_delay=30.0)
         assert d == 30.0
 
+    def test_retry_after_header_on_generic_429_status_error(self):
+        """A 429 APIStatusError (not RateLimitError) should also honor Retry-After."""
+        resp = _make_response(429)
+        resp.headers["retry-after"] = "7"
+        err = openai.APIStatusError(
+            message="Rate limited",
+            response=resp,
+            body={"error": {"message": "Rate limited"}},
+        )
+        d = _get_retry_delay(err, 0)
+        assert d == 7.0
+
 
 # === with_retries Tests ===
 

--- a/backend/tests/modules/simulation/test_openai_error_handler.py
+++ b/backend/tests/modules/simulation/test_openai_error_handler.py
@@ -1,0 +1,341 @@
+"""
+Tests for OpenAI error handling and retry logic.
+
+Covers:
+- Error classification (rate limit, auth, transient, invalid request, internal)
+- User-facing message sanitization (no implementation details leaked)
+- Retry logic with exponential backoff
+- Retry-After header respect for rate limiting
+- Stream retry (only before first token)
+- Non-retryable errors fail immediately
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch
+
+import openai
+from httpx import Response, Request
+
+from common.services.openai_error_handler import (
+    ErrorCategory,
+    classify_openai_error,
+    get_user_message,
+    is_retryable,
+    with_retries,
+    stream_with_retries,
+    _get_retry_delay,
+    USER_MESSAGES,
+    MAX_RETRIES,
+    BASE_DELAY_SECONDS,
+)
+
+
+# --- Helpers to create OpenAI error instances ---
+
+def _make_request():
+    return Request("POST", "https://api.openai.com/v1/chat/completions")
+
+
+def _make_response(status_code: int, body: str = '{"error": {"message": "test"}}'):
+    return Response(status_code=status_code, request=_make_request(), text=body)
+
+
+def _rate_limit_error(retry_after: str = None):
+    resp = _make_response(429)
+    if retry_after:
+        resp.headers["retry-after"] = retry_after
+    return openai.RateLimitError(
+        message="Rate limit exceeded",
+        response=resp,
+        body={"error": {"message": "Rate limit exceeded"}},
+    )
+
+
+def _auth_error():
+    return openai.AuthenticationError(
+        message="Invalid API key",
+        response=_make_response(401),
+        body={"error": {"message": "Invalid API key"}},
+    )
+
+
+def _api_status_error(status_code: int):
+    return openai.APIStatusError(
+        message=f"Error {status_code}",
+        response=_make_response(status_code),
+        body={"error": {"message": f"Error {status_code}"}},
+    )
+
+
+def _connection_error():
+    return openai.APIConnectionError(request=_make_request())
+
+
+def _generic_api_error():
+    return openai.APIError(
+        message="Unknown API error",
+        request=_make_request(),
+        body=None,
+    )
+
+
+# === Error Classification Tests ===
+
+
+class TestClassifyOpenaiError:
+    """Error classification correctly maps OpenAI exceptions to categories."""
+
+    def test_rate_limit_error(self):
+        assert classify_openai_error(_rate_limit_error()) == ErrorCategory.RATE_LIMITED
+
+    def test_auth_error(self):
+        assert classify_openai_error(_auth_error()) == ErrorCategory.AUTH_ERROR
+
+    def test_connection_error(self):
+        assert classify_openai_error(_connection_error()) == ErrorCategory.TRANSIENT
+
+    def test_502_gateway_error(self):
+        assert classify_openai_error(_api_status_error(502)) == ErrorCategory.TRANSIENT
+
+    def test_503_service_unavailable(self):
+        assert classify_openai_error(_api_status_error(503)) == ErrorCategory.TRANSIENT
+
+    def test_504_gateway_timeout(self):
+        assert classify_openai_error(_api_status_error(504)) == ErrorCategory.TRANSIENT
+
+    def test_429_via_status_error(self):
+        assert classify_openai_error(_api_status_error(429)) == ErrorCategory.RATE_LIMITED
+
+    def test_401_via_status_error(self):
+        assert classify_openai_error(_api_status_error(401)) == ErrorCategory.AUTH_ERROR
+
+    def test_400_bad_request(self):
+        assert classify_openai_error(_api_status_error(400)) == ErrorCategory.INVALID_REQUEST
+
+    def test_generic_api_error(self):
+        assert classify_openai_error(_generic_api_error()) == ErrorCategory.TRANSIENT
+
+    def test_non_openai_error(self):
+        assert classify_openai_error(ValueError("oops")) == ErrorCategory.INTERNAL
+
+
+# === Retryable Tests ===
+
+
+class TestIsRetryable:
+    def test_rate_limited_is_retryable(self):
+        assert is_retryable(ErrorCategory.RATE_LIMITED) is True
+
+    def test_transient_is_retryable(self):
+        assert is_retryable(ErrorCategory.TRANSIENT) is True
+
+    def test_auth_error_not_retryable(self):
+        assert is_retryable(ErrorCategory.AUTH_ERROR) is False
+
+    def test_invalid_request_not_retryable(self):
+        assert is_retryable(ErrorCategory.INVALID_REQUEST) is False
+
+    def test_internal_not_retryable(self):
+        assert is_retryable(ErrorCategory.INTERNAL) is False
+
+
+# === User Message Tests ===
+
+
+class TestGetUserMessage:
+    """User-facing messages should not leak implementation details."""
+
+    def test_rate_limit_message(self):
+        msg = get_user_message(_rate_limit_error())
+        assert msg == USER_MESSAGES[ErrorCategory.RATE_LIMITED]
+        assert "api" not in msg.lower() or "ai service" in msg.lower()
+        assert "openai" not in msg.lower()
+
+    def test_auth_error_message(self):
+        msg = get_user_message(_auth_error())
+        assert msg == USER_MESSAGES[ErrorCategory.AUTH_ERROR]
+        assert "api key" not in msg.lower()
+        assert "openai" not in msg.lower()
+
+    def test_transient_error_message(self):
+        msg = get_user_message(_connection_error())
+        assert msg == USER_MESSAGES[ErrorCategory.TRANSIENT]
+        assert "openai" not in msg.lower()
+
+    def test_invalid_request_message(self):
+        msg = get_user_message(_api_status_error(400))
+        assert msg == USER_MESSAGES[ErrorCategory.INVALID_REQUEST]
+
+    def test_internal_error_message(self):
+        msg = get_user_message(ValueError("internal details"))
+        assert msg == USER_MESSAGES[ErrorCategory.INTERNAL]
+        assert "internal details" not in msg
+
+
+# === Retry Delay Tests ===
+
+
+class TestGetRetryDelay:
+    def test_exponential_backoff(self):
+        err = _connection_error()
+        d0 = _get_retry_delay(err, 0)
+        d1 = _get_retry_delay(err, 1)
+        d2 = _get_retry_delay(err, 2)
+        assert d0 == BASE_DELAY_SECONDS * 1
+        assert d1 == BASE_DELAY_SECONDS * 2
+        assert d2 == BASE_DELAY_SECONDS * 4
+
+    def test_max_delay_cap(self):
+        err = _connection_error()
+        d = _get_retry_delay(err, 100, max_delay=10.0)
+        assert d == 10.0
+
+    def test_retry_after_header(self):
+        err = _rate_limit_error(retry_after="5")
+        d = _get_retry_delay(err, 0)
+        assert d == 5.0
+
+    def test_retry_after_capped_by_max_delay(self):
+        err = _rate_limit_error(retry_after="999")
+        d = _get_retry_delay(err, 0, max_delay=30.0)
+        assert d == 30.0
+
+
+# === with_retries Tests ===
+
+
+class TestWithRetries:
+    @pytest.mark.asyncio
+    async def test_success_on_first_try(self):
+        call_count = 0
+
+        async def succeed():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        result = await with_retries(succeed, max_retries=3, context="test")
+        assert result == "ok"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_then_succeeds(self):
+        call_count = 0
+
+        async def fail_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise _connection_error()
+            return "ok"
+
+        async def instant_sleep(delay):
+            pass
+
+        with patch("common.services.openai_error_handler.asyncio.sleep", side_effect=instant_sleep):
+            result = await with_retries(fail_then_succeed, max_retries=3, context="test")
+        assert result == "ok"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_fails_immediately(self):
+        call_count = 0
+
+        async def auth_fail():
+            nonlocal call_count
+            call_count += 1
+            raise _auth_error()
+
+        with pytest.raises(openai.AuthenticationError):
+            await with_retries(auth_fail, max_retries=3, context="test")
+        assert call_count == 1  # No retries for auth errors
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_raises(self):
+        call_count = 0
+
+        async def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise _connection_error()
+
+        async def instant_sleep(delay):
+            pass
+
+        with patch("common.services.openai_error_handler.asyncio.sleep", side_effect=instant_sleep):
+            with pytest.raises(openai.APIConnectionError):
+                await with_retries(always_fail, max_retries=2, context="test")
+        assert call_count == 3  # Initial + 2 retries
+
+
+# === stream_with_retries Tests ===
+
+
+class TestStreamWithRetries:
+    @pytest.mark.asyncio
+    async def test_stream_success(self):
+        async def gen():
+            yield "a"
+            yield "b"
+            yield "c"
+
+        tokens = []
+        async for token in stream_with_retries(gen, max_retries=3, context="test"):
+            tokens.append(token)
+        assert tokens == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_stream_retries_before_first_token(self):
+        call_count = 0
+
+        async def fail_then_stream():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise _connection_error()
+            yield "token1"
+            yield "token2"
+
+        async def instant_sleep(delay):
+            pass
+
+        tokens = []
+        with patch("common.services.openai_error_handler.asyncio.sleep", side_effect=instant_sleep):
+            async for token in stream_with_retries(fail_then_stream, max_retries=3, context="test"):
+                tokens.append(token)
+        assert tokens == ["token1", "token2"]
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_no_retry_after_first_token(self):
+        """If error occurs after tokens were yielded, don't retry (data already sent)."""
+        call_count = 0
+
+        async def fail_mid_stream():
+            nonlocal call_count
+            call_count += 1
+            yield "token1"
+            raise _connection_error()
+
+        tokens = []
+        with pytest.raises(openai.APIConnectionError):
+            async for token in stream_with_retries(fail_mid_stream, max_retries=3, context="test"):
+                tokens.append(token)
+        assert tokens == ["token1"]
+        assert call_count == 1  # No retry
+
+    @pytest.mark.asyncio
+    async def test_stream_non_retryable_fails_immediately(self):
+        call_count = 0
+
+        async def auth_fail_stream():
+            nonlocal call_count
+            call_count += 1
+            raise _auth_error()
+            yield  # Make it a generator
+
+        with pytest.raises(openai.AuthenticationError):
+            async for _ in stream_with_retries(auth_fail_stream, max_retries=3, context="test"):
+                pass
+        assert call_count == 1


### PR DESCRIPTION
## Summary
- Add structured OpenAI API error handling with retry logic for transient failures (502, 429, connection errors)
- Sanitize all error messages to prevent leaking implementation details to users
- Return classified error types (`error_category`, `retryable`) in SSE payloads for frontend consumption

Fixes #350

## Changes
- **New: `backend/common/services/openai_error_handler.py`** — Error classification (rate_limited, auth_error, transient, invalid_request, internal), exponential backoff with Retry-After header support, `with_retries()` and `stream_with_retries()` utilities, sanitized user-facing messages
- **`backend/modules/simulation/agents/persona_agent.py`** — Retry loop around `agent_executor.ainvoke()` and `astream_events()` for transient OpenAI errors; streaming only retries before first token is yielded; OpenAI-specific exception handlers with classified logging
- **`backend/modules/simulation/handlers/chat_handler.py`** — OpenAI-specific error handlers at all 4 catch points (inner persona, outer persona, multi-mention, top-level); returns user-friendly messages instead of raw `str(e)`
- **`backend/modules/simulation/router.py`** — OpenAI error handler in `/linear-chat-stream` with `error_category` and `retryable` fields in error SSE payloads

## Tests added
- 33 unit tests in `backend/tests/modules/simulation/test_openai_error_handler.py`:
  - Error classification for all OpenAI error types (RateLimitError, AuthenticationError, APIConnectionError, APIStatusError 4xx/5xx)
  - Retryable vs non-retryable classification
  - User message sanitization (no OpenAI/API key leaks)
  - Exponential backoff calculation and max delay cap
  - Retry-After header respect
  - `with_retries()`: success, transient retry+succeed, non-retryable immediate fail, retry exhaustion
  - `stream_with_retries()`: success, pre-token retry, no retry after first token, non-retryable immediate fail

## Test plan
- [x] Unit tests pass (33/33)
- [ ] Manual verification: trigger 429/502 from OpenAI and observe retry + user-friendly message
- [ ] Verify SSE error payloads include `error_category` and `retryable` fields

Generated by Ralph Loop iteration 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and retry logic for API calls, automatically retrying transient failures with exponential backoff.
  * Improved user-facing error messages that provide clearer feedback without exposing technical details.
  * Added error categorization (rate limiting, authentication, transient, invalid request, internal) for better diagnostics.

* **Tests**
  * Added comprehensive test coverage for error classification and retry mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->