### PR TITLE
feat: email-verified forgot-password flow (#343)

### DIFF
--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -71,6 +71,14 @@ class Settings(BaseSettings):
     daytona_api_url: Optional[str] = None
     daytona_target: Optional[str] = "us"
 
+    # SMTP / Email Configuration (used for password reset emails, etc.)
+    smtp_server: str = "smtp.gmail.com"
+    smtp_port: int = 587
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    from_email: Optional[str] = None
+    from_name: str = "n-aible"
+
     @property
     def worker_id(self) -> str:
         """

--- a/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
+++ b/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
@@ -1,0 +1,107 @@
+"""Add password_reset_tokens table
+
+Revision ID: add_password_reset_tokens
+Revises: add_enhanced_persona_fields
+Create Date: 2026-04-05 12:00:00.000000
+
+Adds the password_reset_tokens table used by the email-verified forgot
+password flow. Tokens are single-use, expire after 1 hour, and are removed
+automatically when the owning user is deleted (ON DELETE CASCADE).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision: str = "add_password_reset_tokens"
+down_revision: Union[str, None] = "add_enhanced_persona_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create password_reset_tokens table if it doesn't already exist."""
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    def _table_exists() -> bool:
+        if dialect == "postgresql":
+            result = conn.execute(
+                sa.text(
+                    "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                    "WHERE table_name = 'password_reset_tokens')"
+                )
+            )
+            return bool(result.scalar())
+        # Fallback for sqlite and others
+        return sa.inspect(conn).has_table("password_reset_tokens")
+
+    if not _table_exists():
+        op.create_table(
+            "password_reset_tokens",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("token", sa.String(length=255), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("token", name="uq_password_reset_tokens_token"),
+        )
+
+    # Indexes — create idempotently so this migration is safe to re-run.
+    def _index_exists(name: str) -> bool:
+        if dialect == "postgresql":
+            result = conn.execute(
+                sa.text(
+                    "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = :n)"
+                ),
+                {"n": name},
+            )
+            return bool(result.scalar())
+        insp = sa.inspect(conn)
+        return any(
+            idx["name"] == name
+            for idx in insp.get_indexes("password_reset_tokens")
+        )
+
+    for index_name, columns in (
+        ("idx_password_reset_tokens_token", ["token"]),
+        ("idx_password_reset_tokens_user_id", ["user_id"]),
+    ):
+        if not _index_exists(index_name):
+            op.create_index(index_name, "password_reset_tokens", columns)
+
+
+def downgrade() -> None:
+    """Drop the password_reset_tokens table and its indexes."""
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    for index_name in (
+        "idx_password_reset_tokens_user_id",
+        "idx_password_reset_tokens_token",
+    ):
+        if dialect == "postgresql":
+            conn.execute(sa.text(f"DROP INDEX IF EXISTS {index_name}"))
+        else:
+            try:
+                op.drop_index(index_name, table_name="password_reset_tokens")
+            except Exception:
+                pass
+
+    if dialect == "postgresql":
+        conn.execute(sa.text("DROP TABLE IF EXISTS password_reset_tokens"))
+    else:
+        try:
+            op.drop_table("password_reset_tokens")
+        except Exception:
+            pass

--- a/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
+++ b/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
@@ -1,7 +1,7 @@
 """Add password_reset_tokens table
 
 Revision ID: add_password_reset_tokens
-Revises: add_enhanced_persona_fields
+Revises: merge_persona_code_challenge
 Create Date: 2026-04-05 12:00:00.000000
 
 Adds the password_reset_tokens table used by the email-verified forgot
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 # Revision identifiers, used by Alembic.
 revision: str = "add_password_reset_tokens"
-down_revision: Union[str, None] = "add_enhanced_persona_fields"
+down_revision: Union[str, None] = "merge_persona_code_challenge"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
+++ b/backend/common/db/migrations/versions/2026_04_05_1200-add_password_reset_tokens.py
@@ -86,22 +86,24 @@ def downgrade() -> None:
     conn = op.get_bind()
     dialect = conn.dialect.name
 
+    inspector = sa.inspect(conn)
+    table_exists = inspector.has_table("password_reset_tokens")
+
     for index_name in (
         "idx_password_reset_tokens_user_id",
         "idx_password_reset_tokens_token",
     ):
         if dialect == "postgresql":
             conn.execute(sa.text(f"DROP INDEX IF EXISTS {index_name}"))
-        else:
-            try:
+        elif table_exists:
+            existing = {
+                idx["name"]
+                for idx in inspector.get_indexes("password_reset_tokens")
+            }
+            if index_name in existing:
                 op.drop_index(index_name, table_name="password_reset_tokens")
-            except Exception:
-                pass
 
     if dialect == "postgresql":
         conn.execute(sa.text("DROP TABLE IF EXISTS password_reset_tokens"))
-    else:
-        try:
-            op.drop_table("password_reset_tokens")
-        except Exception:
-            pass
+    elif table_exists:
+        op.drop_table("password_reset_tokens")

--- a/backend/common/db/models/__init__.py
+++ b/backend/common/db/models/__init__.py
@@ -7,6 +7,7 @@ Models are organized by feature module.
 
 # Import from module-specific subdirectories
 from .auth.user import User
+from .auth.password_reset_token import PasswordResetToken
 from .publishing.simulation import (
     Simulation,
     SimulationPersona,
@@ -48,6 +49,7 @@ ScenarioReview = SimulationReview
 __all__ = [
     # Auth models
     "User",
+    "PasswordResetToken",
     # Publishing models
     "Simulation",
     "SimulationPersona",

--- a/backend/common/db/models/auth/__init__.py
+++ b/backend/common/db/models/auth/__init__.py
@@ -1,4 +1,5 @@
 """Authentication models."""
 from .user import User
+from .password_reset_token import PasswordResetToken
 
-__all__ = ["User"]
+__all__ = ["User", "PasswordResetToken"]

--- a/backend/common/db/models/auth/password_reset_token.py
+++ b/backend/common/db/models/auth/password_reset_token.py
@@ -1,0 +1,40 @@
+"""Password reset token model.
+
+Stores single-use, time-limited tokens that authorise a user to reset their
+password via the email-verified reset flow.
+"""
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from common.db.base import Base
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class PasswordResetToken(Base):
+    """Single-use token issued to a user to reset their password."""
+
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id])
+
+    __table_args__ = (
+        Index("idx_password_reset_tokens_token", "token"),
+        Index("idx_password_reset_tokens_user_id", "user_id"),
+    )

--- a/backend/common/db/models/auth/password_reset_token.py
+++ b/backend/common/db/models/auth/password_reset_token.py
@@ -25,7 +25,7 @@ class PasswordResetToken(Base):
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
-    token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/common/services/email_service.py
+++ b/backend/common/services/email_service.py
@@ -1,1 +1,128 @@
-"""Placeholder for outbound email helpers (SMTP, templates)."""
+"""Outbound email helpers (SMTP).
+
+Provides async email sending via SMTP with STARTTLS. SMTP calls run in a
+thread executor to avoid blocking the asyncio event loop (matching the
+pattern used in :mod:`common.security.passwords`).
+"""
+import asyncio
+import logging
+import smtplib
+import ssl
+from email.message import EmailMessage
+from typing import Optional
+
+from common.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _send_email_sync(
+    recipient: str,
+    subject: str,
+    html_body: str,
+    *,
+    smtp_server: str,
+    smtp_port: int,
+    smtp_username: Optional[str],
+    smtp_password: Optional[str],
+    from_email: str,
+    from_name: str,
+) -> None:
+    """Blocking SMTP send — intended to be run inside a thread executor."""
+    message = EmailMessage()
+    message["From"] = f"{from_name} <{from_email}>"
+    message["To"] = recipient
+    message["Subject"] = subject
+    # Provide a plain-text fallback so the message is multipart/alternative.
+    message.set_content(
+        "This email requires an HTML-capable mail client to view correctly."
+    )
+    message.add_alternative(html_body, subtype="html")
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(smtp_server, smtp_port, timeout=30) as smtp:
+        smtp.ehlo()
+        smtp.starttls(context=context)
+        smtp.ehlo()
+        if smtp_username and smtp_password:
+            smtp.login(smtp_username, smtp_password)
+        smtp.send_message(message)
+
+
+async def send_email(recipient: str, subject: str, html_body: str) -> bool:
+    """Send an HTML email asynchronously.
+
+    Returns True on success, False on failure (failures are logged but not
+    raised so callers can respond with generic messages to avoid leaking
+    information — e.g. in the password reset flow).
+    """
+    settings = get_settings()
+
+    # Required configuration check. In local/dev environments SMTP may not
+    # be configured; in that case log and return False so callers can decide
+    # how to handle it (the password reset flow still returns a generic
+    # success message to the client).
+    from_email = settings.from_email or settings.smtp_username
+    if not from_email:
+        logger.warning(
+            "send_email: SMTP sender address is not configured "
+            "(set FROM_EMAIL or SMTP_USERNAME). Skipping send."
+        )
+        return False
+
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(
+            None,
+            lambda: _send_email_sync(
+                recipient,
+                subject,
+                html_body,
+                smtp_server=settings.smtp_server,
+                smtp_port=settings.smtp_port,
+                smtp_username=settings.smtp_username,
+                smtp_password=settings.smtp_password,
+                from_email=from_email,
+                from_name=settings.from_name,
+            ),
+        )
+        logger.info("send_email: delivered to %s (subject=%r)", recipient, subject)
+        return True
+    except Exception as exc:  # pragma: no cover — network/SMTP errors
+        logger.error(
+            "send_email: failed to deliver to %s: %s", recipient, exc, exc_info=True
+        )
+        return False
+
+
+def _build_password_reset_html(reset_link: str) -> str:
+    return f"""<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; background:#0f172a; color:#e2e8f0; padding:24px;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; margin:0 auto; background:#1e293b; border-radius:12px; padding:32px;">
+      <tr><td>
+        <h1 style="color:#f8fafc; margin-top:0;">Reset your password</h1>
+        <p>We received a request to reset the password for your n-aible account.</p>
+        <p>Click the button below to choose a new password. This link will expire in 1 hour.</p>
+        <p style="text-align:center; margin:32px 0;">
+          <a href="{reset_link}" style="display:inline-block; background:#6366f1; color:#ffffff; text-decoration:none; padding:12px 24px; border-radius:8px; font-weight:600;">Reset password</a>
+        </p>
+        <p style="font-size:13px; color:#94a3b8;">If the button doesn't work, copy and paste this URL into your browser:</p>
+        <p style="font-size:13px; word-break:break-all; color:#cbd5e1;">{reset_link}</p>
+        <hr style="border:none; border-top:1px solid #334155; margin:24px 0;" />
+        <p style="font-size:12px; color:#94a3b8;">If you didn't request this, you can safely ignore this email — your password won't be changed.</p>
+      </td></tr>
+    </table>
+  </body>
+</html>
+"""
+
+
+async def send_password_reset_email(email: str, reset_link: str) -> bool:
+    """Send the password reset email to the user."""
+    subject = "Reset your n-aible password"
+    html_body = _build_password_reset_html(reset_link)
+    return await send_email(email, subject, html_body)
+
+
+__all__ = ["send_email", "send_password_reset_email"]

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -1,6 +1,7 @@
 """
 Authentication router - Login, register, token refresh, OAuth endpoints
 """
+import hashlib
 import os
 import logging
 import secrets
@@ -9,7 +10,7 @@ import time
 import json
 import traceback
 from typing import Optional
-from fastapi import APIRouter, HTTPException, Depends, status, Request, Response
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Depends, status, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -213,16 +214,43 @@ PASSWORD_RESET_GENERIC_MESSAGE = (
 PASSWORD_RESET_TOKEN_TTL = timedelta(hours=1)
 
 
+def _hash_reset_token(raw_token: str) -> str:
+    """Return a SHA-256 hex digest of a reset token.
+
+    We only ever persist the digest so that read access to the database
+    cannot be turned into redeemable reset links.
+    """
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+async def _dispatch_reset_email(email: str, reset_link: str) -> None:
+    """Send the reset email and swallow errors so the background task never crashes.
+
+    Runs out of band from the HTTP response path so SMTP latency can't be
+    used to distinguish real password accounts from unknown/OAuth emails.
+    """
+    try:
+        await send_password_reset_email(email, reset_link)
+    except Exception as exc:  # pragma: no cover — defensive, email service already logs
+        logger.error(
+            "request_password_reset: failed to dispatch email to %s: %s",
+            email,
+            exc,
+        )
+
+
 @router.post("/request-reset", response_model=PasswordResetResponse)
 async def request_password_reset(
     request: PasswordReset,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     """Start the forgot-password flow by emailing a single-use reset token.
 
     Always returns a generic success message to prevent email enumeration —
     no matter whether the email exists, belongs to an OAuth-only account, or
-    the SMTP send fails.
+    the SMTP send fails. Email dispatch is deferred to a background task so
+    response latency cannot be used to distinguish account states.
     """
     email = request.email  # already normalised by the schema validator
 
@@ -234,6 +262,14 @@ async def request_password_reset(
 
     # Only issue a token if the user exists AND has a password-based account.
     if user and user.password_hash and (not user.provider or user.provider == "password"):
+        # Serialize concurrent issuance for this user so the delete-then-insert
+        # below cannot race and leave multiple unused tokens alive.
+        try:
+            db.query(User).filter(User.id == user.id).with_for_update().first()
+        except Exception:
+            # SQLite and some test backends don't support SELECT ... FOR UPDATE.
+            pass
+
         # Invalidate any previous unused tokens for this user so only the
         # newest link works.
         db.query(PasswordResetToken).filter(
@@ -241,28 +277,24 @@ async def request_password_reset(
             PasswordResetToken.used_at.is_(None),
         ).delete(synchronize_session=False)
 
-        token_value = secrets.token_urlsafe(32)
+        raw_token = secrets.token_urlsafe(32)
+        token_digest = _hash_reset_token(raw_token)
         expires_at = datetime.now(timezone.utc) + PASSWORD_RESET_TOKEN_TTL
 
         reset_token = PasswordResetToken(
             user_id=user.id,
-            token=token_value,
+            token=token_digest,
             expires_at=expires_at,
         )
         db.add(reset_token)
         db.commit()
 
         frontend_url = (settings.frontend_url or FRONTEND_URL).rstrip("/")
-        reset_link = f"{frontend_url}/reset-password?token={token_value}"
+        reset_link = f"{frontend_url}/reset-password?token={raw_token}"
 
-        try:
-            await send_password_reset_email(user.email, reset_link)
-        except Exception as exc:  # pragma: no cover — defensive, email service already logs
-            logger.error(
-                "request_password_reset: failed to dispatch email to %s: %s",
-                user.email,
-                exc,
-            )
+        # Dispatch the email out of band so SMTP round-trip latency does not
+        # leak account existence and so the HTTP response is not blocked on it.
+        background_tasks.add_task(_dispatch_reset_email, user.email, reset_link)
 
     return PasswordResetResponse(message=PASSWORD_RESET_GENERIC_MESSAGE)
 
@@ -272,12 +304,20 @@ async def confirm_password_reset(
     request: PasswordResetConfirm,
     db: Session = Depends(get_db),
 ):
-    """Finish the forgot-password flow by consuming a token and setting a new password."""
-    token_record = (
-        db.query(PasswordResetToken)
-        .filter(PasswordResetToken.token == request.token)
-        .first()
-    )
+    """Finish the forgot-password flow by consuming a token and setting a new password.
+
+    Token consumption is performed under a row lock in the same transaction
+    as the password update, so the same reset link cannot be redeemed twice
+    by racing requests.
+    """
+    token_digest = _hash_reset_token(request.token)
+
+    query = db.query(PasswordResetToken).filter(PasswordResetToken.token == token_digest)
+    try:
+        token_record = query.with_for_update().first()
+    except Exception:
+        # Fall back for DBs without row-level locking (e.g. SQLite in tests).
+        token_record = query.first()
 
     if not token_record:
         raise HTTPException(
@@ -315,6 +355,7 @@ async def confirm_password_reset(
             detail="This account uses Google sign-in. Please login with Google to manage your password.",
         )
 
+    # Mark the token used and update the password atomically in one commit.
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
     user.updated_at = datetime.utcnow()
     token_record.used_at = now

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -3,6 +3,7 @@ Authentication router - Login, register, token refresh, OAuth endpoints
 """
 import os
 import logging
+import secrets
 import urllib.parse
 import time
 import json
@@ -12,15 +13,17 @@ from fastapi import APIRouter, HTTPException, Depends, status, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import func
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from app.dependencies import get_current_user
 from common.db.core import get_db
 from common.config import get_settings
-from common.db.models import User
+from common.db.models import User, PasswordResetToken
 from common.db.schemas import UserResponse
+from common.services.email_service import send_password_reset_email
 from modules.auth.schemas import (
-    UserRegister, UserLogin, UserLoginResponse, PasswordResetRequest,
+    UserRegister, UserLogin, UserLoginResponse,
+    PasswordReset, PasswordResetConfirm, PasswordResetResponse,
     AccountLinkingRequest, RoleSelectionRequest, OAuthUserData
 )
 from modules.auth.service import auth_service
@@ -202,32 +205,125 @@ async def logout_user(response: Response):
     return {"message": "Successfully logged out"}
 
 
-@router.post("/forgot-password")
-async def forgot_password(request: PasswordResetRequest, db: Session = Depends(get_db)):
-    """Reset a user's password after confirming email"""
-    normalized_email = request.email.strip().lower()
+# --- Password reset (email token flow) ---
 
-    user = db.query(User).filter(func.lower(User.email) == normalized_email).first()
+PASSWORD_RESET_GENERIC_MESSAGE = (
+    "If an account exists with this email, a reset link has been sent."
+)
+PASSWORD_RESET_TOKEN_TTL = timedelta(hours=1)
+
+
+@router.post("/request-reset", response_model=PasswordResetResponse)
+async def request_password_reset(
+    request: PasswordReset,
+    db: Session = Depends(get_db),
+):
+    """Start the forgot-password flow by emailing a single-use reset token.
+
+    Always returns a generic success message to prevent email enumeration —
+    no matter whether the email exists, belongs to an OAuth-only account, or
+    the SMTP send fails.
+    """
+    email = request.email  # already normalised by the schema validator
+
+    user = (
+        db.query(User)
+        .filter(func.lower(User.email) == email)
+        .first()
+    )
+
+    # Only issue a token if the user exists AND has a password-based account.
+    if user and user.password_hash and (not user.provider or user.provider == "password"):
+        # Invalidate any previous unused tokens for this user so only the
+        # newest link works.
+        db.query(PasswordResetToken).filter(
+            PasswordResetToken.user_id == user.id,
+            PasswordResetToken.used_at.is_(None),
+        ).delete(synchronize_session=False)
+
+        token_value = secrets.token_urlsafe(32)
+        expires_at = datetime.now(timezone.utc) + PASSWORD_RESET_TOKEN_TTL
+
+        reset_token = PasswordResetToken(
+            user_id=user.id,
+            token=token_value,
+            expires_at=expires_at,
+        )
+        db.add(reset_token)
+        db.commit()
+
+        frontend_url = (settings.frontend_url or FRONTEND_URL).rstrip("/")
+        reset_link = f"{frontend_url}/reset-password?token={token_value}"
+
+        try:
+            await send_password_reset_email(user.email, reset_link)
+        except Exception as exc:  # pragma: no cover — defensive, email service already logs
+            logger.error(
+                "request_password_reset: failed to dispatch email to %s: %s",
+                user.email,
+                exc,
+            )
+
+    return PasswordResetResponse(message=PASSWORD_RESET_GENERIC_MESSAGE)
+
+
+@router.post("/reset-password", response_model=PasswordResetResponse)
+async def confirm_password_reset(
+    request: PasswordResetConfirm,
+    db: Session = Depends(get_db),
+):
+    """Finish the forgot-password flow by consuming a token and setting a new password."""
+    token_record = (
+        db.query(PasswordResetToken)
+        .filter(PasswordResetToken.token == request.token)
+        .first()
+    )
+
+    if not token_record:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset token.",
+        )
+
+    if token_record.used_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This reset link has already been used. Please request a new one.",
+        )
+
+    now = datetime.now(timezone.utc)
+    # Some DBs may return naive datetimes — coerce for safe comparison.
+    expires_at = token_record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at <= now:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This reset link has expired. Please request a new one.",
+        )
+
+    user = db.query(User).filter(User.id == token_record.user_id).first()
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No account found with that email address"
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset token.",
         )
 
     if user.provider and user.provider != "password":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This account uses Google sign-in. Please login with Google to manage your password."
+            detail="This account uses Google sign-in. Please login with Google to manage your password.",
         )
 
-    # Use async password hashing to avoid blocking the event loop
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
     user.updated_at = datetime.utcnow()
+    token_record.used_at = now
 
     db.add(user)
+    db.add(token_record)
     db.commit()
 
-    return {"message": "Password updated successfully"}
+    return PasswordResetResponse(message="Your password has been reset. You can now log in.")
 
 
 @router.post("/check-email")

--- a/backend/modules/auth/router.py
+++ b/backend/modules/auth/router.py
@@ -357,7 +357,7 @@ async def confirm_password_reset(
 
     # Mark the token used and update the password atomically in one commit.
     user.password_hash = await auth_service.get_password_hash_async(request.new_password)
-    user.updated_at = datetime.utcnow()
+    user.updated_at = datetime.now(timezone.utc)
     token_record.used_at = now
 
     db.add(user)

--- a/backend/modules/auth/schemas.py
+++ b/backend/modules/auth/schemas.py
@@ -40,19 +40,6 @@ class PasswordChange(BaseModel):
     current_password: str
     new_password: str
 
-class PasswordResetRequest(BaseModel):
-    email: str
-    confirm_email: str
-    new_password: str
-
-    @model_validator(mode="after")
-    def validate_emails(self):
-        if self.email.strip().lower() != self.confirm_email.strip().lower():
-            raise ValueError("Emails must match")
-        if len(self.new_password) < 6:
-            raise ValueError("New password must be at least 6 characters long")
-        return self
-
 class ProfileUpdate(BaseModel):
     full_name: Optional[str] = None
     username: Optional[str] = None
@@ -62,11 +49,41 @@ class ProfileUpdate(BaseModel):
     allow_contact: Optional[bool] = None
 
 class PasswordReset(BaseModel):
+    """Request a password reset email for the given address."""
     email: str
 
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        value = (v or "").strip().lower()
+        if not value or "@" not in value:
+            raise ValueError("A valid email address is required")
+        return value
+
 class PasswordResetConfirm(BaseModel):
+    """Confirm a password reset using a token delivered via email."""
     token: str
     new_password: str
+
+    @field_validator("token")
+    @classmethod
+    def validate_token(cls, v: str) -> str:
+        value = (v or "").strip()
+        if not value:
+            raise ValueError("Reset token is required")
+        return value
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: str) -> str:
+        if not v or len(v) < 6:
+            raise ValueError("New password must be at least 6 characters long")
+        return v
+
+
+class PasswordResetResponse(BaseModel):
+    """Generic response for password reset endpoints."""
+    message: str
 
 # OAuth schemas
 class GoogleOAuthRequest(BaseModel):

--- a/backend/tests/modules/auth/test_email_normalization.py
+++ b/backend/tests/modules/auth/test_email_normalization.py
@@ -175,11 +175,11 @@ async def test_check_email_with_whitespace(async_client: AsyncClient):
     assert resp.json()["exists"] is True
 
 
-# --- Forgot password case-insensitivity (already implemented, regression test) ---
+# --- Forgot password case-insensitivity (regression test) ---
 
 @pytest.mark.asyncio
-async def test_forgot_password_case_insensitive(async_client: AsyncClient):
-    """Forgot-password should work with case-variant email."""
+async def test_request_password_reset_case_insensitive(async_client: AsyncClient):
+    """Request-reset should accept case-variant email and return a generic success response."""
     uid = str(uuid.uuid4())[:8]
     email = f"forgottest_{uid}@example.com"
 
@@ -196,11 +196,8 @@ async def test_forgot_password_case_insensitive(async_client: AsyncClient):
     assert reg.status_code == 200
 
     resp = await async_client.post(
-        "/api/auth/users/forgot-password",
-        json={
-            "email": email.upper(),
-            "confirm_email": email.upper(),
-            "new_password": "NewPassword456!",
-        },
+        "/api/auth/users/request-reset",
+        json={"email": email.upper()},
     )
     assert resp.status_code == 200
+    assert "reset link" in resp.json()["message"].lower()

--- a/backend/tests/modules/auth/test_password_reset.py
+++ b/backend/tests/modules/auth/test_password_reset.py
@@ -1,0 +1,292 @@
+"""Tests for the email-verified password reset flow.
+
+Covers the two-step flow:
+  POST /api/auth/users/request-reset   → issues a token + sends email
+  POST /api/auth/users/reset-password  → validates token and updates password
+
+These tests monkey-patch ``send_password_reset_email`` so no real SMTP call
+is made and the generated token can be captured from the database.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.orm import Session
+
+from common.db.models import PasswordResetToken, User
+from modules.auth.router import PASSWORD_RESET_GENERIC_MESSAGE
+
+
+GENERIC = PASSWORD_RESET_GENERIC_MESSAGE
+
+
+async def _register_user(async_client: AsyncClient, *, email: str, password: str = "Password123!") -> None:
+    uid = str(uuid.uuid4())[:8]
+    resp = await async_client.post(
+        "/api/auth/users/register",
+        json={
+            "email": email,
+            "password": password,
+            "full_name": "Reset Test",
+            "username": f"reset_{uid}",
+            "role": "student",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _latest_token_for(db_session: Session, email: str) -> PasswordResetToken:
+    user = db_session.query(User).filter(User.email == email).first()
+    assert user is not None, f"user {email!r} should exist"
+    token = (
+        db_session.query(PasswordResetToken)
+        .filter(PasswordResetToken.user_id == user.id)
+        .order_by(PasswordResetToken.id.desc())
+        .first()
+    )
+    assert token is not None, "expected a password reset token to have been created"
+    return token
+
+
+@pytest.fixture
+def stub_send_email(monkeypatch):
+    """Prevent real SMTP calls and capture invocations."""
+    calls: list[tuple[str, str]] = []
+
+    async def _fake(email: str, reset_link: str) -> bool:
+        calls.append((email, reset_link))
+        return True
+
+    # Patch the symbol imported into the router module (that's what the
+    # endpoint calls).
+    import modules.auth.router as auth_router_module
+
+    monkeypatch.setattr(auth_router_module, "send_password_reset_email", _fake)
+    return calls
+
+
+# --------------------------------------------------------------------------
+# /request-reset
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_reset_returns_generic_message_for_unknown_email(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    resp = await async_client.post(
+        "/api/auth/users/request-reset",
+        json={"email": "nobody-" + uuid.uuid4().hex[:6] + "@example.com"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == GENERIC
+    # No email dispatched, no token created.
+    assert stub_send_email == []
+    assert db_session.query(PasswordResetToken).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_request_reset_happy_path_creates_token_and_sends_email(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"happy_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+
+    resp = await async_client.post(
+        "/api/auth/users/request-reset", json={"email": email}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == GENERIC
+
+    # A token was created with a future expiry and no used_at.
+    token = _latest_token_for(db_session, email)
+    assert token.used_at is None
+    expires_at = token.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    assert expires_at > datetime.now(timezone.utc)
+
+    # Exactly one email dispatched with a reset link that contains the token.
+    assert len(stub_send_email) == 1
+    sent_email, reset_link = stub_send_email[0]
+    assert sent_email == email
+    assert token.token in reset_link
+    assert "/reset-password?token=" in reset_link
+
+
+@pytest.mark.asyncio
+async def test_request_reset_is_case_insensitive_on_email(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"caseins_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+
+    resp = await async_client.post(
+        "/api/auth/users/request-reset", json={"email": email.upper()}
+    )
+    assert resp.status_code == 200
+    assert len(stub_send_email) == 1
+
+
+@pytest.mark.asyncio
+async def test_request_reset_invalidates_previous_unused_tokens(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"invalidate_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    first_token = _latest_token_for(db_session, email).token
+
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+
+    # Only the newest token should remain for this user.
+    user = db_session.query(User).filter(User.email == email).first()
+    remaining = (
+        db_session.query(PasswordResetToken)
+        .filter(PasswordResetToken.user_id == user.id)
+        .all()
+    )
+    assert len(remaining) == 1
+    assert remaining[0].token != first_token
+
+
+# --------------------------------------------------------------------------
+# /reset-password
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_password_happy_path_updates_password_and_marks_token_used(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"reset_{uuid.uuid4().hex[:8]}@example.com"
+    old_password = "OldPassword123!"
+    new_password = "NewPassword456!"
+    await _register_user(async_client, email=email, password=old_password)
+
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    token = _latest_token_for(db_session, email).token
+
+    resp = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": token, "new_password": new_password},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Old password no longer works.
+    bad = await async_client.post(
+        "/api/auth/users/login", json={"email": email, "password": old_password}
+    )
+    assert bad.status_code == 401
+
+    # New password works.
+    ok = await async_client.post(
+        "/api/auth/users/login", json={"email": email, "password": new_password}
+    )
+    assert ok.status_code == 200
+
+    # Token is now marked used.
+    db_session.expire_all()
+    used_token = (
+        db_session.query(PasswordResetToken)
+        .filter(PasswordResetToken.token == token)
+        .first()
+    )
+    assert used_token is not None
+    assert used_token.used_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_unknown_token(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": "this-token-does-not-exist", "new_password": "whatever123"},
+    )
+    assert resp.status_code == 400
+    assert "invalid" in resp.json()["detail"].lower() or "expired" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_reused_token(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"reuse_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    token = _latest_token_for(db_session, email).token
+
+    first = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": token, "new_password": "FirstReset123!"},
+    )
+    assert first.status_code == 200
+
+    second = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": token, "new_password": "SecondReset123!"},
+    )
+    assert second.status_code == 400
+    assert "already" in second.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_expired_token(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"expired_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+
+    token_row = _latest_token_for(db_session, email)
+    # Force the token into the past.
+    token_row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    db_session.add(token_row)
+    db_session.commit()
+    token_value = token_row.token
+
+    resp = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": token_value, "new_password": "LatePassword123!"},
+    )
+    assert resp.status_code == 400
+    assert "expired" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_short_password(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    email = f"short_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    token = _latest_token_for(db_session, email).token
+
+    resp = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": token, "new_password": "abc"},
+    )
+    # FastAPI returns 422 for pydantic validation errors.
+    assert resp.status_code == 422
+
+
+# --------------------------------------------------------------------------
+# Regression: old insecure endpoint must be gone.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_old_forgot_password_endpoint_is_removed(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/api/auth/users/forgot-password",
+        json={
+            "email": "whoever@example.com",
+            "confirm_email": "whoever@example.com",
+            "new_password": "hackhack123",
+        },
+    )
+    # The old direct-reset endpoint must no longer exist.
+    assert resp.status_code in (404, 405)

--- a/backend/tests/modules/auth/test_password_reset.py
+++ b/backend/tests/modules/auth/test_password_reset.py
@@ -11,13 +11,19 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.orm import Session
 
 from common.db.models import PasswordResetToken, User
-from modules.auth.router import PASSWORD_RESET_GENERIC_MESSAGE
+from modules.auth.router import PASSWORD_RESET_GENERIC_MESSAGE, _hash_reset_token
+
+
+def _raw_token_from_link(reset_link: str) -> str:
+    """Extract the raw token value from a reset URL."""
+    return parse_qs(urlparse(reset_link).query)["token"][0]
 
 
 GENERIC = PASSWORD_RESET_GENERIC_MESSAGE
@@ -101,6 +107,11 @@ async def test_request_reset_happy_path_creates_token_and_sends_email(
     assert resp.status_code == 200
     assert resp.json()["message"] == GENERIC
 
+    # Flush any background tasks (email dispatch is deferred).
+    import asyncio
+
+    await asyncio.sleep(0)
+
     # A token was created with a future expiry and no used_at.
     token = _latest_token_for(db_session, email)
     assert token.used_at is None
@@ -109,12 +120,16 @@ async def test_request_reset_happy_path_creates_token_and_sends_email(
         expires_at = expires_at.replace(tzinfo=timezone.utc)
     assert expires_at > datetime.now(timezone.utc)
 
-    # Exactly one email dispatched with a reset link that contains the token.
+    # Exactly one email dispatched with a reset link that contains the raw
+    # token. The DB persists only the SHA-256 digest of that raw token.
     assert len(stub_send_email) == 1
     sent_email, reset_link = stub_send_email[0]
     assert sent_email == email
-    assert token.token in reset_link
     assert "/reset-password?token=" in reset_link
+    raw_token = _raw_token_from_link(reset_link)
+    assert _hash_reset_token(raw_token) == token.token
+    # The raw bearer secret must NOT be persisted as-is.
+    assert raw_token != token.token
 
 
 @pytest.mark.asyncio
@@ -127,6 +142,9 @@ async def test_request_reset_is_case_insensitive_on_email(
     resp = await async_client.post(
         "/api/auth/users/request-reset", json={"email": email.upper()}
     )
+    import asyncio
+
+    await asyncio.sleep(0)
     assert resp.status_code == 200
     assert len(stub_send_email) == 1
 
@@ -139,7 +157,7 @@ async def test_request_reset_invalidates_previous_unused_tokens(
     await _register_user(async_client, email=email)
 
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
-    first_token = _latest_token_for(db_session, email).token
+    first_digest = _latest_token_for(db_session, email).token
 
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
 
@@ -151,7 +169,7 @@ async def test_request_reset_invalidates_previous_unused_tokens(
         .all()
     )
     assert len(remaining) == 1
-    assert remaining[0].token != first_token
+    assert remaining[0].token != first_digest
 
 
 # --------------------------------------------------------------------------
@@ -169,11 +187,14 @@ async def test_reset_password_happy_path_updates_password_and_marks_token_used(
     await _register_user(async_client, email=email, password=old_password)
 
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
-    token = _latest_token_for(db_session, email).token
+    import asyncio
+
+    await asyncio.sleep(0)
+    raw_token = _raw_token_from_link(stub_send_email[-1][1])
 
     resp = await async_client.post(
         "/api/auth/users/reset-password",
-        json={"token": token, "new_password": new_password},
+        json={"token": raw_token, "new_password": new_password},
     )
     assert resp.status_code == 200, resp.text
 
@@ -193,7 +214,7 @@ async def test_reset_password_happy_path_updates_password_and_marks_token_used(
     db_session.expire_all()
     used_token = (
         db_session.query(PasswordResetToken)
-        .filter(PasswordResetToken.token == token)
+        .filter(PasswordResetToken.token == _hash_reset_token(raw_token))
         .first()
     )
     assert used_token is not None
@@ -217,17 +238,20 @@ async def test_reset_password_rejects_reused_token(
     email = f"reuse_{uuid.uuid4().hex[:8]}@example.com"
     await _register_user(async_client, email=email)
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
-    token = _latest_token_for(db_session, email).token
+    import asyncio
+
+    await asyncio.sleep(0)
+    raw_token = _raw_token_from_link(stub_send_email[-1][1])
 
     first = await async_client.post(
         "/api/auth/users/reset-password",
-        json={"token": token, "new_password": "FirstReset123!"},
+        json={"token": raw_token, "new_password": "FirstReset123!"},
     )
     assert first.status_code == 200
 
     second = await async_client.post(
         "/api/auth/users/reset-password",
-        json={"token": token, "new_password": "SecondReset123!"},
+        json={"token": raw_token, "new_password": "SecondReset123!"},
     )
     assert second.status_code == 400
     assert "already" in second.json()["detail"].lower()
@@ -240,17 +264,20 @@ async def test_reset_password_rejects_expired_token(
     email = f"expired_{uuid.uuid4().hex[:8]}@example.com"
     await _register_user(async_client, email=email)
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    import asyncio
+
+    await asyncio.sleep(0)
+    raw_token = _raw_token_from_link(stub_send_email[-1][1])
 
     token_row = _latest_token_for(db_session, email)
     # Force the token into the past.
     token_row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
     db_session.add(token_row)
     db_session.commit()
-    token_value = token_row.token
 
     resp = await async_client.post(
         "/api/auth/users/reset-password",
-        json={"token": token_value, "new_password": "LatePassword123!"},
+        json={"token": raw_token, "new_password": "LatePassword123!"},
     )
     assert resp.status_code == 400
     assert "expired" in resp.json()["detail"].lower()
@@ -263,14 +290,53 @@ async def test_reset_password_rejects_short_password(
     email = f"short_{uuid.uuid4().hex[:8]}@example.com"
     await _register_user(async_client, email=email)
     await async_client.post("/api/auth/users/request-reset", json={"email": email})
-    token = _latest_token_for(db_session, email).token
+    import asyncio
+
+    await asyncio.sleep(0)
+    raw_token = _raw_token_from_link(stub_send_email[-1][1])
 
     resp = await async_client.post(
         "/api/auth/users/reset-password",
-        json={"token": token, "new_password": "abc"},
+        json={"token": raw_token, "new_password": "abc"},
     )
     # FastAPI returns 422 for pydantic validation errors.
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_oauth_only_account(
+    async_client: AsyncClient, stub_send_email, db_session: Session
+):
+    """A valid token for a user converted to OAuth-only must be rejected.
+
+    Guards against someone who registered with a password, started a reset,
+    and then had their account migrated to Google-only before redeeming the
+    link — the reset endpoint must refuse to set a password on an OAuth-only
+    account.
+    """
+    email = f"oauthonly_{uuid.uuid4().hex[:8]}@example.com"
+    await _register_user(async_client, email=email)
+    await async_client.post("/api/auth/users/request-reset", json={"email": email})
+    import asyncio
+
+    await asyncio.sleep(0)
+    raw_token = _raw_token_from_link(stub_send_email[-1][1])
+
+    # Flip the user to OAuth-only after the token was issued.
+    user = db_session.query(User).filter(User.email == email).first()
+    assert user is not None
+    user.provider = "google"
+    user.google_id = f"google-{uuid.uuid4().hex[:8]}"
+    db_session.add(user)
+    db_session.commit()
+
+    resp = await async_client.post(
+        "/api/auth/users/reset-password",
+        json={"token": raw_token, "new_password": "BrandNewPw123!"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"].lower()
+    assert "google" in detail or "oauth" in detail
 
 
 # --------------------------------------------------------------------------

--- a/frontend/app/api/auth/request-reset/route.ts
+++ b/frontend/app/api/auth/request-reset/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!backendUrl) {
+      console.error('Request-reset API route: NEXT_PUBLIC_API_URL is not configured')
+      return NextResponse.json(
+        { error: 'Backend server configuration is missing. Please contact support.' },
+        { status: 500 }
+      )
+    }
+
+    const backendEndpoint = `${backendUrl.replace(/\/$/, '')}/api/auth/users/request-reset`
+
+    let response: Response
+    try {
+      response = await fetch(backendEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    } catch (fetchError) {
+      console.error('Request-reset API route: Network error:', fetchError)
+      return NextResponse.json(
+        { error: 'Backend server is unavailable. Please try again in a moment.' },
+        { status: 503 }
+      )
+    }
+
+    const contentType = response.headers.get('content-type')
+    if (!contentType?.includes('application/json')) {
+      const text = await response.text()
+      console.error('Request-reset: non-JSON response:', text.substring(0, 200))
+      return NextResponse.json(
+        { error: 'Backend returned invalid response' },
+        { status: 500 }
+      )
+    }
+
+    const data = await response.json()
+
+    if (!response.ok) {
+      const errorMessage = data.error || data.detail || data.message || 'Unable to send reset email'
+      return NextResponse.json({ error: errorMessage }, { status: response.status })
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error('Request-reset API route: Unexpected error:', error)
+    return NextResponse.json(
+      { error: 'Failed to process request. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/auth/request-reset/route.ts
+++ b/frontend/app/api/auth/request-reset/route.ts
@@ -4,9 +4,9 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    const backendUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL
     if (!backendUrl) {
-      console.error('Request-reset API route: NEXT_PUBLIC_API_URL is not configured')
+      console.error('Request-reset API route: API_URL/NEXT_PUBLIC_API_URL is not configured')
       return NextResponse.json(
         { error: 'Backend server configuration is missing. Please contact support.' },
         { status: 500 }

--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!backendUrl) {
+      console.error('Reset-password API route: NEXT_PUBLIC_API_URL is not configured')
+      return NextResponse.json(
+        { error: 'Backend server configuration is missing. Please contact support.' },
+        { status: 500 }
+      )
+    }
+
+    const backendEndpoint = `${backendUrl.replace(/\/$/, '')}/api/auth/users/reset-password`
+
+    let response: Response
+    try {
+      response = await fetch(backendEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    } catch (fetchError) {
+      console.error('Reset-password API route: Network error:', fetchError)
+      return NextResponse.json(
+        { error: 'Backend server is unavailable. Please try again in a moment.' },
+        { status: 503 }
+      )
+    }
+
+    const contentType = response.headers.get('content-type')
+    if (!contentType?.includes('application/json')) {
+      const text = await response.text()
+      console.error('Reset-password: non-JSON response:', text.substring(0, 200))
+      return NextResponse.json(
+        { error: 'Backend returned invalid response' },
+        { status: 500 }
+      )
+    }
+
+    const data = await response.json()
+
+    if (!response.ok) {
+      const errorMessage = data.error || data.detail || data.message || 'Unable to reset password'
+      return NextResponse.json({ error: errorMessage }, { status: response.status })
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error('Reset-password API route: Unexpected error:', error)
+    return NextResponse.json(
+      { error: 'Failed to reset password. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -4,9 +4,9 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL
+    const backendUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL
     if (!backendUrl) {
-      console.error('Reset-password API route: NEXT_PUBLIC_API_URL is not configured')
+      console.error('Reset-password API route: API_URL/NEXT_PUBLIC_API_URL is not configured')
       return NextResponse.json(
         { error: 'Backend server configuration is missing. Please contact support.' },
         { status: 500 }

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,73 +1,36 @@
 "use client"
 
 import { useState } from "react"
+import type { FormEvent } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { apiClient } from "@/lib/api"
 
 export default function ForgotPasswordPage() {
-  const router = useRouter()
   const [email, setEmail] = useState("")
-  const [confirmEmail, setConfirmEmail] = useState("")
-  const [newPassword, setNewPassword] = useState("")
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+  const [message, setMessage] = useState("")
+  const [error, setError] = useState("")
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setError(null)
-    setSuccess(null)
-
-    if (!email.trim() || !confirmEmail.trim() || !newPassword.trim()) {
-      setError("Please complete all fields.")
-      return
-    }
-
-    if (email.trim().toLowerCase() !== confirmEmail.trim().toLowerCase()) {
-      setError("Emails do not match.")
-      return
-    }
-
-    if (newPassword.trim().length < 6) {
-      setError("New password must be at least 6 characters long.")
-      return
-    }
-
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
     setLoading(true)
+    setError("")
+
     try {
-      const response = await fetch("/api/auth/forgot-password", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          email,
-          confirm_email: confirmEmail,
-          new_password: newPassword,
-        }),
-      })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.detail || data.message || "Failed to reset password.")
-      }
-
-      setSuccess("Password updated successfully! You can now log in with your new password.")
-      setEmail("")
-      setConfirmEmail("")
-      setNewPassword("")
-      // Redirect back to login after a short delay
-      setTimeout(() => router.push("/"), 3000)
+      const result = await apiClient.requestPasswordReset({ email: email.trim() })
+      setMessage(
+        result?.message ||
+          "If an account exists with this email, a reset link has been sent."
+      )
+      setSubmitted(true)
     } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message)
-      } else {
-        setError("Failed to reset password. Please try again.")
-      }
+      const errorMessage =
+        err instanceof Error ? err.message : "Unable to send reset email. Please try again."
+      setError(errorMessage)
     } finally {
       setLoading(false)
     }
@@ -76,87 +39,92 @@ export default function ForgotPasswordPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse" />
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse" style={{ animationDelay: "1s" }} />
+        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
+        <div
+          className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse"
+          style={{ animationDelay: "1s" }}
+        ></div>
       </div>
 
       <div className="w-full max-w-md relative z-10 animate-fade-scale">
-        <div className="text-center mb-8">
+        <div className="text-center mb-10">
           <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
-            <img src="/n-aiblelogo.png" alt="Logo" className="h-16 w-auto opacity-95 object-contain" />
+            <img
+              src="/n-aiblelogo.png"
+              alt="Logo"
+              className="h-16 w-auto opacity-95 object-contain"
+            />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">Reset your password</h1>
+          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">
+            Forgot your password?
+          </h1>
           <p className="text-gray-400 text-sm">
-            Confirm your email and set a new password for your account.
+            Enter your email and we'll send you a link to reset it.
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5" noValidate>
-          <div className="space-y-3">
-            <Label htmlFor="email" className="text-white font-medium">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder="Enter your email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
-            />
-          </div>
-
-          <div className="space-y-3">
-            <Label htmlFor="confirmEmail" className="text-white font-medium">Confirm Email</Label>
-            <Input
-              id="confirmEmail"
-              type="email"
-              placeholder="Retype your email"
-              value={confirmEmail}
-              onChange={(event) => setConfirmEmail(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
-            />
-          </div>
-
-          <div className="space-y-3">
-            <Label htmlFor="newPassword" className="text-white font-medium">New Password</Label>
-            <Input
-              id="newPassword"
-              type="password"
-              placeholder="Create a new password"
-              value={newPassword}
-              onChange={(event) => setNewPassword(event.target.value)}
-              className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
-            />
-          </div>
-
-          {error && (
-            <div className="bg-red-900/20 border border-red-500/50 rounded-md p-3">
-              <p className="text-red-400 text-sm font-medium">{error}</p>
-            </div>
-          )}
-
-          {success && (
-            <div className="bg-emerald-900/20 border border-emerald-500/50 rounded-md p-3">
-              <p className="text-emerald-400 text-sm font-medium">{success}</p>
-            </div>
-          )}
-
-          <Button
-            type="submit"
-            className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] font-semibold"
-            disabled={loading}
+        {submitted ? (
+          <div
+            data-testid="forgot-password-success"
+            className="bg-green-900/30 border border-green-500/60 rounded-lg p-6 text-center space-y-4"
           >
-            {loading ? "Updating password..." : "Update password"}
-          </Button>
-        </form>
+            <h2 className="text-xl font-semibold text-green-200">Check your inbox</h2>
+            <p className="text-green-100 text-sm">{message}</p>
+            <p className="text-green-100/70 text-xs">
+              The reset link will expire in 1 hour. Don't forget to check your spam folder.
+            </p>
+            <Link
+              href="/login"
+              className="inline-block text-white underline hover:text-green-200"
+            >
+              Back to login
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div className="space-y-3">
+              <Label htmlFor="email" className="text-white font-medium">
+                Email
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="Enter your email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  if (error) setError("")
+                }}
+                className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+                required
+              />
+            </div>
 
-        <div className="text-center mt-6">
-          <span className="text-gray-400">Remembered your password? </span>
-          <Link href="/" className="text-white hover:underline">
-            Return to login
-          </Link>
-        </div>
+            {error && error.length > 0 && (
+              <div
+                data-testid="forgot-password-error"
+                className="bg-red-900/40 border-2 border-red-500 rounded-lg p-4"
+              >
+                <p className="text-red-200 text-sm font-medium">{error}</p>
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] font-semibold"
+              disabled={loading}
+            >
+              {loading ? "Sending..." : "Send reset link"}
+            </Button>
+
+            <div className="text-center mt-6">
+              <Link href="/login" className="text-gray-400 hover:text-white transition-colors">
+                ← Back to login
+              </Link>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   )
 }
-

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { Suspense, useState } from "react"
+import type { FormEvent } from "react"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { apiClient } from "@/lib/api"
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token") || ""
+
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState(false)
+
+  if (!token) {
+    return (
+      <div
+        data-testid="reset-password-missing-token"
+        className="bg-red-900/30 border border-red-500/60 rounded-lg p-6 text-center space-y-4"
+      >
+        <h2 className="text-xl font-semibold text-red-200">Invalid reset link</h2>
+        <p className="text-red-100 text-sm">
+          This password reset link is missing a token. Please request a new one from the forgot
+          password page.
+        </p>
+        <Link href="/forgot-password" className="inline-block text-white underline">
+          Request a new link
+        </Link>
+      </div>
+    )
+  }
+
+  if (success) {
+    return (
+      <div
+        data-testid="reset-password-success"
+        className="bg-green-900/30 border border-green-500/60 rounded-lg p-6 text-center space-y-4"
+      >
+        <h2 className="text-xl font-semibold text-green-200">Password reset</h2>
+        <p className="text-green-100 text-sm">
+          Your password has been updated. You can now log in with your new password.
+        </p>
+        <Link
+          href="/login"
+          className="inline-block bg-white text-gray-900 font-semibold px-4 py-2 rounded-md hover:bg-green-100"
+        >
+          Go to login
+        </Link>
+      </div>
+    )
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError("")
+
+    if (password.length < 6) {
+      setError("New password must be at least 6 characters long.")
+      return
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.")
+      return
+    }
+
+    setLoading(true)
+    try {
+      await apiClient.resetPassword({ token, new_password: password })
+      setSuccess(true)
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Unable to reset password. Please try again."
+      setError(errorMessage)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div className="space-y-3">
+        <Label htmlFor="password" className="text-white font-medium">
+          New password
+        </Label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="At least 6 characters"
+          value={password}
+          onChange={(e) => {
+            setPassword(e.target.value)
+            if (error) setError("")
+          }}
+          className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+          required
+          minLength={6}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <Label htmlFor="confirmPassword" className="text-white font-medium">
+          Confirm new password
+        </Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          placeholder="Retype your new password"
+          value={confirmPassword}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value)
+            if (error) setError("")
+          }}
+          className="bg-gray-900/50 backdrop-blur-sm border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all rounded-lg"
+          required
+          minLength={6}
+        />
+      </div>
+
+      {error && error.length > 0 && (
+        <div
+          data-testid="reset-password-error"
+          className="bg-red-900/40 border-2 border-red-500 rounded-lg p-4"
+        >
+          <p className="text-red-200 text-sm font-medium">{error}</p>
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] font-semibold"
+        disabled={loading}
+      >
+        {loading ? "Resetting..." : "Reset password"}
+      </Button>
+
+      <div className="text-center mt-6">
+        <Link href="/login" className="text-gray-400 hover:text-white transition-colors">
+          ← Back to login
+        </Link>
+      </div>
+    </form>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white flex items-center justify-center p-4 relative pattern-grid overflow-hidden">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute top-0 left-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
+        <div
+          className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse"
+          style={{ animationDelay: "1s" }}
+        ></div>
+      </div>
+
+      <div className="w-full max-w-md relative z-10 animate-fade-scale">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center justify-center mb-6 animate-scale-in">
+            <img
+              src="/n-aiblelogo.png"
+              alt="Logo"
+              className="h-16 w-auto opacity-95 object-contain"
+            />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-2 tracking-tight">
+            Set a new password
+          </h1>
+          <p className="text-gray-400 text-sm">
+            Enter a new password for your account.
+          </p>
+        </div>
+
+        <Suspense fallback={<p className="text-gray-400 text-center">Loading…</p>}>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/frontend/e2e/forgot-password-link.spec.ts
+++ b/frontend/e2e/forgot-password-link.spec.ts
@@ -1,8 +1,12 @@
 /**
- * E2E tests for forgot-password link on login page (issue #363).
+ * E2E tests for the forgot-password + reset-password flow (issues #343, #363).
  *
- * Verifies that the login page contains a visible "Forgot password?" link
- * that navigates to /forgot-password.
+ * Verifies:
+ *  - Login page has a visible "Forgot password?" link that navigates to /forgot-password
+ *  - Forgot-password page renders the new email-only request form
+ *  - Submitting the form shows a generic success message (backend response mocked)
+ *  - Reset-password page renders the new-password form when a token is present in the URL
+ *  - Reset-password page shows an error state when the token is missing
  */
 
 import { test, expect } from '@playwright/test'
@@ -27,21 +31,90 @@ test.describe('Forgot password link on login page', () => {
     await expect(page).toHaveURL(/\/forgot-password/)
   })
 
-  test('should have the forgot-password page render a reset form', async ({ page }) => {
-    await page.goto('/forgot-password')
-
-    // The forgot-password page should have email and password fields
-    await expect(page.locator('input#email')).toBeVisible({ timeout: 5000 })
-    await expect(page.locator('input#confirmEmail')).toBeVisible({ timeout: 5000 })
-    await expect(page.locator('input#newPassword')).toBeVisible({ timeout: 5000 })
-    await expect(page.getByRole('button', { name: /update password/i })).toBeVisible()
-  })
-
   test('regression: login page must not lack forgot-password navigation', async ({ page }) => {
     await page.goto(LOGIN_URL)
 
-    // There must be at least one link pointing to /forgot-password
     const links = page.locator('a[href="/forgot-password"]')
     await expect(links).toHaveCount(1)
+  })
+})
+
+test.describe('Forgot-password page (email token flow)', () => {
+  test('should render an email-only request form (no confirm_email/new_password fields)', async ({ page }) => {
+    await page.goto('/forgot-password')
+
+    await expect(page.locator('input#email')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('input#confirmEmail')).toHaveCount(0)
+    await expect(page.locator('input#newPassword')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /send reset link/i })).toBeVisible()
+  })
+
+  test('submitting the form shows a generic success message', async ({ page }) => {
+    // Mock the frontend proxy so the test does not need a live backend.
+    await page.route('**/api/auth/request-reset', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'If an account exists with this email, a reset link has been sent.',
+        }),
+      })
+    })
+
+    await page.goto('/forgot-password')
+    await page.locator('input#email').fill('someone@example.com')
+    await page.getByRole('button', { name: /send reset link/i }).click()
+
+    const banner = page.getByTestId('forgot-password-success')
+    await expect(banner).toBeVisible({ timeout: 5000 })
+    await expect(banner).toContainText(/reset link/i)
+  })
+})
+
+test.describe('Reset-password page', () => {
+  test('shows an error state when the token query parameter is missing', async ({ page }) => {
+    await page.goto('/reset-password')
+
+    await expect(page.getByTestId('reset-password-missing-token')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('input#password')).toHaveCount(0)
+  })
+
+  test('renders the new-password form when a token is present', async ({ page }) => {
+    await page.goto('/reset-password?token=sample-token-value')
+
+    await expect(page.locator('input#password')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('input#confirmPassword')).toBeVisible()
+    await expect(page.getByRole('button', { name: /reset password/i })).toBeVisible()
+  })
+
+  test('client-side validation: mismatched passwords show an error', async ({ page }) => {
+    await page.goto('/reset-password?token=sample-token-value')
+
+    await page.locator('input#password').fill('newpassword123')
+    await page.locator('input#confirmPassword').fill('different456')
+    await page.getByRole('button', { name: /reset password/i }).click()
+
+    const errorBanner = page.getByTestId('reset-password-error')
+    await expect(errorBanner).toBeVisible({ timeout: 3000 })
+    await expect(errorBanner).toContainText(/do not match/i)
+  })
+
+  test('successful reset shows a success banner (backend mocked)', async ({ page }) => {
+    await page.route('**/api/auth/reset-password', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'Your password has been reset. You can now log in.',
+        }),
+      })
+    })
+
+    await page.goto('/reset-password?token=sample-token-value')
+    await page.locator('input#password').fill('newpassword123')
+    await page.locator('input#confirmPassword').fill('newpassword123')
+    await page.getByRole('button', { name: /reset password/i }).click()
+
+    await expect(page.getByTestId('reset-password-success')).toBeVisible({ timeout: 5000 })
   })
 })

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,6 @@
 // Real API client for connecting to the backend
 import { debugLog } from './debug'
-import { User, LoginCredentials, RegisterData, TokenResponse } from './types'
+import { User, LoginCredentials, RegisterData, TokenResponse, RequestResetData, ResetPasswordData, ResetResponse } from './types'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -218,6 +218,38 @@ export const apiClient = {
       }
       throw error
     }
+  },
+
+  requestPasswordReset: async (data: RequestResetData): Promise<ResetResponse> => {
+    const response = await fetch('/api/auth/request-reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      const errorMessage = errorData.error || errorData.detail || errorData.message || 'Unable to send reset email'
+      throw new Error(errorMessage)
+    }
+
+    return response.json()
+  },
+
+  resetPassword: async (data: ResetPasswordData): Promise<ResetResponse> => {
+    const response = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      const errorMessage = errorData.error || errorData.detail || errorData.message || 'Unable to reset password'
+      throw new Error(errorMessage)
+    }
+
+    return response.json()
   },
 
   logout: async (): Promise<void> => {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -32,4 +32,17 @@ export interface TokenResponse {
   user: User
 }
 
+export interface RequestResetData {
+  email: string
+}
+
+export interface ResetPasswordData {
+  token: string
+  new_password: string
+}
+
+export interface ResetResponse {
+  message: string
+}
+
 


### PR DESCRIPTION
## Summary

Replaces the insecure legacy `/forgot-password` endpoint (which allowed any caller to overwrite a user's password by supplying their email) with a proper email-verified, token-based reset flow end to end.

Fixes #343
Source: Canny (score=3)

## Changes

### Backend
- `POST /api/auth/users/request-reset` (`PasswordReset` schema)
  - Always returns the generic message `"If an account exists with this email, a reset link has been sent."` to prevent email enumeration.
  - When the user exists and is password-based: invalidates any previous unused tokens, generates a `secrets.token_urlsafe(32)` token with a 1-hour expiry, persists a `PasswordResetToken`, and dispatches a reset email via `send_password_reset_email`.
- `POST /api/auth/users/reset-password` (`PasswordResetConfirm` schema)
  - Validates the token exists, is not expired, and has not been used (with specific error messages).
  - Rejects the request if the account is OAuth-only.
  - Hashes the new password with `auth_service.get_password_hash_async` and marks `used_at` on the token.
- New `PasswordResetToken` model (FK to `users` with `ON DELETE CASCADE`, explicit indexes on `token` and `user_id`, unique constraint on `token`).
- New idempotent Alembic migration `2026_04_05_1200-add_password_reset_tokens` (down-revision `add_enhanced_persona_fields`).
- Replaced the stub `common.services.email_service` with a real async SMTP implementation (STARTTLS, run inside a thread executor — matching the async pattern in `common.security.passwords`) and a `send_password_reset_email` helper that builds a styled HTML email.
- Wired SMTP settings (`smtp_server`, `smtp_port`, `smtp_username`, `smtp_password`, `from_email`, `from_name`) into `common.config.Settings`.
- Removed the insecure `/forgot-password` endpoint and the `PasswordResetRequest` schema.

### Frontend
- New `/forgot-password` page — email-only request form matching the existing dark gradient auth theme, with loading / success / error states.
- New `/reset-password` page — reads `?token=` via `useSearchParams`, shows an error state when the token is missing, validates password length and match client-side, and shows a success banner with a link back to `/login`.
- New Next.js proxy routes `app/api/auth/request-reset/route.ts` and `app/api/auth/reset-password/route.ts` (no cookie rewriting — these endpoints don't create sessions).
- New typed API client helpers `apiClient.requestPasswordReset` / `apiClient.resetPassword` plus supporting types in `lib/types.ts`.
- Login page already had a "Forgot password?" link to `/forgot-password` (#363); this PR makes it land on a working flow.

## Tests added

### Backend unit / integration (`backend/tests/modules/auth/test_password_reset.py`)
- `request-reset` returns the generic message for unknown emails, issues no token, sends no email.
- `request-reset` happy path creates a token with a future expiry and dispatches an email whose link embeds the token.
- `request-reset` is case-insensitive on email.
- `request-reset` invalidates previous unused tokens for the same user.
- `reset-password` happy path updates the password (verified by logging in with the new credentials and rejection of the old one) and marks `used_at`.
- `reset-password` rejects unknown, reused, and expired tokens, and passwords shorter than 6 chars (422 from pydantic).
- Regression: old `/forgot-password` endpoint is gone.
- Updated existing `test_email_normalization` forgot-password case-insensitivity test to target `/request-reset`.

### Playwright E2E (`frontend/e2e/forgot-password-link.spec.ts`)
- Login page has a visible "Forgot password?" link that navigates to `/forgot-password` (retained).
- Forgot-password page renders the new email-only form (no `confirmEmail`/`newPassword` fields).
- Submitting the request form shows the generic success banner (backend mocked via `page.route`).
- Reset-password page shows the missing-token error state when no token is present.
- Reset-password page renders the new-password form when a token is present, validates mismatched passwords client-side, and shows the success banner on a mocked successful reset.

## Test plan
- [ ] Backend unit tests pass (`pytest backend/tests/modules/auth/test_password_reset.py`)
- [ ] Frontend lint passes
- [ ] Playwright E2E tests pass
- [ ] Manual: request a reset for a known email, click the emailed link, set a new password, log in with new credentials
- [ ] Manual: verify reused/expired/invalid tokens all produce clear errors
- [ ] Manual: verify requesting for an unknown email still returns the generic success message (no enumeration)

Generated by Ralph Loop iteration 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email-based password reset using secure time-limited tokens
  * Request reset via a simplified "Forgot Password" form (email only)
  * Client "Reset Password" page to set a new password from a tokenized link
  * Sending of reset emails via configurable SMTP settings and outbound email service
  * Frontend API endpoints to proxy reset requests to the backend

* **Tests**
  * Comprehensive unit and integration tests for request and redemption flows
  * End-to-end tests covering the full forgot-password → reset-password journey
<!-- end of auto-generated comment: release notes by coderabbit.ai -->