### PR TITLE
fix: add forgot-password link to login page

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -144,6 +144,11 @@ export default function LoginPage() {
               className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
               required
             />
+            <div className="flex justify-end">
+              <Link href="/forgot-password" className="text-sm text-gray-400 hover:text-white transition-colors">
+                Forgot password?
+              </Link>
+            </div>
           </div>
 
           {error && error.length > 0 && (

--- a/frontend/e2e/forgot-password-link.spec.ts
+++ b/frontend/e2e/forgot-password-link.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * E2E tests for forgot-password link on login page (issue #363).
+ *
+ * Verifies that the login page contains a visible "Forgot password?" link
+ * that navigates to /forgot-password.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const LOGIN_URL = '/login'
+
+test.describe('Forgot password link on login page', () => {
+  test('should display a "Forgot password?" link on the login page', async ({ page }) => {
+    await page.goto(LOGIN_URL)
+
+    const forgotLink = page.getByRole('link', { name: /forgot password/i })
+    await expect(forgotLink).toBeVisible({ timeout: 5000 })
+  })
+
+  test('should navigate to /forgot-password when clicking the link', async ({ page }) => {
+    await page.goto(LOGIN_URL)
+
+    const forgotLink = page.getByRole('link', { name: /forgot password/i })
+    await expect(forgotLink).toBeVisible({ timeout: 5000 })
+    await forgotLink.click()
+
+    await expect(page).toHaveURL(/\/forgot-password/)
+  })
+
+  test('should have the forgot-password page render a reset form', async ({ page }) => {
+    await page.goto('/forgot-password')
+
+    // The forgot-password page should have email and password fields
+    await expect(page.locator('input#email')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('input#confirmEmail')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('input#newPassword')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /update password/i })).toBeVisible()
+  })
+
+  test('regression: login page must not lack forgot-password navigation', async ({ page }) => {
+    await page.goto(LOGIN_URL)
+
+    // There must be at least one link pointing to /forgot-password
+    const links = page.locator('a[href="/forgot-password"]')
+    await expect(links).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Added a "Forgot password?" link to the login page that navigates to `/forgot-password`
- The forgot-password flow was fully implemented but inaccessible because the login page had no link to it

Fixes #363

## Changes
- Added `<Link href="/forgot-password">` below the password input field in `frontend/app/login/page.tsx`
- Styled consistently with existing login form design (gray-400 text, white on hover)

## Tests added
- **E2E (Playwright):** `frontend/e2e/forgot-password-link.spec.ts`
  - Forgot password link is visible on login page
  - Link navigates to /forgot-password
  - Forgot-password page renders the reset form correctly
  - Regression: login page must contain forgot-password navigation link

## Test plan
- [ ] Playwright E2E tests pass
- [ ] Manual: visit /login, verify "Forgot password?" link is visible below password field
- [ ] Manual: click the link, verify it navigates to /forgot-password
- [ ] Manual: complete password reset flow on /forgot-password page

Generated by Ralph Loop iteration 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Forgot password?" link on the login page for easy access to password recovery options.

* **Tests**
  * Added end-to-end tests to validate the password recovery functionality and ensure all login page features work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->