### PR TITLE
fix: enforce turn limit on @mention/@all and persist scene-transition reset (#368)

### DIFF
--- a/backend/modules/simulation/handlers/chat_handler.py
+++ b/backend/modules/simulation/handlers/chat_handler.py
@@ -44,7 +44,59 @@ class ChatHandler:
     def __init__(self, db: Session, repository: SimulationRepository):
         self.db = db
         self.repository = repository
-    
+
+    async def _safe_handle_timeout(
+        self,
+        *,
+        orchestrator,
+        user_progress,
+        current_scene,
+        current_scene_id,
+        full_response,
+        persona_name,
+        persona_id,
+        scene_progression_handler,
+        orchestrator_manager,
+        generate_scene_intro_fn,
+        path_name: str,
+    ) -> Optional[str]:
+        """
+        Call ``handle_timeout`` with consistent error handling + state persistence.
+
+        If ``handle_timeout`` raises, we still attempt to persist any partial
+        in-memory state (e.g., a turn_count reset that happened before the
+        exception) via ``save_orchestrator_state`` + commit, then re-raise so
+        the outer error handler can respond to the client (issue #368).
+        """
+        try:
+            return await handle_timeout(
+                orchestrator=orchestrator,
+                user_progress=user_progress,
+                current_scene=current_scene,
+                current_scene_id=current_scene_id,
+                full_response=full_response,
+                persona_name=persona_name,
+                persona_id=persona_id,
+                scene_progression_handler=scene_progression_handler,
+                orchestrator_manager=orchestrator_manager,
+                generate_scene_intro_fn=generate_scene_intro_fn,
+            )
+        except Exception:
+            logger.exception(
+                "[TURN_COUNT] handle_timeout failed for %s; "
+                "committing any partial state changes before re-raising",
+                path_name,
+            )
+            try:
+                orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                self.db.commit()
+            except Exception:
+                logger.exception(
+                    "[TURN_COUNT] Failed to persist partial state after handle_timeout error (%s)",
+                    path_name,
+                )
+            raise
+
     async def handle_stream_message(
         self,
         user_id: int,
@@ -805,31 +857,19 @@ class ChatHandler:
                                             
                                             # Check for timeout BEFORE yielding final metadata so that
                                             # the turn-limit check runs on single @mention too (issue #368).
-                                            single_mention_timeout_result = None
-                                            try:
-                                                single_mention_timeout_result = await handle_timeout(
-                                                    orchestrator=orchestrator,
-                                                    user_progress=user_progress,
-                                                    current_scene=current_scene,
-                                                    current_scene_id=correct_scene_id,
-                                                    full_response=response_text,
-                                                    persona_name=persona_name,
-                                                    persona_id=persona_id,
-                                                    scene_progression_handler=scene_progression_handler,
-                                                    orchestrator_manager=orchestrator_manager,
-                                                    generate_scene_intro_fn=generate_scene_intro_fn
-                                                )
-                                            except Exception:
-                                                logger.exception(
-                                                    "[TURN_COUNT] handle_timeout failed for single @mention; "
-                                                    "committing any partial state changes before re-raising"
-                                                )
-                                                try:
-                                                    orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
-                                                    self.db.commit()
-                                                except Exception:
-                                                    logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
-                                                raise
+                                            single_mention_timeout_result = await self._safe_handle_timeout(
+                                                orchestrator=orchestrator,
+                                                user_progress=user_progress,
+                                                current_scene=current_scene,
+                                                current_scene_id=correct_scene_id,
+                                                full_response=response_text,
+                                                persona_name=persona_name,
+                                                persona_id=persona_id,
+                                                scene_progression_handler=scene_progression_handler,
+                                                orchestrator_manager=orchestrator_manager,
+                                                generate_scene_intro_fn=generate_scene_intro_fn,
+                                                path_name="single @mention",
+                                            )
                                             # CRITICAL: Commit AFTER handle_timeout so that any reset
                                             # state (turn_count=0 on scene transition) is persisted.
                                             self.db.commit()
@@ -1036,31 +1076,19 @@ class ChatHandler:
                 orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
                 user_progress.last_activity = datetime.utcnow()
                 self.db.commit()
-                all_timeout_result = None
-                try:
-                    all_timeout_result = await handle_timeout(
-                        orchestrator=orchestrator,
-                        user_progress=user_progress,
-                        current_scene=current_scene,
-                        current_scene_id=correct_scene_id,
-                        full_response=full_response,
-                        persona_name=persona_name,
-                        persona_id=persona_id,
-                        scene_progression_handler=scene_progression_handler,
-                        orchestrator_manager=orchestrator_manager,
-                        generate_scene_intro_fn=generate_scene_intro_fn
-                    )
-                except Exception:
-                    logger.exception(
-                        "[TURN_COUNT] handle_timeout failed for @all; "
-                        "committing any partial state changes before re-raising"
-                    )
-                    try:
-                        orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
-                        self.db.commit()
-                    except Exception:
-                        logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
-                    raise
+                all_timeout_result = await self._safe_handle_timeout(
+                    orchestrator=orchestrator,
+                    user_progress=user_progress,
+                    current_scene=current_scene,
+                    current_scene_id=correct_scene_id,
+                    full_response=full_response,
+                    persona_name=persona_name,
+                    persona_id=persona_id,
+                    scene_progression_handler=scene_progression_handler,
+                    orchestrator_manager=orchestrator_manager,
+                    generate_scene_intro_fn=generate_scene_intro_fn,
+                    path_name="@all",
+                )
                 # Commit AFTER handle_timeout so the reset turn_count=0 on a scene
                 # transition is persisted (was missing previously — see issue #368).
                 self.db.commit()
@@ -1074,31 +1102,19 @@ class ChatHandler:
                 orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
                 user_progress.last_activity = datetime.utcnow()
                 self.db.commit()
-                multi_timeout_result = None
-                try:
-                    multi_timeout_result = await handle_timeout(
-                        orchestrator=orchestrator,
-                        user_progress=user_progress,
-                        current_scene=current_scene,
-                        current_scene_id=correct_scene_id,
-                        full_response=full_response,
-                        persona_name=persona_name,
-                        persona_id=persona_id,
-                        scene_progression_handler=scene_progression_handler,
-                        orchestrator_manager=orchestrator_manager,
-                        generate_scene_intro_fn=generate_scene_intro_fn
-                    )
-                except Exception:
-                    logger.exception(
-                        "[TURN_COUNT] handle_timeout failed for multi-mention; "
-                        "committing any partial state changes before re-raising"
-                    )
-                    try:
-                        orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
-                        self.db.commit()
-                    except Exception:
-                        logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
-                    raise
+                multi_timeout_result = await self._safe_handle_timeout(
+                    orchestrator=orchestrator,
+                    user_progress=user_progress,
+                    current_scene=current_scene,
+                    current_scene_id=correct_scene_id,
+                    full_response=full_response,
+                    persona_name=persona_name,
+                    persona_id=persona_id,
+                    scene_progression_handler=scene_progression_handler,
+                    orchestrator_manager=orchestrator_manager,
+                    generate_scene_intro_fn=generate_scene_intro_fn,
+                    path_name="multi-mention",
+                )
                 # CRITICAL: Commit AFTER handle_timeout so that the reset
                 # turn_count=0 on a scene transition is persisted (issue #368).
                 self.db.commit()
@@ -1120,30 +1136,19 @@ class ChatHandler:
             self.db.commit()
             
             # Check for timeout (uses orchestrator.state.turn_count which was just saved)
-            try:
-                timeout_result = await handle_timeout(
-                    orchestrator=orchestrator,
-                    user_progress=user_progress,
-                    current_scene=current_scene,
-                    current_scene_id=correct_scene_id,
-                    full_response=full_response,
-                    persona_name=persona_name,
-                    persona_id=persona_id,
-                    scene_progression_handler=scene_progression_handler,
-                    orchestrator_manager=orchestrator_manager,
-                    generate_scene_intro_fn=generate_scene_intro_fn
-                )
-            except Exception:
-                logger.exception(
-                    "[TURN_COUNT] handle_timeout failed for orchestrator path; "
-                    "committing any partial state changes before re-raising"
-                )
-                try:
-                    orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
-                    self.db.commit()
-                except Exception:
-                    logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
-                raise
+            timeout_result = await self._safe_handle_timeout(
+                orchestrator=orchestrator,
+                user_progress=user_progress,
+                current_scene=current_scene,
+                current_scene_id=correct_scene_id,
+                full_response=full_response,
+                persona_name=persona_name,
+                persona_id=persona_id,
+                scene_progression_handler=scene_progression_handler,
+                orchestrator_manager=orchestrator_manager,
+                generate_scene_intro_fn=generate_scene_intro_fn,
+                path_name="orchestrator",
+            )
 
             # CRITICAL: Commit AFTER handle_timeout so that any scene transition
             # state (turn_count=0, current_scene_index bump) is persisted even

--- a/backend/modules/simulation/handlers/chat_handler.py
+++ b/backend/modules/simulation/handlers/chat_handler.py
@@ -803,9 +803,44 @@ class ChatHandler:
                                                 }
                                             )
                                             
-                                            # CRITICAL: Yield final metadata with turn_count (matching @all behavior)
-                                            yield f"data: {json.dumps({'done': True, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None, 'scene_completed': False, 'next_scene_id': None, 'turn_count': current_turn_count, 'full_content': response_text})}\n\n"
-                                            
+                                            # Check for timeout BEFORE yielding final metadata so that
+                                            # the turn-limit check runs on single @mention too (issue #368).
+                                            single_mention_timeout_result = None
+                                            try:
+                                                single_mention_timeout_result = await handle_timeout(
+                                                    orchestrator=orchestrator,
+                                                    user_progress=user_progress,
+                                                    current_scene=current_scene,
+                                                    current_scene_id=correct_scene_id,
+                                                    full_response=response_text,
+                                                    persona_name=persona_name,
+                                                    persona_id=persona_id,
+                                                    scene_progression_handler=scene_progression_handler,
+                                                    orchestrator_manager=orchestrator_manager,
+                                                    generate_scene_intro_fn=generate_scene_intro_fn
+                                                )
+                                            except Exception:
+                                                logger.exception(
+                                                    "[TURN_COUNT] handle_timeout failed for single @mention; "
+                                                    "committing any partial state changes before re-raising"
+                                                )
+                                                try:
+                                                    orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                                                    self.db.commit()
+                                                except Exception:
+                                                    logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
+                                                raise
+                                            # CRITICAL: Commit AFTER handle_timeout so that any reset
+                                            # state (turn_count=0 on scene transition) is persisted.
+                                            self.db.commit()
+
+                                            if single_mention_timeout_result is not None:
+                                                # Scene transition (or simulation complete) triggered.
+                                                yield f"data: {single_mention_timeout_result}\n\n"
+                                            else:
+                                                # CRITICAL: Yield final metadata with turn_count (matching @all behavior)
+                                                yield f"data: {json.dumps({'done': True, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None, 'scene_completed': False, 'next_scene_id': None, 'turn_count': current_turn_count, 'full_content': response_text})}\n\n"
+
                                             # CRITICAL: Return early for single @mention (matching @all behavior)
                                             return
                                         except (openai.APIError, openai.APIConnectionError) as e:
@@ -992,11 +1027,45 @@ class ChatHandler:
             # and we already yielded the final metadata (line 479), so we can return early.
             # Only orchestrator messages need to continue to the final yield.
             if is_all_message_global:
-                # @all messages: already yielded per persona, no need for final yield
+                # @all messages: already yielded per persona. Still need to run
+                # handle_timeout so the turn-limit check applies to @all too (issue #368).
                 logger.debug(
                     f"[TURN_COUNT] @all message - turn_count already incremented per persona response, "
                     f"already yielded final metadata per persona, current turn_count={orchestrator.state.turn_count}"
                 )
+                orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                user_progress.last_activity = datetime.utcnow()
+                self.db.commit()
+                all_timeout_result = None
+                try:
+                    all_timeout_result = await handle_timeout(
+                        orchestrator=orchestrator,
+                        user_progress=user_progress,
+                        current_scene=current_scene,
+                        current_scene_id=correct_scene_id,
+                        full_response=full_response,
+                        persona_name=persona_name,
+                        persona_id=persona_id,
+                        scene_progression_handler=scene_progression_handler,
+                        orchestrator_manager=orchestrator_manager,
+                        generate_scene_intro_fn=generate_scene_intro_fn
+                    )
+                except Exception:
+                    logger.exception(
+                        "[TURN_COUNT] handle_timeout failed for @all; "
+                        "committing any partial state changes before re-raising"
+                    )
+                    try:
+                        orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                        self.db.commit()
+                    except Exception:
+                        logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
+                    raise
+                # Commit AFTER handle_timeout so the reset turn_count=0 on a scene
+                # transition is persisted (was missing previously — see issue #368).
+                self.db.commit()
+                if all_timeout_result is not None:
+                    yield f"data: {all_timeout_result}\n\n"
                 return
             elif is_multi_mention:
                 # Multi-mention: all persona responses already streamed and saved.
@@ -1005,18 +1074,36 @@ class ChatHandler:
                 orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
                 user_progress.last_activity = datetime.utcnow()
                 self.db.commit()
-                await handle_timeout(
-                    orchestrator=orchestrator,
-                    user_progress=user_progress,
-                    current_scene=current_scene,
-                    current_scene_id=correct_scene_id,
-                    full_response=full_response,
-                    persona_name=persona_name,
-                    persona_id=persona_id,
-                    scene_progression_handler=scene_progression_handler,
-                    orchestrator_manager=orchestrator_manager,
-                    generate_scene_intro_fn=generate_scene_intro_fn
-                )
+                multi_timeout_result = None
+                try:
+                    multi_timeout_result = await handle_timeout(
+                        orchestrator=orchestrator,
+                        user_progress=user_progress,
+                        current_scene=current_scene,
+                        current_scene_id=correct_scene_id,
+                        full_response=full_response,
+                        persona_name=persona_name,
+                        persona_id=persona_id,
+                        scene_progression_handler=scene_progression_handler,
+                        orchestrator_manager=orchestrator_manager,
+                        generate_scene_intro_fn=generate_scene_intro_fn
+                    )
+                except Exception:
+                    logger.exception(
+                        "[TURN_COUNT] handle_timeout failed for multi-mention; "
+                        "committing any partial state changes before re-raising"
+                    )
+                    try:
+                        orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                        self.db.commit()
+                    except Exception:
+                        logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
+                    raise
+                # CRITICAL: Commit AFTER handle_timeout so that the reset
+                # turn_count=0 on a scene transition is persisted (issue #368).
+                self.db.commit()
+                if multi_timeout_result is not None:
+                    yield f"data: {multi_timeout_result}\n\n"
                 return
             elif persona_id:
                 # Single @mention messages: already yielded final metadata at line 479, no need for final yield
@@ -1033,19 +1120,37 @@ class ChatHandler:
             self.db.commit()
             
             # Check for timeout (uses orchestrator.state.turn_count which was just saved)
-            timeout_result = await handle_timeout(
-                orchestrator=orchestrator,
-                user_progress=user_progress,
-                current_scene=current_scene,
-                current_scene_id=correct_scene_id,
-                full_response=full_response,
-                persona_name=persona_name,
-                persona_id=persona_id,
-                scene_progression_handler=scene_progression_handler,
-                orchestrator_manager=orchestrator_manager,
-                generate_scene_intro_fn=generate_scene_intro_fn
-            )
-            
+            try:
+                timeout_result = await handle_timeout(
+                    orchestrator=orchestrator,
+                    user_progress=user_progress,
+                    current_scene=current_scene,
+                    current_scene_id=correct_scene_id,
+                    full_response=full_response,
+                    persona_name=persona_name,
+                    persona_id=persona_id,
+                    scene_progression_handler=scene_progression_handler,
+                    orchestrator_manager=orchestrator_manager,
+                    generate_scene_intro_fn=generate_scene_intro_fn
+                )
+            except Exception:
+                logger.exception(
+                    "[TURN_COUNT] handle_timeout failed for orchestrator path; "
+                    "committing any partial state changes before re-raising"
+                )
+                try:
+                    orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+                    self.db.commit()
+                except Exception:
+                    logger.exception("[TURN_COUNT] Failed to persist partial state after handle_timeout error")
+                raise
+
+            # CRITICAL: Commit AFTER handle_timeout so that any scene transition
+            # state (turn_count=0, current_scene_index bump) is persisted even
+            # when the simulation is not complete (issue #368).
+            if timeout_result is not None:
+                self.db.commit()
+
             if timeout_result is not None:
                 # Clean up sandbox if simulation completed via timeout
                 try:

--- a/backend/modules/simulation/handlers/commands/timeout_handler.py
+++ b/backend/modules/simulation/handlers/commands/timeout_handler.py
@@ -2,9 +2,12 @@
 
 from typing import Dict, Any, Optional
 import json
+import logging
 
 from modules.simulation.core import ChatOrchestrator, OrchestratorManager, SceneProgressionHandler
 from common.db.models import UserProgress
+
+logger = logging.getLogger(__name__)
 
 
 async def handle_timeout(
@@ -59,11 +62,14 @@ async def handle_timeout(
             try:
                 orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
             except Exception:  # pragma: no cover - defensive
-                pass
+                logger.warning(
+                    "[TURN_COUNT] Failed to save orchestrator state after "
+                    "progress_to_next_scene (user_progress_id=%s, current_scene_id=%s)",
+                    getattr(user_progress, "id", None),
+                    current_scene_id,
+                    exc_info=True,
+                )
 
-        if progression_result is None:
-            return None
-        
         if progression_result.get('simulation_complete'):
             # Simulation complete
             return json.dumps({'done': True, 'persona_name': persona_name, 'persona_id': str(persona_id) if persona_id else None, 'scene_completed': True, 'next_scene_id': None, 'turn_count': orchestrator.state.turn_count, 'simulation_complete': True, 'full_content': full_response})

--- a/backend/modules/simulation/handlers/commands/timeout_handler.py
+++ b/backend/modules/simulation/handlers/commands/timeout_handler.py
@@ -40,17 +40,29 @@ async def handle_timeout(
     timeout_turns = current_scene.get('timeout_turns') or current_scene.get('max_turns', 15)
     
     if orchestrator.state.turn_count >= timeout_turns:
-        # Handle timeout - progress to next scene
-        progression_result = scene_progression_handler.progress_to_next_scene(
-            orchestrator=orchestrator,
-            user_progress=user_progress,
-            current_scene_id=current_scene_id,
-            generate_scene_intro_fn=generate_scene_intro_fn
-        )
-        
-        # Save orchestrator state
-        orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
-        # Note: Commit handled by service layer
+        # Handle timeout - progress to next scene.
+        # Use try/finally so that if progress_to_next_scene raises AFTER
+        # turn_count has been reset to 0 (e.g., scene intro generation fails),
+        # we still persist the in-memory reset to orchestrator_data rather
+        # than leaving the DB out of sync with the in-memory state (issue #368).
+        progression_result = None
+        try:
+            progression_result = scene_progression_handler.progress_to_next_scene(
+                orchestrator=orchestrator,
+                user_progress=user_progress,
+                current_scene_id=current_scene_id,
+                generate_scene_intro_fn=generate_scene_intro_fn
+            )
+        finally:
+            # Save orchestrator state whether or not progression fully succeeded.
+            # Commit is handled by the caller (service/handler layer).
+            try:
+                orchestrator_manager.save_orchestrator_state(orchestrator, user_progress)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        if progression_result is None:
+            return None
         
         if progression_result.get('simulation_complete'):
             # Simulation complete

--- a/backend/tests/modules/simulation/test_turn_count_reset.py
+++ b/backend/tests/modules/simulation/test_turn_count_reset.py
@@ -179,3 +179,7 @@ async def test_handle_timeout_uses_max_turns_fallback():
 
     assert result is not None
     scene_progression_handler.progress_to_next_scene.assert_called_once()
+    # Persistence must also fire on the max_turns fallback path.
+    orchestrator_manager.save_orchestrator_state.assert_called_once_with(
+        orchestrator, user_progress
+    )

--- a/backend/tests/modules/simulation/test_turn_count_reset.py
+++ b/backend/tests/modules/simulation/test_turn_count_reset.py
@@ -34,6 +34,8 @@ def _make_orchestrator(turn_count: int):
 
 @pytest.mark.asyncio
 async def test_handle_timeout_progresses_scene_when_limit_reached():
+    """When turn_count >= timeout_turns, handle_timeout must call
+    progress_to_next_scene and persist the reset via save_orchestrator_state."""
     orchestrator = _make_orchestrator(turn_count=15)
     user_progress = MagicMock()
     current_scene = {"timeout_turns": 15, "max_turns": 15}
@@ -41,6 +43,8 @@ async def test_handle_timeout_progresses_scene_when_limit_reached():
     scene_progression_handler = MagicMock()
     # Simulate reset-to-zero inside progress_to_next_scene (real behavior).
     def _progress(**kwargs):
+        """Stand-in for progress_to_next_scene that mutates orchestrator state
+        the same way the real implementation does (reset + index bump)."""
         orchestrator.state.turn_count = 0
         orchestrator.state.current_scene_index = 1
         return {
@@ -79,6 +83,8 @@ async def test_handle_timeout_progresses_scene_when_limit_reached():
 
 @pytest.mark.asyncio
 async def test_handle_timeout_returns_none_when_below_limit():
+    """Below the turn limit, handle_timeout is a no-op: no progression, no save,
+    and it returns None so the caller continues the normal response flow."""
     orchestrator = _make_orchestrator(turn_count=5)
     user_progress = MagicMock()
     current_scene = {"timeout_turns": 15}
@@ -119,6 +125,9 @@ async def test_handle_timeout_persists_state_when_progression_raises_after_reset
     scene_progression_handler = MagicMock()
 
     def _progress_then_raise(**kwargs):
+        """Simulate the pathological case: progress_to_next_scene resets
+        turn_count to 0, then raises before returning — exactly the failure
+        mode that motivated the try/finally persistence fix."""
         # Reset happens BEFORE the exception, matching real code path.
         orchestrator.state.turn_count = 0
         orchestrator.state.current_scene_index = 1

--- a/backend/tests/modules/simulation/test_turn_count_reset.py
+++ b/backend/tests/modules/simulation/test_turn_count_reset.py
@@ -1,0 +1,181 @@
+"""
+Tests for turn-count reset / scene-transition persistence (Issue #368).
+
+Verifies that:
+1. `handle_timeout` triggers `progress_to_next_scene` and returns a scene
+   transition payload when turn_count >= timeout_turns.
+2. `handle_timeout` persists `turn_count=0` via `save_orchestrator_state`
+   EVEN when `progress_to_next_scene` raises an exception AFTER the reset
+   (the try/finally safety net).
+3. `handle_timeout` returns None and does NOT call `progress_to_next_scene`
+   when the turn limit has not been reached.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.simulation.handlers.commands.timeout_handler import handle_timeout
+
+
+def _make_orchestrator(turn_count: int):
+    """Build a minimal orchestrator stand-in with a mutable state object."""
+    state = SimpleNamespace(
+        turn_count=turn_count,
+        current_scene_index=0,
+        current_scene_id=1,
+        scene_completed=False,
+        session_id="sess-1",
+    )
+    return SimpleNamespace(state=state, user_progress_id=1, simulation={"scenes": []})
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_progresses_scene_when_limit_reached():
+    orchestrator = _make_orchestrator(turn_count=15)
+    user_progress = MagicMock()
+    current_scene = {"timeout_turns": 15, "max_turns": 15}
+
+    scene_progression_handler = MagicMock()
+    # Simulate reset-to-zero inside progress_to_next_scene (real behavior).
+    def _progress(**kwargs):
+        orchestrator.state.turn_count = 0
+        orchestrator.state.current_scene_index = 1
+        return {
+            "next_scene_id": 2,
+            "next_scene": {"id": 2},
+            "scene_intro_message": "Welcome to scene 2",
+        }
+    scene_progression_handler.progress_to_next_scene.side_effect = _progress
+
+    orchestrator_manager = MagicMock()
+
+    result = await handle_timeout(
+        orchestrator=orchestrator,
+        user_progress=user_progress,
+        current_scene=current_scene,
+        current_scene_id=1,
+        full_response="Some response",
+        persona_name="Alice",
+        persona_id=42,
+        scene_progression_handler=scene_progression_handler,
+        orchestrator_manager=orchestrator_manager,
+        generate_scene_intro_fn=None,
+    )
+
+    assert result is not None, "Expected a timeout result when turn limit reached"
+    payload = json.loads(result)
+    assert payload["scene_completed"] is True
+    assert payload["next_scene_id"] == 2
+    assert payload["turn_count"] == 0
+    scene_progression_handler.progress_to_next_scene.assert_called_once()
+    # The fix: save_orchestrator_state MUST be called so the reset persists.
+    orchestrator_manager.save_orchestrator_state.assert_called_once_with(
+        orchestrator, user_progress
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_returns_none_when_below_limit():
+    orchestrator = _make_orchestrator(turn_count=5)
+    user_progress = MagicMock()
+    current_scene = {"timeout_turns": 15}
+
+    scene_progression_handler = MagicMock()
+    orchestrator_manager = MagicMock()
+
+    result = await handle_timeout(
+        orchestrator=orchestrator,
+        user_progress=user_progress,
+        current_scene=current_scene,
+        current_scene_id=1,
+        full_response="Some response",
+        persona_name="Alice",
+        persona_id=42,
+        scene_progression_handler=scene_progression_handler,
+        orchestrator_manager=orchestrator_manager,
+        generate_scene_intro_fn=None,
+    )
+
+    assert result is None
+    scene_progression_handler.progress_to_next_scene.assert_not_called()
+    orchestrator_manager.save_orchestrator_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_persists_state_when_progression_raises_after_reset():
+    """
+    Regression for issue #368 phase 3: if progress_to_next_scene resets
+    turn_count and then raises (e.g., scene intro generation fails), the
+    in-memory reset must still be persisted via save_orchestrator_state so
+    that the DB does not diverge from in-memory state.
+    """
+    orchestrator = _make_orchestrator(turn_count=15)
+    user_progress = MagicMock()
+    current_scene = {"timeout_turns": 15}
+
+    scene_progression_handler = MagicMock()
+
+    def _progress_then_raise(**kwargs):
+        # Reset happens BEFORE the exception, matching real code path.
+        orchestrator.state.turn_count = 0
+        orchestrator.state.current_scene_index = 1
+        raise RuntimeError("scene intro generation failed")
+
+    scene_progression_handler.progress_to_next_scene.side_effect = _progress_then_raise
+    orchestrator_manager = MagicMock()
+
+    with pytest.raises(RuntimeError, match="scene intro generation failed"):
+        await handle_timeout(
+            orchestrator=orchestrator,
+            user_progress=user_progress,
+            current_scene=current_scene,
+            current_scene_id=1,
+            full_response="Some response",
+            persona_name="Alice",
+            persona_id=42,
+            scene_progression_handler=scene_progression_handler,
+            orchestrator_manager=orchestrator_manager,
+            generate_scene_intro_fn=None,
+        )
+
+    # Critical assertion: state was saved even though progression raised.
+    orchestrator_manager.save_orchestrator_state.assert_called_once_with(
+        orchestrator, user_progress
+    )
+    # And the in-memory reset took effect before the raise.
+    assert orchestrator.state.turn_count == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_uses_max_turns_fallback():
+    """When timeout_turns is missing, the function falls back to max_turns."""
+    orchestrator = _make_orchestrator(turn_count=10)
+    user_progress = MagicMock()
+    current_scene = {"max_turns": 10}  # no timeout_turns key
+
+    scene_progression_handler = MagicMock()
+    scene_progression_handler.progress_to_next_scene.return_value = {
+        "next_scene_id": 2,
+        "next_scene": {"id": 2},
+        "scene_intro_message": None,
+    }
+    orchestrator_manager = MagicMock()
+
+    result = await handle_timeout(
+        orchestrator=orchestrator,
+        user_progress=user_progress,
+        current_scene=current_scene,
+        current_scene_id=1,
+        full_response="resp",
+        persona_name="Bob",
+        persona_id=None,
+        scene_progression_handler=scene_progression_handler,
+        orchestrator_manager=orchestrator_manager,
+        generate_scene_intro_fn=None,
+    )
+
+    assert result is not None
+    scene_progression_handler.progress_to_next_scene.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes the turn-count / scene-transition reset bug in the simulation chat handler. The turn limit was not enforced for single `@mention` or `@all` messages, and even when it was enforced the `turn_count = 0` reset was never committed — on re-entry the orchestrator still saw the stale high turn_count and the scene never advanced.

Fixes #368

## Changes
- `chat_handler.py`:
  - Call `handle_timeout` on the single `@mention` and `@all` paths (previously missing) and yield any transition SSE event.
  - Move `db.commit()` to AFTER `handle_timeout` on every path (single `@mention`, `@all`, multi-mention, orchestrator) so that the reset `turn_count = 0` from a scene transition is persisted.
  - Wrap every `handle_timeout` call in a `try/except` that flushes partial state before re-raising, preventing DB/in-memory divergence on downstream errors.
- `timeout_handler.py`:
  - Wrap `progress_to_next_scene` in `try/finally` that always calls `save_orchestrator_state`, so the `turn_count = 0` reset is captured even when scene-intro generation raises.

## Tests added
- `backend/tests/modules/simulation/test_turn_count_reset.py`
  - `test_handle_timeout_progresses_scene_when_limit_reached` — happy path: scene transition triggered and state saved.
  - `test_handle_timeout_returns_none_when_below_limit` — no-op under the limit.
  - `test_handle_timeout_persists_state_when_progression_raises_after_reset` — regression: `save_orchestrator_state` is called even when `progress_to_next_scene` raises after resetting `turn_count`.
  - `test_handle_timeout_uses_max_turns_fallback` — falls back to `max_turns` when `timeout_turns` is missing.

## Test plan
- [ ] Unit tests pass (CI)
- [ ] Lint passes
- [ ] Manual verification: with a scene `max_turns`/`timeout_turns` of N, hitting the limit via single `@mention`, `@all`, or multi-mention now advances to the next scene AND the next scene's turn_count starts at 0 after a browser refresh / re-entry.

Generated by Ralph Loop iteration 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened timeout handling across chat flows so timeout outcomes are yielded when triggered and scene-transition state is reliably persisted (including commits after timeout handling).
  * Ensured turn-count resets persist when advancing scenes, even if progression raises; added guarded persistence and warning logs on persistence failures.

* **Tests**
  * Added tests validating timeout-triggered scene progression, turn-count reset persistence, and related failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->