### PR TITLE
fix: increase grading LLM max_tokens to 4096 and allow retry on failure

### DIFF
--- a/backend/common/services/simulation_helper/langchain_service.py
+++ b/backend/common/services/simulation_helper/langchain_service.py
@@ -117,6 +117,21 @@ class LangChainManager:
             max_tokens=1000,
             streaming=True
         )
+
+    def get_grading_llm(self) -> ChatOpenAI:
+        """Create an LLM instance configured for grading with higher token limit.
+
+        Grading requires structured JSON output (rubric scores, feedback per criterion)
+        which can exceed the default 1000 token limit, causing JSON truncation failures.
+        Streaming is disabled since grading uses structured output parsing.
+        """
+        return ChatOpenAI(
+            model=settings.openai_model,
+            api_key=settings.openai_api_key,
+            temperature=0.7,
+            max_tokens=4096,
+            streaming=False
+        )
     
     @property
     def embeddings(self):

--- a/backend/modules/simulation/agents/grading_agent.py
+++ b/backend/modules/simulation/agents/grading_agent.py
@@ -54,7 +54,7 @@ class GradingAgent:
     """LangChain-based grading agent using structured output for reliable score extraction"""
 
     def __init__(self):
-        self.llm = langchain_manager.llm
+        self.llm = langchain_manager.get_grading_llm()
 
         # Create structured output LLMs for grading
         # These return Pydantic models directly - no parsing needed

--- a/backend/tests/test_grading_llm.py
+++ b/backend/tests/test_grading_llm.py
@@ -1,0 +1,92 @@
+"""
+Tests for grading LLM configuration and GradingAgent initialization.
+
+Verifies that:
+1. get_grading_llm() returns an LLM with max_tokens=4096 (prevents JSON truncation)
+2. get_grading_llm() disables streaming (required for structured output parsing)
+3. GradingAgent uses the grading LLM, not the default 1000-token LLM
+4. Default LLM remains unchanged at 1000 tokens
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestGradingLLMConfiguration:
+    """Tests for the dedicated grading LLM in langchain_service."""
+
+    def test_grading_llm_has_4096_max_tokens(self):
+        """get_grading_llm() must return an LLM with max_tokens=4096 to prevent JSON truncation."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        llm = langchain_manager.get_grading_llm()
+        assert llm.max_tokens == 4096
+
+    def test_grading_llm_streaming_disabled(self):
+        """Grading LLM should have streaming=False for structured output parsing."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        llm = langchain_manager.get_grading_llm()
+        assert llm.streaming is False
+
+    def test_default_llm_unchanged_at_1000_tokens(self):
+        """Default LLM must remain at 1000 tokens for cost-efficient conversation use."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        llm = langchain_manager.llm
+        assert llm.max_tokens == 1000
+
+    def test_default_llm_streaming_enabled(self):
+        """Default LLM should still have streaming enabled."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        llm = langchain_manager.llm
+        assert llm.streaming is True
+
+    def test_grading_llm_uses_same_model_as_default(self):
+        """Grading LLM should use the same model as the default LLM."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        default_llm = langchain_manager.llm
+        grading_llm = langchain_manager.get_grading_llm()
+        assert grading_llm.model_name == default_llm.model_name
+
+    def test_grading_llm_creates_fresh_instance(self):
+        """Each call to get_grading_llm() should return a new instance."""
+        from common.services.simulation_helper.langchain_service import langchain_manager
+
+        llm1 = langchain_manager.get_grading_llm()
+        llm2 = langchain_manager.get_grading_llm()
+        assert llm1 is not llm2
+
+
+class TestGradingAgentInit:
+    """Tests that GradingAgent uses the grading-specific LLM."""
+
+    @patch("modules.simulation.agents.grading_agent.langchain_manager")
+    def test_grading_agent_uses_grading_llm(self, mock_manager):
+        """GradingAgent.__init__ must call get_grading_llm(), not .llm property."""
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value = MagicMock()
+        mock_manager.get_grading_llm.return_value = mock_llm
+
+        from modules.simulation.agents.grading_agent import GradingAgent
+        agent = GradingAgent()
+
+        mock_manager.get_grading_llm.assert_called_once()
+        assert agent.llm is mock_llm
+
+    @patch("modules.simulation.agents.grading_agent.langchain_manager")
+    def test_grading_agent_creates_structured_output_chains(self, mock_manager):
+        """GradingAgent should create both scene_grader and overall_grader chains."""
+        mock_llm = MagicMock()
+        mock_scene_grader = MagicMock()
+        mock_overall_grader = MagicMock()
+        mock_llm.with_structured_output.side_effect = [mock_scene_grader, mock_overall_grader]
+        mock_manager.get_grading_llm.return_value = mock_llm
+
+        from modules.simulation.agents.grading_agent import GradingAgent
+        agent = GradingAgent()
+
+        assert mock_llm.with_structured_output.call_count == 2
+        assert agent.scene_grader is mock_scene_grader
+        assert agent.overall_grader is mock_overall_grader

--- a/frontend/app/student/run-simulation/[instanceId]/page.tsx
+++ b/frontend/app/student/run-simulation/[instanceId]/page.tsx
@@ -2628,14 +2628,12 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
           }
       } else {
         setInputBlocked(false)
-        setCanSubmitForGrading(false)
         setHasSubmittedForGrading(false)
       }
     } catch (error) {
       setInputBlocked(false)
-      setCanSubmitForGrading(false)
       setHasSubmittedForGrading(false)
-      alert('Failed to submit for grading.')
+      alert('Failed to submit for grading. Please try again.')
     }
   }
 

--- a/frontend/e2e/grading-retry.spec.ts
+++ b/frontend/e2e/grading-retry.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E tests for grading submission retry behavior (issue #346).
+ *
+ * Verifies that when grading fails (network error or scene-not-completed),
+ * the "Submit for Grading" button remains visible so students can retry.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Grading submission retry', () => {
+  const SIM_URL = '/student/run-simulation/test-instance-123'
+
+  test.describe('Submit for Grading button stays visible after failure', () => {
+    test('button remains after network error on grading submission', async ({ page }) => {
+      // Intercept the simulation data load
+      await page.route('**/api/simulation/instance/**', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            user_progress_id: 1,
+            current_scene: { id: 1, scene_order: 1, title: 'Test Scene', description: 'Test' },
+            simulation: { id: 1, title: 'Test Sim' },
+            simulation_status: 'in_progress',
+            scenes: [{ id: 1, scene_order: 1, title: 'Test Scene' }]
+          })
+        })
+      )
+
+      // Make the grading submission fail with network error
+      await page.route('**/api/simulation/linear-chat', route =>
+        route.abort('connectionrefused')
+      )
+
+      await page.goto(SIM_URL)
+
+      // Look for the submit for grading button
+      const submitButton = page.locator('button', { hasText: /submit for grading/i })
+
+      // If the button exists and we click it, after failure it should still be visible
+      if (await submitButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await submitButton.click()
+
+        // After the error, button should remain visible for retry
+        await expect(submitButton).toBeVisible({ timeout: 5000 })
+      }
+    })
+
+    test('button remains after scene_completed=false response', async ({ page }) => {
+      await page.route('**/api/simulation/instance/**', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            user_progress_id: 1,
+            current_scene: { id: 1, scene_order: 1, title: 'Test Scene', description: 'Test' },
+            simulation: { id: 1, title: 'Test Sim' },
+            simulation_status: 'in_progress',
+            scenes: [{ id: 1, scene_order: 1, title: 'Test Scene' }]
+          })
+        })
+      )
+
+      // Return scene_completed=false (grading didn't proceed)
+      await page.route('**/api/simulation/linear-chat', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ scene_completed: false })
+        })
+      )
+
+      await page.goto(SIM_URL)
+
+      const submitButton = page.locator('button', { hasText: /submit for grading/i })
+
+      if (await submitButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await submitButton.click()
+
+        // Button should remain visible since canSubmitForGrading stays true
+        await expect(submitButton).toBeVisible({ timeout: 5000 })
+      }
+    })
+  })
+})

--- a/frontend/e2e/grading-retry.spec.ts
+++ b/frontend/e2e/grading-retry.spec.ts
@@ -10,76 +10,100 @@ import { test, expect } from '@playwright/test'
 test.describe('Grading submission retry', () => {
   const SIM_URL = '/student/run-simulation/test-instance-123'
 
+  /** Mock the start-simulation endpoint with a valid response that renders the UI. */
+  async function mockStartSimulation(page: import('@playwright/test').Page) {
+    await page.route('**/student-simulation-instances/**/start-simulation', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user_progress_id: 1,
+          instance_id: 123,
+          current_scene: {
+            id: 1,
+            scene_order: 1,
+            title: 'Test Scene',
+            description: 'Test',
+            personas: []
+          },
+          simulation: { id: 1, title: 'Test Sim', total_scenes: 1 },
+          simulation_status: 'in_progress',
+          is_resuming: true,
+          turn_count: 1,
+          conversation_history: [
+            {
+              id: 1,
+              sender: 'System',
+              text: 'Welcome to the simulation.',
+              timestamp: new Date().toISOString(),
+              type: 'system'
+            }
+          ],
+          all_scenes: [
+            { id: 1, scene_order: 1, title: 'Test Scene', personas: [] }
+          ]
+        })
+      })
+    )
+  }
+
   test.describe('Submit for Grading button stays visible after failure', () => {
     test('button remains after network error on grading submission', async ({ page }) => {
-      // Intercept the simulation data load
-      await page.route('**/api/simulation/instance/**', route =>
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            user_progress_id: 1,
-            current_scene: { id: 1, scene_order: 1, title: 'Test Scene', description: 'Test' },
-            simulation: { id: 1, title: 'Test Sim' },
-            simulation_status: 'in_progress',
-            scenes: [{ id: 1, scene_order: 1, title: 'Test Scene' }]
-          })
-        })
-      )
+      await mockStartSimulation(page)
 
-      // Make the grading submission fail with network error
-      await page.route('**/api/simulation/linear-chat', route =>
-        route.abort('connectionrefused')
-      )
+      // Track how many times the grading endpoint is called
+      let gradingCallCount = 0
+      await page.route('**/api/simulation/linear-chat', route => {
+        gradingCallCount++
+        return route.abort('connectionrefused')
+      })
 
       await page.goto(SIM_URL)
 
-      // Look for the submit for grading button
-      const submitButton = page.locator('button', { hasText: /submit for grading/i })
+      const submitButton = page.getByRole('button', { name: /submit for grading/i })
+      await expect(submitButton).toBeVisible({ timeout: 10000 })
 
-      // If the button exists and we click it, after failure it should still be visible
-      if (await submitButton.isVisible({ timeout: 5000 }).catch(() => false)) {
-        await submitButton.click()
+      // First attempt — should fail with network error
+      await submitButton.click()
 
-        // After the error, button should remain visible for retry
-        await expect(submitButton).toBeVisible({ timeout: 5000 })
-      }
+      // Button must remain visible for retry after the error
+      await expect(submitButton).toBeVisible({ timeout: 5000 })
+      expect(gradingCallCount).toBeGreaterThanOrEqual(1)
+
+      // Second attempt — proves retry is possible
+      await submitButton.click()
+      await expect(submitButton).toBeVisible({ timeout: 5000 })
+      expect(gradingCallCount).toBeGreaterThanOrEqual(2)
     })
 
     test('button remains after scene_completed=false response', async ({ page }) => {
-      await page.route('**/api/simulation/instance/**', route =>
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            user_progress_id: 1,
-            current_scene: { id: 1, scene_order: 1, title: 'Test Scene', description: 'Test' },
-            simulation: { id: 1, title: 'Test Sim' },
-            simulation_status: 'in_progress',
-            scenes: [{ id: 1, scene_order: 1, title: 'Test Scene' }]
-          })
-        })
-      )
+      await mockStartSimulation(page)
 
-      // Return scene_completed=false (grading didn't proceed)
-      await page.route('**/api/simulation/linear-chat', route =>
-        route.fulfill({
+      let gradingCallCount = 0
+      await page.route('**/api/simulation/linear-chat', route => {
+        gradingCallCount++
+        return route.fulfill({
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify({ scene_completed: false })
         })
-      )
+      })
 
       await page.goto(SIM_URL)
 
-      const submitButton = page.locator('button', { hasText: /submit for grading/i })
+      const submitButton = page.getByRole('button', { name: /submit for grading/i })
+      await expect(submitButton).toBeVisible({ timeout: 10000 })
 
-      if (await submitButton.isVisible({ timeout: 5000 }).catch(() => false)) {
-        await submitButton.click()
+      await submitButton.click()
 
-        // Button should remain visible since canSubmitForGrading stays true
-        await expect(submitButton).toBeVisible({ timeout: 5000 })
-      }
+      // Button should remain visible since scene was not completed
+      await expect(submitButton).toBeVisible({ timeout: 5000 })
+      expect(gradingCallCount).toBeGreaterThanOrEqual(1)
+
+      // Retry is possible
+      await submitButton.click()
+      await expect(submitButton).toBeVisible({ timeout: 5000 })
+      expect(gradingCallCount).toBeGreaterThanOrEqual(2)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Added dedicated `get_grading_llm()` method with `max_tokens=4096` and `streaming=False` to prevent JSON truncation during structured output parsing
- Updated `GradingAgent` to use the new grading-specific LLM for both scene and overall grading chains
- Fixed frontend to preserve `canSubmitForGrading=true` on error/scene-not-completed paths, keeping the retry button visible

Fixes #346

## Changes
- `backend/common/services/simulation_helper/langchain_service.py`: Added `get_grading_llm()` method returning ChatOpenAI with max_tokens=4096, streaming=False
- `backend/modules/simulation/agents/grading_agent.py`: Changed `__init__` to use `langchain_manager.get_grading_llm()` instead of `.llm`
- `frontend/app/student/run-simulation/[instanceId]/page.tsx`: Removed `setCanSubmitForGrading(false)` from catch block and scene-not-completed else branch

## Tests added
- Unit: `get_grading_llm()` returns max_tokens=4096, streaming=False
- Unit: Default LLM unchanged (max_tokens=1000, streaming=True)
- Unit: GradingAgent calls `get_grading_llm()` and creates both structured output chains
- E2E: Submit for Grading button stays visible after network error
- E2E: Submit for Grading button stays visible after scene_completed=false response

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass
- [ ] Manual: trigger grading on a simulation → verify grading completes without JSON truncation
- [ ] Manual: disconnect network during grading → verify retry button remains visible

Generated by Ralph Loop iteration 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded grading backend to handle larger structured outputs for more robust grading results.
* **Bug Fixes**
  * Grading submission is more resilient: the "Submit for Grading" button remains visible and clickable after failures.
  * Improved error message on grading submission failures: "Failed to submit for grading. Please try again."
* **Tests**
  * Added unit and end-to-end tests to verify grading retry behavior and grading configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->