### PR TITLE
fix: reduce excessive database polling from health checks and background tasks

### DIFF
--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -178,7 +178,7 @@ async def _redis_subscriber():
                 )
                 
                 if message is None:
-                    await asyncio.sleep(0.1)  # Small sleep to prevent tight loop
+                    await asyncio.sleep(1.0)  # Sleep between polls to reduce CPU usage
                     continue
                 
                 if message["type"] == "pmessage":
@@ -223,8 +223,8 @@ async def _redis_subscriber():
 async def _session_cleanup_task():
     """
     Background task to clean up expired agent sessions.
-    
-    Runs every 5 minutes to mark expired sessions as inactive.
+
+    Runs every 15 minutes to mark expired sessions as inactive.
     """
     from common.services.simulation_helper.session_manager import session_manager
     
@@ -255,5 +255,5 @@ async def _session_cleanup_task():
         except Exception as e:
             logger.error(f"Error in session cleanup task: {e}")
         
-        # Run cleanup every 5 minutes
-        await asyncio.sleep(300)
+        # Run cleanup every 15 minutes (expired sessions are not urgent)
+        await asyncio.sleep(900)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -120,10 +120,19 @@ def create_app() -> FastAPI:
         """Route alias for /api/stream-chat -> /api/simulation/linear-chat-stream"""
         return await linear_chat_stream_handler(request, current_user, db)
 
-    # 3. Health Check
+    # 3. Health Check (cached to reduce database polling)
+    import time as _time
+    _health_cache: dict = {"status": None, "ts": 0.0}
+    _HEALTH_CACHE_TTL = 30  # seconds
+
     @app.get("/health", tags=["System"])
     async def health_check():
-        """Health check endpoint with database connectivity test."""
+        """Health check endpoint with cached database connectivity test."""
+        now = _time.monotonic()
+        # Return cached result if still fresh
+        if _health_cache["status"] is not None and (now - _health_cache["ts"]) < _HEALTH_CACHE_TTL:
+            return _health_cache["status"]
+
         try:
             # Test database connection
             db = SessionLocal()
@@ -135,12 +144,15 @@ def create_app() -> FastAPI:
                 db_status = f"error: {str(e)}"
             finally:
                 db.close()
-            
-            return {
+
+            result = {
                 "status": "ok",
                 "version": "2.0.0",
                 "database": db_status
             }
+            _health_cache["status"] = result
+            _health_cache["ts"] = now
+            return result
         except Exception as e:
             logger.error(f"Health check error: {e}")
             return JSONResponse(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,11 @@ logging.getLogger('sqlalchemy.dialects').setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 
+# Health check cache (module-level so tests can import/inspect)
+import time as _time
+_health_cache: dict = {"status": None, "ts": 0.0}
+_HEALTH_CACHE_TTL = 30  # seconds
+
 def create_app() -> FastAPI:
     """Factory function to create the FastAPI application."""
     
@@ -121,10 +126,6 @@ def create_app() -> FastAPI:
         return await linear_chat_stream_handler(request, current_user, db)
 
     # 3. Health Check (cached to reduce database polling)
-    import time as _time
-    _health_cache: dict = {"status": None, "ts": 0.0}
-    _HEALTH_CACHE_TTL = 30  # seconds
-
     @app.get("/health", tags=["System"])
     async def health_check():
         """Health check endpoint with cached database connectivity test."""

--- a/backend/common/db/core.py
+++ b/backend/common/db/core.py
@@ -24,7 +24,7 @@ sqlalchemy_echo = _sqlalchemy_echo_env in ("1", "true", "yes", "on")
 _engine_kwargs = {
     "future": True,
     "echo":  sqlalchemy_echo,  # Controlled by SQLALCHEMY_ECHO env var (default: False)
-    "pool_pre_ping": True,  # Verify connections before use
+    "pool_pre_ping": os.getenv("DB_POOL_PRE_PING", "true").lower() in ("1", "true", "yes", "on"),
 }
 
 # PostgreSQL-specific settings for connection pooling

--- a/backend/modules/publishing/tasks.py
+++ b/backend/modules/publishing/tasks.py
@@ -631,15 +631,21 @@ async def process_upload_job(job: Dict[str, Any], db: Session) -> bool:
 
 
 async def process_queue():
-    """Continuously poll Redis queue and process upload jobs."""
+    """Continuously process upload jobs from Redis queue using blocking pop."""
     logger.info("[IMAGE_WORKER] Starting image upload worker...")
-    
+
+    BRPOP_TIMEOUT = 5  # seconds to block waiting for a job
+
     try:
         while True:
             try:
-                # Dequeue job from Redis
-                job = redis_manager.rpop(QUEUE_KEY)
-                
+                # Use blocking pop — waits on Redis server instead of polling
+                loop = asyncio.get_event_loop()
+                job = await loop.run_in_executor(
+                    None,
+                    lambda: redis_manager.brpop(QUEUE_KEY, timeout=BRPOP_TIMEOUT)
+                )
+
                 if job:
                     # Create a fresh DB session for this job
                     db = SessionLocal()
@@ -648,14 +654,12 @@ async def process_queue():
                     finally:
                         # Always close the session after processing
                         db.close()
-                else:
-                    # No jobs available, wait a bit before checking again
-                    await asyncio.sleep(1)
-                    
+                # No else/sleep needed — brpop already waited BRPOP_TIMEOUT seconds
+
             except Exception as e:
                 logger.error(f"[IMAGE_WORKER] Error in queue processing loop: {str(e)}")
                 await asyncio.sleep(5)  # Wait before retrying
-                
+
     except KeyboardInterrupt:
         logger.info("[IMAGE_WORKER] Worker stopped by user")
 

--- a/backend/tests/test_excessive_db_polling.py
+++ b/backend/tests/test_excessive_db_polling.py
@@ -1,0 +1,146 @@
+"""
+Tests for GitHub Issue #357: Excessive database polling fixes.
+
+Validates that health checks are cached, pool_pre_ping is configurable,
+session cleanup runs at the correct interval, and the image worker
+uses blocking pop instead of polling.
+"""
+import os
+import sys
+import time
+from unittest.mock import patch, MagicMock, AsyncMock
+import asyncio
+
+import pytest
+
+# --- PATH SETUP ---
+backend_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if backend_path not in sys.path:
+    sys.path.insert(0, backend_path)
+
+
+class TestHealthCheckCaching:
+    """Tests that the /health endpoint caches its DB query result."""
+
+    def test_health_check_returns_ok(self, client):
+        """Health check should return status ok."""
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+
+    def test_health_check_is_cached(self, client):
+        """Second call within TTL should return cached result without new DB query."""
+        # First call – populates cache
+        resp1 = client.get("/health")
+        assert resp1.status_code == 200
+
+        # Second call – should be served from cache (same result)
+        resp2 = client.get("/health")
+        assert resp2.status_code == 200
+        assert resp1.json() == resp2.json()
+
+    def test_health_check_cache_expires(self, client):
+        """After TTL expires, the cache should be refreshed."""
+        from app.main import _health_cache, _HEALTH_CACHE_TTL
+
+        # First call to populate cache
+        client.get("/health")
+
+        # Artificially expire the cache
+        _health_cache["ts"] = time.monotonic() - _HEALTH_CACHE_TTL - 1
+
+        # Next call should refresh (still returns ok, but cache timestamp updates)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert (time.monotonic() - _health_cache["ts"]) < 2  # freshly updated
+
+
+class TestPoolPrePingConfigurable:
+    """Tests that pool_pre_ping can be disabled via environment variable."""
+
+    def test_pool_pre_ping_defaults_to_true(self):
+        """Without env override, pool_pre_ping should default to True."""
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove the var if it exists
+            os.environ.pop("DB_POOL_PRE_PING", None)
+            val = os.getenv("DB_POOL_PRE_PING", "true").lower() in ("1", "true", "yes", "on")
+            assert val is True
+
+    def test_pool_pre_ping_can_be_disabled(self):
+        """Setting DB_POOL_PRE_PING=false should disable pre-ping."""
+        with patch.dict(os.environ, {"DB_POOL_PRE_PING": "false"}):
+            val = os.getenv("DB_POOL_PRE_PING", "true").lower() in ("1", "true", "yes", "on")
+            assert val is False
+
+
+class TestSessionCleanupInterval:
+    """Tests that session cleanup runs at 15-minute interval (not 5)."""
+
+    def test_cleanup_interval_is_900_seconds(self):
+        """The session cleanup task should sleep for 900 seconds (15 min)."""
+        import inspect
+        from app.lifespan import _session_cleanup_task
+
+        source = inspect.getsource(_session_cleanup_task)
+        assert "asyncio.sleep(900)" in source
+        assert "asyncio.sleep(300)" not in source
+
+
+class TestRedisSubscriberSleep:
+    """Tests that the Redis subscriber uses a 1-second idle sleep."""
+
+    def test_subscriber_sleep_is_one_second(self):
+        """The Redis subscriber should sleep 1.0s between empty polls."""
+        import inspect
+        from app.lifespan import _redis_subscriber
+
+        source = inspect.getsource(_redis_subscriber)
+        assert "asyncio.sleep(1.0)" in source
+        assert "asyncio.sleep(0.1)" not in source
+
+
+class TestImageWorkerBRPOP:
+    """Tests that the image worker uses blocking pop instead of rpop + sleep."""
+
+    def test_image_worker_uses_brpop(self):
+        """process_queue should use brpop (blocking) instead of rpop."""
+        import inspect
+        from modules.publishing.tasks import process_queue
+
+        source = inspect.getsource(process_queue)
+        assert "brpop" in source
+        assert "rpop" not in source
+
+    def test_image_worker_no_idle_sleep(self):
+        """process_queue should not have a 1-second idle sleep (brpop handles waiting)."""
+        import inspect
+        from modules.publishing.tasks import process_queue
+
+        source = inspect.getsource(process_queue)
+        # Should not have the old `await asyncio.sleep(1)` idle pattern
+        assert "asyncio.sleep(1)" not in source
+
+
+class TestFrontendPollingIntervals:
+    """Tests that frontend polling intervals were increased from 3s to 10s."""
+
+    def test_edit_grading_polling_interval(self):
+        """edit-grading page should poll every 10 seconds, not 3."""
+        grading_path = os.path.join(
+            backend_path, '..', 'frontend', 'app', 'professor', 'edit-grading', 'page.tsx'
+        )
+        with open(grading_path, 'r') as f:
+            content = f.read()
+        assert "}, 10000)" in content
+        assert "}, 3000)" not in content
+
+    def test_simulation_builder_polling_interval(self):
+        """simulation-builder page should poll every 10 seconds, not 3."""
+        builder_path = os.path.join(
+            backend_path, '..', 'frontend', 'app', 'professor', 'simulation-builder', 'page.tsx'
+        )
+        with open(builder_path, 'r') as f:
+            content = f.read()
+        assert "}, 10000);" in content
+        assert "}, 3000);" not in content

--- a/backend/tests/test_excessive_db_polling.py
+++ b/backend/tests/test_excessive_db_polling.py
@@ -5,6 +5,7 @@ Validates that health checks are cached, pool_pre_ping is configurable,
 session cleanup runs at the correct interval, and the image worker
 uses blocking pop instead of polling.
 """
+import importlib
 import os
 import sys
 import time
@@ -31,14 +32,39 @@ class TestHealthCheckCaching:
 
     def test_health_check_is_cached(self, client):
         """Second call within TTL should return cached result without new DB query."""
-        # First call – populates cache
-        resp1 = client.get("/health")
-        assert resp1.status_code == 200
+        from app.main import _health_cache
 
-        # Second call – should be served from cache (same result)
-        resp2 = client.get("/health")
-        assert resp2.status_code == 200
-        assert resp1.json() == resp2.json()
+        # Reset cache so first call hits DB
+        _health_cache["status"] = None
+        _health_cache["ts"] = 0.0
+
+        # Patch SessionLocal to count DB calls
+        call_count = {"n": 0}
+        _orig_session_local = __import__('app.main', fromlist=['SessionLocal']).SessionLocal
+
+        class _CountingSession:
+            def __init__(self):
+                self._real = _orig_session_local()
+                call_count["n"] += 1
+
+            def execute(self, *a, **kw):
+                return self._real.execute(*a, **kw)
+
+            def close(self):
+                return self._real.close()
+
+        with patch('app.main.SessionLocal', _CountingSession):
+            # First call - populates cache
+            resp1 = client.get("/health")
+            assert resp1.status_code == 200
+            assert call_count["n"] == 1
+
+            # Second call - should be served from cache (same result)
+            resp2 = client.get("/health")
+            assert resp2.status_code == 200
+            assert resp1.json() == resp2.json()
+            # No additional DB call on the cached hit
+            assert call_count["n"] == 1
 
     def test_health_check_cache_expires(self, client):
         """After TTL expires, the cache should be refreshed."""
@@ -61,17 +87,18 @@ class TestPoolPrePingConfigurable:
 
     def test_pool_pre_ping_defaults_to_true(self):
         """Without env override, pool_pre_ping should default to True."""
+        import common.db.core as core_module
         with patch.dict(os.environ, {}, clear=False):
-            # Remove the var if it exists
             os.environ.pop("DB_POOL_PRE_PING", None)
-            val = os.getenv("DB_POOL_PRE_PING", "true").lower() in ("1", "true", "yes", "on")
-            assert val is True
+            importlib.reload(core_module)
+            assert core_module._engine_kwargs["pool_pre_ping"] is True
 
     def test_pool_pre_ping_can_be_disabled(self):
         """Setting DB_POOL_PRE_PING=false should disable pre-ping."""
+        import common.db.core as core_module
         with patch.dict(os.environ, {"DB_POOL_PRE_PING": "false"}):
-            val = os.getenv("DB_POOL_PRE_PING", "true").lower() in ("1", "true", "yes", "on")
-            assert val is False
+            importlib.reload(core_module)
+            assert core_module._engine_kwargs["pool_pre_ping"] is False
 
 
 class TestSessionCleanupInterval:
@@ -104,13 +131,15 @@ class TestImageWorkerBRPOP:
     """Tests that the image worker uses blocking pop instead of rpop + sleep."""
 
     def test_image_worker_uses_brpop(self):
-        """process_queue should use brpop (blocking) instead of rpop."""
+        """process_queue should use brpop (blocking) with correct timeout instead of rpop."""
         import inspect
         from modules.publishing.tasks import process_queue
 
         source = inspect.getsource(process_queue)
         assert ".brpop(" in source
         assert ".rpop(" not in source
+        # Verify the brpop call uses the expected timeout
+        assert "timeout=BRPOP_TIMEOUT" in source
 
     def test_image_worker_no_idle_sleep(self):
         """process_queue should not have a 1-second idle sleep (brpop handles waiting)."""

--- a/backend/tests/test_excessive_db_polling.py
+++ b/backend/tests/test_excessive_db_polling.py
@@ -109,8 +109,8 @@ class TestImageWorkerBRPOP:
         from modules.publishing.tasks import process_queue
 
         source = inspect.getsource(process_queue)
-        assert "brpop" in source
-        assert "rpop" not in source
+        assert ".brpop(" in source
+        assert ".rpop(" not in source
 
     def test_image_worker_no_idle_sleep(self):
         """process_queue should not have a 1-second idle sleep (brpop handles waiting)."""

--- a/frontend/app/professor/edit-grading/page.tsx
+++ b/frontend/app/professor/edit-grading/page.tsx
@@ -87,7 +87,7 @@ export default function EditGradingPage() {
     if (simulationId && processingMaterials.size > 0) {
       const interval = setInterval(() => {
         loadGradingMaterials(parseInt(simulationId))
-      }, 3000)
+      }, 10000)
       return () => clearInterval(interval)
     }
   }, [simulationId, processingMaterials.size])

--- a/frontend/app/professor/simulation-builder/page.tsx
+++ b/frontend/app/professor/simulation-builder/page.tsx
@@ -347,7 +347,7 @@ useEffect(() => {
     if (savedSimulationId && processingMaterials.size > 0) {
       const interval = setInterval(() => {
         checkProcessingStatus(savedSimulationId);
-      }, 3000); // Check every 3 seconds
+      }, 10000); // Check every 10 seconds
 
       return () => clearInterval(interval);
     }

--- a/frontend/e2e/excessive-db-polling.spec.ts
+++ b/frontend/e2e/excessive-db-polling.spec.ts
@@ -11,20 +11,37 @@ test.describe('Health check caching', () => {
   test('GET /health returns cached result on rapid successive calls', async ({ request }) => {
     // First call
     const resp1 = await request.get('/api/proxy/health')
+
+    // Skip if backend is not available
+    if (resp1.status() === 502 || resp1.status() === 503) {
+      test.skip(true, 'Backend not available')
+      return
+    }
+
     // Second call immediately after
     const resp2 = await request.get('/api/proxy/health')
 
-    // Both should succeed (200 or proxied)
-    // In CI without a running backend, we just verify the requests are made;
-    // the key assertion is the source-code-level tests in backend/tests/.
-    expect([200, 502, 503]).toContain(resp1.status())
-    expect([200, 502, 503]).toContain(resp2.status())
+    expect(resp1.status()).toBe(200)
+    expect(resp2.status()).toBe(200)
+    expect(await resp2.json()).toEqual(await resp1.json())
   })
 })
 
 test.describe('Frontend polling intervals', () => {
+  async function mockAuth(page: import('@playwright/test').Page) {
+    await page.route('**/api/proxy/api/auth/me', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1, role: 'professor', email: 'prof@test.com' })
+      })
+    )
+  }
+
   test('simulation-builder polls processing status at 10s interval', async ({ page }) => {
     const pollRequests: number[] = []
+
+    await mockAuth(page)
 
     // Intercept the processing-status requests and record timestamps
     await page.route('**/grading-materials**', route => {
@@ -33,7 +50,7 @@ test.describe('Frontend polling intervals', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify([
-          { id: 1, status: 'processing', name: 'test-material' }
+          { id: 1, processing_status: 'processing', filename: 'test-material' }
         ])
       })
     })
@@ -48,7 +65,7 @@ test.describe('Frontend polling intervals', () => {
     )
 
     // Navigate (page may not fully load without backend, but polling should start)
-    await page.goto('/professor/simulation-builder?id=1', { waitUntil: 'domcontentloaded' })
+    await page.goto('/professor/simulation-builder?edit=1', { waitUntil: 'domcontentloaded' })
 
     // Wait enough time to detect whether polling is 3s or 10s
     // If we wait 8 seconds, with 3s interval we'd see ~2-3 requests,
@@ -66,18 +83,20 @@ test.describe('Frontend polling intervals', () => {
   test('edit-grading page polls at 10s interval', async ({ page }) => {
     const pollRequests: number[] = []
 
+    await mockAuth(page)
+
     await page.route('**/grading-materials**', route => {
       pollRequests.push(Date.now())
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify([
-          { id: 1, status: 'processing', name: 'test-material' }
+          { id: 1, processing_status: 'processing', filename: 'test-material' }
         ])
       })
     })
 
-    await page.goto('/professor/edit-grading?simulationId=1', { waitUntil: 'domcontentloaded' })
+    await page.goto('/professor/edit-grading?id=1', { waitUntil: 'domcontentloaded' })
     await page.waitForTimeout(8000)
 
     expect(pollRequests.length).toBeLessThanOrEqual(3)

--- a/frontend/e2e/excessive-db-polling.spec.ts
+++ b/frontend/e2e/excessive-db-polling.spec.ts
@@ -49,9 +49,9 @@ test.describe('Frontend polling intervals', () => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([
-          { id: 1, processing_status: 'processing', filename: 'test-material' }
-        ])
+        body: JSON.stringify({
+          materials: [{ id: 1, processing_status: 'processing', filename: 'test-material' }]
+        })
       })
     })
 
@@ -90,9 +90,9 @@ test.describe('Frontend polling intervals', () => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([
-          { id: 1, processing_status: 'processing', filename: 'test-material' }
-        ])
+        body: JSON.stringify({
+          materials: [{ id: 1, processing_status: 'processing', filename: 'test-material' }]
+        })
       })
     })
 

--- a/frontend/e2e/excessive-db-polling.spec.ts
+++ b/frontend/e2e/excessive-db-polling.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E tests for issue #357: excessive database polling.
+ *
+ * Validates that the /health endpoint caches its response and that
+ * frontend pages use 10-second polling intervals instead of 3-second.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Health check caching', () => {
+  test('GET /health returns cached result on rapid successive calls', async ({ request }) => {
+    // First call
+    const resp1 = await request.get('/api/proxy/health')
+    // Second call immediately after
+    const resp2 = await request.get('/api/proxy/health')
+
+    // Both should succeed (200 or proxied)
+    // In CI without a running backend, we just verify the requests are made;
+    // the key assertion is the source-code-level tests in backend/tests/.
+    expect([200, 502, 503]).toContain(resp1.status())
+    expect([200, 502, 503]).toContain(resp2.status())
+  })
+})
+
+test.describe('Frontend polling intervals', () => {
+  test('simulation-builder polls processing status at 10s interval', async ({ page }) => {
+    const pollRequests: number[] = []
+
+    // Intercept the processing-status requests and record timestamps
+    await page.route('**/grading-materials**', route => {
+      pollRequests.push(Date.now())
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, status: 'processing', name: 'test-material' }
+        ])
+      })
+    })
+
+    // Mock the simulation-builder page data
+    await page.route('**/api/proxy/api/simulations/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1, title: 'Test', status: 'draft' })
+      })
+    )
+
+    // Navigate (page may not fully load without backend, but polling should start)
+    await page.goto('/professor/simulation-builder?id=1', { waitUntil: 'domcontentloaded' })
+
+    // Wait enough time to detect whether polling is 3s or 10s
+    // If we wait 8 seconds, with 3s interval we'd see ~2-3 requests,
+    // with 10s we'd see 0-1.  This is a best-effort E2E check.
+    await page.waitForTimeout(8000)
+
+    // With 10s interval, there should be at most 1 poll in 8 seconds
+    // (the initial load + at most 1 interval fire)
+    // We don't assert a hard number because the page may not trigger
+    // polling at all without proper auth/state — the source-level test
+    // in backend/tests/test_excessive_db_polling.py is the authoritative check.
+    expect(pollRequests.length).toBeLessThanOrEqual(3)
+  })
+
+  test('edit-grading page polls at 10s interval', async ({ page }) => {
+    const pollRequests: number[] = []
+
+    await page.route('**/grading-materials**', route => {
+      pollRequests.push(Date.now())
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, status: 'processing', name: 'test-material' }
+        ])
+      })
+    })
+
+    await page.goto('/professor/edit-grading?simulationId=1', { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(8000)
+
+    expect(pollRequests.length).toBeLessThanOrEqual(3)
+  })
+})


### PR DESCRIPTION
## Summary
- Caches `/health` endpoint DB query for 30s to prevent per-request `SELECT 1` queries
- Makes `pool_pre_ping` configurable via `DB_POOL_PRE_PING` env var (defaults to `true`)
- Increases session cleanup interval from 5min → 15min
- Increases Redis pub/sub subscriber idle sleep from 0.1s → 1.0s
- Replaces image worker `rpop` + `sleep(1)` polling with efficient `BRPOP` blocking
- Increases frontend polling intervals from 3s → 10s in grading and simulation-builder pages

Fixes #357

## Changes
- `backend/app/main.py` — health check caches DB result for 30s TTL
- `backend/common/db/core.py` — `pool_pre_ping` reads from `DB_POOL_PRE_PING` env var
- `backend/app/lifespan.py` — session cleanup at 15min, Redis subscriber sleeps 1.0s
- `backend/modules/publishing/tasks.py` — image worker uses `brpop(timeout=5)` instead of `rpop` + `sleep(1)`
- `frontend/app/professor/edit-grading/page.tsx` — polling interval 3s → 10s
- `frontend/app/professor/simulation-builder/page.tsx` — polling interval 3s → 10s

## Tests added
- `backend/tests/test_excessive_db_polling.py`:
  - Health check returns ok, caching works, cache expires after TTL
  - `pool_pre_ping` defaults to true, can be disabled via env var
  - Session cleanup interval is 900s (15min)
  - Redis subscriber sleep is 1.0s
  - Image worker uses `brpop`, no `rpop`, no idle `sleep(1)`
  - Frontend files contain 10000ms intervals, not 3000ms
- `frontend/e2e/excessive-db-polling.spec.ts`:
  - Health check caching E2E test
  - Simulation-builder and edit-grading polling interval tests

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass (if applicable)
- [ ] Manual verification: monitor DB query count before/after with `SQLALCHEMY_ECHO=true`

Generated by Ralph Loop iteration 6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced background and subscriber polling frequency to lower redundant work.
  * Cached the health endpoint for 30s to avoid repeated DB checks.
  * Made job-queue worker polling more efficient to reduce idle loops.
  * Increased grading-materials polling from 3s to 10s to cut frontend request volume.
  * Made database connection pool pre-ping configurable via environment.

* **Tests**
  * Added unit and end-to-end tests validating caching, polling intervals, and pool configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->