### PR TITLE
fix: hide feedback widget on student simulation page (#371)

### DIFF
--- a/frontend/components/DraggableFeedback.tsx
+++ b/frontend/components/DraggableFeedback.tsx
@@ -6,6 +6,14 @@ import { MessageCircle, Minimize2, X } from "lucide-react"
 import CannyFeedback from "./CannyFeedback"
 import { useAuth } from "@/lib/auth-context"
 
+/**
+ * Floating, draggable feedback widget rendered site-wide for authenticated users.
+ *
+ * Renders a collapsible pill that expands into a Canny-backed feedback card.
+ * The widget is intentionally suppressed on the student simulation runtime
+ * route (`/student/run-simulation/*`) to prevent it from overlapping the chat
+ * composer and causing mis-clicks on "Submit for Grading" — see issue #371.
+ */
 export default function DraggableFeedback() {
   const { user } = useAuth()
   const pathname = usePathname()
@@ -43,7 +51,11 @@ export default function DraggableFeedback() {
     }
   }, [])
 
-  // Direct DOM manipulation for butter-smooth drag
+  /**
+   * Drags the widget by mutating the container's style directly, bypassing
+   * React re-renders for a smooth 60fps drag. Final position is committed to
+   * React state in `handleMouseUp`.
+   */
   const handleMouseMove = useCallback((e: MouseEvent) => {
     if (!dragInfo.current.isDragging || !containerRef.current) return
 
@@ -73,6 +85,11 @@ export default function DraggableFeedback() {
     containerRef.current.style.top = `${boundedY}px`
   }, [])
 
+  /**
+   * Ends an active drag: detaches window listeners and commits the final
+   * DOM-driven position back into React state so subsequent renders stay
+   * in sync with where the user dropped the widget.
+   */
   const handleMouseUp = useCallback(() => {
     if (!dragInfo.current.isDragging) return
     
@@ -88,6 +105,11 @@ export default function DraggableFeedback() {
     }
   }, [handleMouseMove])
 
+  /**
+   * Starts a drag on left-click: records the pointer origin and the widget's
+   * initial position so `handleMouseMove` can compute deltas, then attaches
+   * window-level mousemove/mouseup listeners for the duration of the drag.
+   */
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.button !== 0) return 
     
@@ -114,6 +136,11 @@ export default function DraggableFeedback() {
     window.addEventListener("mouseup", handleMouseUp)
   }
 
+  /**
+   * Expands the pill into the full feedback card, anchoring the card's
+   * bottom-left corner to the pill's position so the expansion grows upward.
+   * No-ops if the click was actually the tail end of a drag (>5px movement).
+   */
   const handleOpen = (e: React.MouseEvent) => {
     // Use Mouse Coordinates to check for drag (more reliable than DOM position)
     const movedX = Math.abs(e.clientX - dragInfo.current.clickStartX)
@@ -147,6 +174,11 @@ export default function DraggableFeedback() {
     setPosition({ x: newX, y: newY })
   }
 
+  /**
+   * Collapses the card back to the pill and restores the pre-open position
+   * captured in `lastPillPosition`, so the pill returns to exactly where the
+   * user left it before expanding.
+   */
   const handleClose = (e: React.MouseEvent) => {
     e.stopPropagation() // Stop event bubbling
     setIsOpen(false)

--- a/frontend/components/DraggableFeedback.tsx
+++ b/frontend/components/DraggableFeedback.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback } from "react"
+import { usePathname } from "next/navigation"
 import { MessageCircle, Minimize2, X } from "lucide-react"
 import CannyFeedback from "./CannyFeedback"
 import { useAuth } from "@/lib/auth-context"
 
 export default function DraggableFeedback() {
   const { user } = useAuth()
+  const pathname = usePathname()
+  const isOnSimulationRoute = pathname?.startsWith("/student/run-simulation/") ?? false
   const [isOpen, setIsOpen] = useState(false)
   
   // React state for committed position (used for rendering)
@@ -151,6 +154,7 @@ export default function DraggableFeedback() {
   }
 
   if (!user) return null
+  if (isOnSimulationRoute) return null
 
   return (
     <div

--- a/frontend/e2e/feedback-widget-hidden-on-simulation.spec.ts
+++ b/frontend/e2e/feedback-widget-hidden-on-simulation.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * E2E tests for issue #371 — the floating feedback widget must not overlap
+ * the chat composer on the student simulation runtime page.
+ *
+ * The fix hides `DraggableFeedback` entirely on `/student/run-simulation/*`
+ * so students cannot accidentally mis-click "Submit for Grading" when
+ * reaching for the send button.
+ */
+
+import { test, expect, Page } from '@playwright/test'
+
+/** Mock the start-simulation endpoint so the sim page renders the composer. */
+async function mockStartSimulation(page: Page, turnCount = 3, timeoutTurns = 15) {
+  await page.route('**/student-simulation-instances/**/start-simulation', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user_progress_id: 1,
+        instance_id: 123,
+        current_scene: {
+          id: 1,
+          scene_order: 1,
+          title: 'Test Scene',
+          description: 'Test',
+          timeout_turns: timeoutTurns,
+          personas: [],
+        },
+        simulation: { id: 1, title: 'Test Sim', total_scenes: 1 },
+        simulation_status: 'in_progress',
+        is_resuming: true,
+        turn_count: turnCount,
+        conversation_history: [
+          {
+            id: 1,
+            sender: 'System',
+            text: 'Welcome.',
+            timestamp: new Date().toISOString(),
+            type: 'system',
+          },
+        ],
+        all_scenes: [{ id: 1, scene_order: 1, title: 'Test Scene', personas: [] }],
+      }),
+    }),
+  )
+}
+
+test.describe('Feedback widget visibility (issue #371)', () => {
+  test('feedback widget is hidden on the student simulation runtime page', async ({ page }) => {
+    await mockStartSimulation(page)
+
+    await page.goto('/student/run-simulation/test-instance-123')
+
+    // Chat composer loaded — use Submit button as a loaded-signal.
+    await expect(page.getByRole('button', { name: /submit for grading/i })).toBeVisible({
+      timeout: 10000,
+    })
+
+    // The Feedback pill/card must not be rendered on this route.
+    await expect(page.getByText('Feedback', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('Give Us Feedback')).toHaveCount(0)
+  })
+
+  test('feedback widget still renders on non-simulation pages', async ({ page }) => {
+    // Visit a route outside /student/run-simulation/. If auth redirects us
+    // away, the assertion below is skipped — we only care that the widget
+    // is not suppressed by the pathname guard when the pathname doesn't
+    // match the simulation prefix.
+    await page.goto('/dashboard')
+
+    // If the page actually rendered as /dashboard (user is authenticated in
+    // the test environment), the feedback pill should be present. Otherwise
+    // we skip — the important assertion is the suppression on the sim page.
+    if (page.url().includes('/dashboard')) {
+      await expect(page.getByText('Feedback', { exact: true })).toBeVisible({ timeout: 5000 })
+    } else {
+      test.skip(true, 'Not authenticated in test env; skipping positive check.')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Students were accidentally clicking **Submit for Grading** when reaching for the send button because the floating `DraggableFeedback` pill (`position: fixed`, `z-index: 9999`, bottom-right) overlapped the chat composer's send control on `/student/run-simulation/[instanceId]`. Two independent Canny reports flagged this — it's a (near-)irreversible action and a high-severity UX defect.

Fixes #371

## Changes

- `frontend/components/DraggableFeedback.tsx`: extend the existing early-return guard to also return `null` when `usePathname()` starts with `/student/run-simulation/`, so the widget is fully suppressed on the simulation runtime (including dynamic `[instanceId]` segments). Minimal, targeted fix following CodeRabbit's Phase 1 plan.

Phase 2 of CodeRabbit's plan (wrap Submit for Grading in an `AlertDialog`) was already implemented in PR #356 — existing tests in `frontend/e2e/submit-grading-confirmation.spec.ts` continue to guard that behavior as a second line of defense.

## Tests added

- `frontend/e2e/feedback-widget-hidden-on-simulation.spec.ts` (new):
  - asserts the Feedback pill/card does not render on `/student/run-simulation/[instanceId]`
  - asserts the Feedback pill still renders on `/dashboard` for authenticated users (skipped if test env isn't authenticated)

## Test plan

- [ ] `npx playwright test frontend/e2e/feedback-widget-hidden-on-simulation.spec.ts`
- [ ] Existing `submit-grading-confirmation.spec.ts` still passes
- [ ] Manual: open a student simulation → feedback pill is absent; navigate to `/dashboard` → pill returns

Generated by Ralph Loop iteration 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback widget is now suppressed on student simulation runtime pages for authenticated users to avoid interfering with the simulation experience.

* **Tests**
  * Added end-to-end tests that verify the feedback widget is hidden on simulation pages and present on dashboard pages when applicable, including appropriate timeouts and conditional assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->