### PR TITLE
fix: add confirmation dialog to Submit for Grading button

### DIFF
--- a/frontend/app/professor/test-simulations/page.tsx
+++ b/frontend/app/professor/test-simulations/page.tsx
@@ -10,6 +10,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
   Send,
   Users,
   Target,
@@ -1651,6 +1661,7 @@ export default function LinearSimulationChat() {
   // Add state for submit button
   const [canSubmitForGrading, setCanSubmitForGrading] = useState(false);
   const [hasSubmittedForGrading, setHasSubmittedForGrading] = useState(false);
+  const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
   // Add state to track if grading has been shown
   const [gradingHasBeenShown, setGradingHasBeenShown] = useState(false);
   const [simulationComplete, setSimulationComplete] = useState(false);
@@ -3090,7 +3101,7 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
                 {(canSubmitForGrading || (inputBlocked && !simulationComplete)) && !simulationComplete ? (
                   <div className="mt-2 flex-shrink-0 animate-fade-in-up stagger-4">
                     <Button
-                      onClick={handleSubmitForGrading}
+                      onClick={() => setShowSubmitConfirm(true)}
                       disabled={inputBlocked || hasSubmittedForGrading}
                       className="btn-gradient-green w-full text-white text-sm font-semibold relative overflow-hidden shadow-md hover:shadow-lg transition-all"
                     >
@@ -3623,6 +3634,32 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
           personaCount={simulationData.current_scene.personas.length}
         />
       </div>
+
+      <AlertDialog open={showSubmitConfirm} onOpenChange={setShowSubmitConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Submit for Grading?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {(() => {
+                const timeoutTurns = simulationData?.current_scene?.timeout_turns ?? 15
+                const remaining = Math.max(0, timeoutTurns - turnCount)
+                return remaining > 0
+                  ? `You have ${remaining} turn${remaining === 1 ? '' : 's'} remaining. Submitting now will end your simulation and you will not be able to continue. This action cannot be undone.`
+                  : 'This will end your simulation and submit it for grading. This action cannot be undone.'
+              })()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleSubmitForGrading}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
+              Yes, Submit for Grading
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
-} 
+}

--- a/frontend/app/student/run-simulation/[instanceId]/page.tsx
+++ b/frontend/app/student/run-simulation/[instanceId]/page.tsx
@@ -8,6 +8,16 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import {
   Send,
@@ -1313,6 +1323,7 @@ export default function StudentSimulationChat() {
   const [gradingData, setGradingData] = useState<any>(null)
   const [canSubmitForGrading, setCanSubmitForGrading] = useState(false)
   const [hasSubmittedForGrading, setHasSubmittedForGrading] = useState(false)
+  const [showSubmitConfirm, setShowSubmitConfirm] = useState(false)
   const [gradingHasBeenShown, setGradingHasBeenShown] = useState(false)
   const [simulationComplete, setSimulationComplete] = useState(false)
   const [gradingInProgress, setGradingInProgress] = useState(false)
@@ -3267,7 +3278,7 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
                       <div className="flex items-center gap-1.5">
                         {(canSubmitForGrading || hasSubmittedForGrading) && (
                           <button
-                            onClick={handleSubmitForGrading}
+                            onClick={() => setShowSubmitConfirm(true)}
                             disabled={inputBlocked || hasSubmittedForGrading || isLoading || isTyping}
                             className="flex items-center gap-1.5 h-8 px-3 rounded-lg bg-emerald-600 text-white text-xs font-semibold hover:bg-emerald-700 disabled:opacity-50 transition-colors"
                           >
@@ -3422,6 +3433,32 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
         maxTurns={simulationData.current_scene.timeout_turns || 15}
         personaCount={simulationData.current_scene.personas.length}
       />
+
+      <AlertDialog open={showSubmitConfirm} onOpenChange={setShowSubmitConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Submit for Grading?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {(() => {
+                const timeoutTurns = simulationData?.current_scene?.timeout_turns ?? 15
+                const remaining = Math.max(0, timeoutTurns - turnCount)
+                return remaining > 0
+                  ? `You have ${remaining} turn${remaining === 1 ? '' : 's'} remaining. Submitting now will end your simulation and you will not be able to continue. This action cannot be undone.`
+                  : 'This will end your simulation and submit it for grading. This action cannot be undone.'
+              })()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleSubmitForGrading}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
+              Yes, Submit for Grading
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {showRerunConfirmation && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in p-4">

--- a/frontend/e2e/submit-grading-confirmation.spec.ts
+++ b/frontend/e2e/submit-grading-confirmation.spec.ts
@@ -48,6 +48,7 @@ test.describe('Submit for Grading confirmation dialog', () => {
     )
   }
 
+  /** Verifies the submit button opens a confirmation dialog rather than submitting immediately. */
   test('clicking Submit for Grading shows confirmation dialog instead of submitting', async ({ page }) => {
     await mockStartSimulation(page, 3, 15)
 
@@ -85,6 +86,7 @@ test.describe('Submit for Grading confirmation dialog', () => {
     expect(gradingCalled).toBe(false)
   })
 
+  /** Verifies clicking Cancel in the dialog closes it without triggering grading. */
   test('cancelling the confirmation dialog does not submit', async ({ page }) => {
     await mockStartSimulation(page, 5, 15)
 
@@ -122,6 +124,7 @@ test.describe('Submit for Grading confirmation dialog', () => {
     await expect(submitButton).toBeEnabled()
   })
 
+  /** Verifies clicking the confirm button in the dialog triggers the grading API call. */
   test('confirming the dialog triggers actual grading submission', async ({ page }) => {
     await mockStartSimulation(page, 10, 15)
 
@@ -155,6 +158,7 @@ test.describe('Submit for Grading confirmation dialog', () => {
     expect(gradingCalled).toBe(true)
   })
 
+  /** Verifies the dialog displays the correct singular turn count when only 1 turn remains. */
   test('dialog shows correct remaining turns count', async ({ page }) => {
     // Student has used 14 of 15 turns — only 1 remaining
     await mockStartSimulation(page, 14, 15)
@@ -181,6 +185,7 @@ test.describe('Submit for Grading confirmation dialog', () => {
     await expect(dialog.getByText(/1 turn remaining/i)).toBeVisible()
   })
 
+  /** Verifies the dialog shows a generic message (no turn count) when all turns are used. */
   test('dialog shows generic message when no turns remain', async ({ page }) => {
     // Student has used all 15 turns
     await mockStartSimulation(page, 15, 15)
@@ -289,6 +294,7 @@ test.describe('Professor test-simulations confirmation dialog', () => {
     )
   }
 
+  /** Verifies the submit button opens a confirmation dialog on the professor test page. */
   test('clicking Submit for Grading shows confirmation dialog on professor page', async ({ page }) => {
     await mockProfessorSimulation(page, 3, 15)
 
@@ -323,6 +329,7 @@ test.describe('Professor test-simulations confirmation dialog', () => {
     expect(gradingCalled).toBe(false)
   })
 
+  /** Verifies clicking Cancel closes the dialog without triggering grading on professor page. */
   test('cancelling the confirmation dialog does not submit on professor page', async ({ page }) => {
     await mockProfessorSimulation(page, 5, 15)
 
@@ -353,6 +360,7 @@ test.describe('Professor test-simulations confirmation dialog', () => {
     await expect(submitButton).toBeEnabled()
   })
 
+  /** Verifies clicking confirm in the dialog triggers grading submission on professor page. */
   test('confirming the dialog triggers grading submission on professor page', async ({ page }) => {
     await mockProfessorSimulation(page, 10, 15)
 

--- a/frontend/e2e/submit-grading-confirmation.spec.ts
+++ b/frontend/e2e/submit-grading-confirmation.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * E2E tests for the "Submit for Grading" confirmation dialog (issue #355).
+ *
+ * Verifies that clicking "Submit for Grading" shows a confirmation dialog
+ * instead of immediately submitting, preventing accidental submissions.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Submit for Grading confirmation dialog', () => {
+  const SIM_URL = '/student/run-simulation/test-instance-123'
+
+  /** Mock the start-simulation endpoint with a response that enables the submit button. */
+  async function mockStartSimulation(page: import('@playwright/test').Page, turnCount = 3, timeoutTurns = 15) {
+    await page.route('**/student-simulation-instances/**/start-simulation', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user_progress_id: 1,
+          instance_id: 123,
+          current_scene: {
+            id: 1,
+            scene_order: 1,
+            title: 'Test Scene',
+            description: 'Test',
+            timeout_turns: timeoutTurns,
+            personas: []
+          },
+          simulation: { id: 1, title: 'Test Sim', total_scenes: 1 },
+          simulation_status: 'in_progress',
+          is_resuming: true,
+          turn_count: turnCount,
+          conversation_history: [
+            {
+              id: 1,
+              sender: 'System',
+              text: 'Welcome to the simulation.',
+              timestamp: new Date().toISOString(),
+              type: 'system'
+            }
+          ],
+          all_scenes: [
+            { id: 1, scene_order: 1, title: 'Test Scene', personas: [] }
+          ]
+        })
+      })
+    )
+  }
+
+  test('clicking Submit for Grading shows confirmation dialog instead of submitting', async ({ page }) => {
+    await mockStartSimulation(page, 3, 15)
+
+    // Ensure the grading endpoint is NOT called prematurely
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 10000 })
+
+    // Click the submit button — should show dialog, NOT submit
+    await submitButton.click()
+
+    // Confirmation dialog should appear
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Dialog should mention remaining turns
+    await expect(dialog.getByText(/12 turns remaining/i)).toBeVisible()
+
+    // Dialog should have cancel and confirm buttons
+    await expect(dialog.getByRole('button', { name: /cancel/i })).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /yes, submit for grading/i })).toBeVisible()
+
+    // Grading endpoint should NOT have been called yet
+    expect(gradingCalled).toBe(false)
+  })
+
+  test('cancelling the confirmation dialog does not submit', async ({ page }) => {
+    await mockStartSimulation(page, 5, 15)
+
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 10000 })
+
+    // Open dialog
+    await submitButton.click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Click cancel
+    await dialog.getByRole('button', { name: /cancel/i }).click()
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 3000 })
+
+    // Grading should NOT have been called
+    expect(gradingCalled).toBe(false)
+
+    // Submit button should still be visible and clickable
+    await expect(submitButton).toBeVisible()
+    await expect(submitButton).toBeEnabled()
+  })
+
+  test('confirming the dialog triggers actual grading submission', async ({ page }) => {
+    await mockStartSimulation(page, 10, 15)
+
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 10000 })
+
+    // Open dialog
+    await submitButton.click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Confirm submission
+    await dialog.getByRole('button', { name: /yes, submit for grading/i }).click()
+
+    // Grading endpoint should now be called
+    await page.waitForTimeout(1000)
+    expect(gradingCalled).toBe(true)
+  })
+
+  test('dialog shows correct remaining turns count', async ({ page }) => {
+    // Student has used 14 of 15 turns — only 1 remaining
+    await mockStartSimulation(page, 14, 15)
+
+    await page.route('**/api/simulation/linear-chat', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    )
+
+    await page.goto(SIM_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 10000 })
+
+    await submitButton.click()
+
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Should show "1 turn remaining" (singular)
+    await expect(dialog.getByText(/1 turn remaining/i)).toBeVisible()
+  })
+
+  test('dialog shows generic message when no turns remain', async ({ page }) => {
+    // Student has used all 15 turns
+    await mockStartSimulation(page, 15, 15)
+
+    await page.route('**/api/simulation/linear-chat', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    )
+
+    await page.goto(SIM_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 10000 })
+
+    await submitButton.click()
+
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Should show the generic "cannot be undone" message without turn count
+    await expect(dialog.getByText(/this will end your simulation/i)).toBeVisible()
+  })
+})

--- a/frontend/e2e/submit-grading-confirmation.spec.ts
+++ b/frontend/e2e/submit-grading-confirmation.spec.ts
@@ -5,13 +5,13 @@
  * instead of immediately submitting, preventing accidental submissions.
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
 test.describe('Submit for Grading confirmation dialog', () => {
   const SIM_URL = '/student/run-simulation/test-instance-123'
 
   /** Mock the start-simulation endpoint with a response that enables the submit button. */
-  async function mockStartSimulation(page: import('@playwright/test').Page, turnCount = 3, timeoutTurns = 15) {
+  async function mockStartSimulation(page: Page, turnCount = 3, timeoutTurns = 15) {
     await page.route('**/student-simulation-instances/**/start-simulation', route =>
       route.fulfill({
         status: 200,
@@ -148,8 +148,10 @@ test.describe('Submit for Grading confirmation dialog', () => {
     // Confirm submission
     await dialog.getByRole('button', { name: /yes, submit for grading/i }).click()
 
-    // Grading endpoint should now be called
-    await page.waitForTimeout(1000)
+    // Wait for the grading endpoint to be called
+    await page.waitForResponse(resp =>
+      resp.url().includes('/api/simulation/linear-chat') && resp.status() === 200
+    )
     expect(gradingCalled).toBe(true)
   })
 
@@ -203,5 +205,181 @@ test.describe('Submit for Grading confirmation dialog', () => {
 
     // Should show the generic "cannot be undone" message without turn count
     await expect(dialog.getByText(/this will end your simulation/i)).toBeVisible()
+  })
+})
+
+/**
+ * E2E tests for the professor test-simulations page confirmation dialog.
+ *
+ * Mirrors the student tests above to ensure the confirmation dialog also works
+ * on the professor's test-simulation route.
+ */
+test.describe('Professor test-simulations confirmation dialog', () => {
+  const PROF_URL = '/professor/test-simulations'
+
+  /** Mock auth, scenarios list, and start-simulation for the professor page. */
+  async function mockProfessorSimulation(page: Page, turnCount = 3, timeoutTurns = 15) {
+    // Mock auth endpoint so the page thinks the user is logged in as a professor
+    await page.route('**/api/auth/me', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 1,
+          email: 'professor@test.com',
+          full_name: 'Test Professor',
+          role: 'professor'
+        })
+      })
+    )
+
+    // Mock scenarios list with one valid scenario
+    await page.route('**/api/publishing/simulations/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 1,
+            title: 'Test Scenario',
+            status: 'active',
+            is_draft: false,
+            created_at: new Date().toISOString(),
+            personas: [{ id: 1, name: 'Persona 1' }],
+            scenes: [{ id: 1, scene_order: 1, title: 'Scene 1' }]
+          }
+        ])
+      })
+    )
+
+    // Mock start-simulation endpoint
+    await page.route('**/api/simulation/start', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user_progress_id: 1,
+          instance_id: 1,
+          current_scene: {
+            id: 1,
+            scene_order: 1,
+            title: 'Test Scene',
+            description: 'Test',
+            timeout_turns: timeoutTurns,
+            personas: [{ id: 1, name: 'Persona 1', image_url: null }]
+          },
+          simulation: { id: 1, title: 'Test Scenario', total_scenes: 1 },
+          simulation_status: 'in_progress',
+          is_resuming: true,
+          turn_count: turnCount,
+          conversation_history: [
+            {
+              id: 1,
+              sender: 'System',
+              text: 'Welcome to the simulation.',
+              timestamp: new Date().toISOString(),
+              type: 'system'
+            }
+          ],
+          all_scenes: [
+            { id: 1, scene_order: 1, title: 'Test Scene', personas: [{ id: 1, name: 'Persona 1', image_url: null }] }
+          ]
+        })
+      })
+    )
+  }
+
+  test('clicking Submit for Grading shows confirmation dialog on professor page', async ({ page }) => {
+    await mockProfessorSimulation(page, 3, 15)
+
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(PROF_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 15000 })
+
+    await submitButton.click()
+
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    // Dialog should mention remaining turns
+    await expect(dialog.getByText(/12 turns remaining/i)).toBeVisible()
+
+    // Dialog should have cancel and confirm buttons
+    await expect(dialog.getByRole('button', { name: /cancel/i })).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /yes, submit for grading/i })).toBeVisible()
+
+    // Grading endpoint should NOT have been called yet
+    expect(gradingCalled).toBe(false)
+  })
+
+  test('cancelling the confirmation dialog does not submit on professor page', async ({ page }) => {
+    await mockProfessorSimulation(page, 5, 15)
+
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(PROF_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 15000 })
+
+    await submitButton.click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    await dialog.getByRole('button', { name: /cancel/i }).click()
+
+    await expect(dialog).not.toBeVisible({ timeout: 3000 })
+    expect(gradingCalled).toBe(false)
+    await expect(submitButton).toBeVisible()
+    await expect(submitButton).toBeEnabled()
+  })
+
+  test('confirming the dialog triggers grading submission on professor page', async ({ page }) => {
+    await mockProfessorSimulation(page, 10, 15)
+
+    let gradingCalled = false
+    await page.route('**/api/simulation/linear-chat', route => {
+      gradingCalled = true
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ scene_completed: false })
+      })
+    })
+
+    await page.goto(PROF_URL)
+
+    const submitButton = page.getByRole('button', { name: /submit for grading/i })
+    await expect(submitButton).toBeVisible({ timeout: 15000 })
+
+    await submitButton.click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+
+    await dialog.getByRole('button', { name: /yes, submit for grading/i }).click()
+
+    await page.waitForResponse(resp =>
+      resp.url().includes('/api/simulation/linear-chat') && resp.status() === 200
+    )
+    expect(gradingCalled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Adds an AlertDialog confirmation step before submitting simulations for grading, preventing accidental submissions that irreversibly end the student's simulation

Fixes #355

## Changes
- **Student simulation** (`frontend/app/student/run-simulation/[instanceId]/page.tsx`): Button now opens a confirmation dialog showing remaining turns count instead of immediately calling `handleSubmitForGrading`
- **Professor test simulation** (`frontend/app/professor/test-simulations/page.tsx`): Same confirmation dialog added for consistency
- Uses existing shadcn/ui `AlertDialog` component — no new dependencies

## Tests added
- `frontend/e2e/submit-grading-confirmation.spec.ts` — 5 Playwright E2E tests:
  - Confirmation dialog appears on button click (grading NOT triggered prematurely)
  - Cancel closes dialog without submitting
  - Confirm triggers actual grading submission
  - Remaining turns displayed correctly (singular/plural)
  - Generic message when no turns remain

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass (requires dev server)
- [ ] Manual verification: click Submit for Grading → dialog appears → Cancel returns to sim → Confirm submits

Generated by Ralph Loop iteration 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when submitting work for grading across student and professor flows; shows remaining turns, adapts messaging, and requires explicit confirmation to proceed.

* **Tests**
  * Added end-to-end tests covering the submit-for-grading confirmation: dialog visibility, Cancel behavior, confirm behavior, and messaging for various remaining-turn scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->