### PR TITLE
fix: allow logged-in students to use cohort invite links

### DIFF
--- a/frontend/app/invite/[token]/page.tsx
+++ b/frontend/app/invite/[token]/page.tsx
@@ -1098,11 +1098,6 @@ export default function InviteLinkPage() {
                 Only student accounts can accept cohort invite links. Log out and sign in with a
                 student account to accept this invite.
               </p>
-              {user.email && (
-                <p className="text-gray-500 text-xs">
-                  Signed in as {user.email}
-                </p>
-              )}
               <Button
                 data-testid="invite-switch-account"
                 onClick={async () => {

--- a/frontend/app/invite/[token]/page.tsx
+++ b/frontend/app/invite/[token]/page.tsx
@@ -13,7 +13,7 @@ import { Users, Clock, AlertCircle, CheckCircle, Loader2, LogIn, UserPlus } from
 export default function InviteLinkPage() {
   const router = useRouter()
   const params = useParams()
-  const { user, isLoading: authLoading, login, register } = useAuth()
+  const { user, isLoading: authLoading, login, register, logout } = useAuth()
   const token = params.token as string
 
   const [inviteData, setInviteData] = useState<any>(null)
@@ -226,17 +226,15 @@ export default function InviteLinkPage() {
         // Check if already enrolled (backend returns this as success but with flag)
         if (response && response.already_enrolled) {
           setAccepting(false)
-          const safeErrorMessage = 'You are already a member of this cohort'
-          const sanitizedErrorCode = 'ERROR_ALREADY_ENROLLED'
-          setError(safeErrorMessage)
-          errorRef.current = safeErrorMessage
+          setAlreadyEnrolled(true)
+          setError(null)
+          errorRef.current = null
           try {
             if (typeof window !== 'undefined') {
-              sessionStorage.setItem('inviteError', sanitizedErrorCode)
+              sessionStorage.removeItem('inviteError')
             }
           } catch {}
-          // Don't redirect, don't show success screen, don't set alreadyEnrolled - just show the error message
-          return // Exit early to prevent further processing
+          return // Exit early to show the Already Enrolled success panel
         } else {
           // Clear error on success
           setError(null)
@@ -273,7 +271,8 @@ export default function InviteLinkPage() {
                 
                 if (retryResponse && retryResponse.already_enrolled) {
                   setAccepting(false)
-                  setError('You are already a member of this cohort')
+                  setAlreadyEnrolled(true)
+                  setError(null)
                   return
                 }
                 
@@ -356,10 +355,11 @@ export default function InviteLinkPage() {
             
             if (response && response.already_enrolled) {
               setAccepting(false)
-              setError('You are already a member of this cohort')
+              setAlreadyEnrolled(true)
+              setError(null)
               return
             }
-            
+
             setSuccess(true)
             setError(null)
             setTimeout(() => {
@@ -494,10 +494,11 @@ export default function InviteLinkPage() {
             
             if (response && response.already_enrolled) {
               setAccepting(false)
-              setError('You are already a member of this cohort')
+              setAlreadyEnrolled(true)
+              setError(null)
               return
             }
-            
+
             setSuccess(true)
             setError(null)
             setTimeout(() => {
@@ -570,17 +571,15 @@ export default function InviteLinkPage() {
       // Check if already enrolled
       if (response && response.already_enrolled) {
         setAccepting(false)
-        const safeErrorMessage = 'You are already a member of this cohort'
-        const sanitizedErrorCode = 'ERROR_ALREADY_ENROLLED'
-        setError(safeErrorMessage)
-        errorRef.current = safeErrorMessage
+        setAlreadyEnrolled(true)
+        setError(null)
+        errorRef.current = null
         try {
           if (typeof window !== 'undefined') {
-            sessionStorage.setItem('inviteError', sanitizedErrorCode)
+            sessionStorage.removeItem('inviteError')
           }
         } catch {}
-        // Don't redirect, don't show success screen, don't set alreadyEnrolled - just show the error message
-        return // Exit early to prevent further processing
+        return // Exit early to show the Already Enrolled success panel
       } else {
         // Clear error on success
         setError(null)
@@ -1090,11 +1089,32 @@ export default function InviteLinkPage() {
               <AlertCircle className="h-12 w-12 text-yellow-400 mx-auto" />
               <h3 className="text-xl font-bold text-white">Professors Cannot Join</h3>
               <p className="text-gray-400 text-sm">
-                Only students can accept cohort invite links. Professors cannot join cohorts as students.
+                You are currently signed in as <strong className="text-white">{user.email}</strong>.
+                Only student accounts can accept cohort invite links. Log out and sign in with a
+                student account to accept this invite.
               </p>
+              {user.email && (
+                <p className="text-gray-500 text-xs">
+                  Signed in as {user.email}
+                </p>
+              )}
               <Button
-                onClick={() => router.push("/professor/cohorts")}
+                data-testid="invite-switch-account"
+                onClick={async () => {
+                  try {
+                    await logout()
+                  } catch (e) {
+                    console.error('[Invite] Logout failed:', e)
+                  }
+                }}
                 className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all"
+              >
+                Log in as Student
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => router.push("/professor/cohorts")}
+                className="w-full bg-transparent border-gray-600 text-gray-300 hover:bg-gray-800 hover:text-white"
               >
                 Go to Cohorts
               </Button>

--- a/frontend/app/invite/[token]/page.tsx
+++ b/frontend/app/invite/[token]/page.tsx
@@ -227,6 +227,7 @@ export default function InviteLinkPage() {
         if (response && response.already_enrolled) {
           setAccepting(false)
           setAlreadyEnrolled(true)
+          setSuccess(true)
           setError(null)
           errorRef.current = null
           try {
@@ -272,6 +273,7 @@ export default function InviteLinkPage() {
                 if (retryResponse && retryResponse.already_enrolled) {
                   setAccepting(false)
                   setAlreadyEnrolled(true)
+                  setSuccess(true)
                   setError(null)
                   return
                 }
@@ -356,6 +358,7 @@ export default function InviteLinkPage() {
             if (response && response.already_enrolled) {
               setAccepting(false)
               setAlreadyEnrolled(true)
+              setSuccess(true)
               setError(null)
               return
             }
@@ -495,6 +498,7 @@ export default function InviteLinkPage() {
             if (response && response.already_enrolled) {
               setAccepting(false)
               setAlreadyEnrolled(true)
+              setSuccess(true)
               setError(null)
               return
             }
@@ -572,6 +576,7 @@ export default function InviteLinkPage() {
       if (response && response.already_enrolled) {
         setAccepting(false)
         setAlreadyEnrolled(true)
+        setSuccess(true)
         setError(null)
         errorRef.current = null
         try {
@@ -1105,6 +1110,9 @@ export default function InviteLinkPage() {
                     await logout()
                   } catch (e) {
                     console.error('[Invite] Logout failed:', e)
+                  } finally {
+                    setLoginLoading(false)
+                    setAuthMode("login")
                   }
                 }}
                 className="w-full btn-gradient text-white border-0 shadow-lg hover:shadow-xl transition-all"

--- a/frontend/components/RoleBasedRedirect.tsx
+++ b/frontend/components/RoleBasedRedirect.tsx
@@ -26,7 +26,7 @@ export default function RoleBasedRedirect({ children }: RoleBasedRedirectProps) 
       if (currentPath === '/') {
         return
       }
-      const skipRedirectPaths = ['/login', '/signup', '/auth']
+      const skipRedirectPaths = ['/login', '/signup', '/auth', '/invite']
       if (skipRedirectPaths.some(path => currentPath.startsWith(path))) {
         return
       }

--- a/frontend/e2e/invite-logged-in-student.spec.ts
+++ b/frontend/e2e/invite-logged-in-student.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E tests for issue #373 — Logged-in students must be able to use a cohort
+ * invite link without logging out first.
+ *
+ * The fix:
+ *  1. Exempts `/invite` from `RoleBasedRedirect` so authenticated users stay
+ *     on the page long enough for the auto-accept effect to fire.
+ *  2. Shows the "Already Enrolled" success panel (instead of an error) when
+ *     the backend returns `already_enrolled: true`.
+ *  3. Adds a "Log in as Student" button for authenticated non-student users
+ *     so they can switch accounts without manually navigating away.
+ */
+
+import { test, expect, Page } from '@playwright/test'
+
+const TOKEN = 'test-invite-token-123'
+
+const INVITE_DATA = {
+  token: TOKEN,
+  cohort: { id: 1, title: 'Fall 2025 Marketing', description: 'Intro cohort' },
+  professor: { name: 'Prof. Smith', email: 'smith@example.edu' },
+  invite_type: 'MULTI_USE',
+  expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+  uses_left: null,
+}
+
+function mockStudentUser(page: Page) {
+  return page.route('**/api/auth/me', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 42,
+        user_id: 'u_42',
+        email: 'student@example.edu',
+        full_name: 'Test Student',
+        username: 'test_student',
+        bio: null,
+        avatar_url: null,
+        role: 'student',
+        is_active: true,
+        is_verified: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+    }),
+  )
+}
+
+function mockProfessorUser(page: Page) {
+  return page.route('**/api/auth/me', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 99,
+        user_id: 'u_99',
+        email: 'prof@example.edu',
+        full_name: 'Prof. User',
+        username: 'prof_user',
+        bio: null,
+        avatar_url: null,
+        role: 'professor',
+        is_active: true,
+        is_verified: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+    }),
+  )
+}
+
+function mockValidateInvite(page: Page) {
+  return page.route(`**/invites/${TOKEN}`, (route, request) => {
+    if (request.method() !== 'GET') return route.fallback()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(INVITE_DATA),
+    })
+  })
+}
+
+function mockAcceptInvite(page: Page, body: Record<string, any>) {
+  return page.route(`**/invites/${TOKEN}/accept`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+test.describe('Invite link flow for logged-in users (issue #373)', () => {
+  test('logged-in student is NOT redirected away from /invite and auto-accepts', async ({
+    page,
+  }) => {
+    await mockStudentUser(page)
+    await mockValidateInvite(page)
+    await mockAcceptInvite(page, {
+      success: true,
+      cohort_id: 1,
+      already_enrolled: false,
+    })
+
+    await page.goto(`/invite/${TOKEN}`)
+
+    // We must remain on /invite — RoleBasedRedirect should not bounce the
+    // authenticated student to /student/dashboard before auto-accept runs.
+    await expect(page).toHaveURL(new RegExp(`/invite/${TOKEN}`))
+
+    // Cohort details should render.
+    await expect(page.getByText('Fall 2025 Marketing')).toBeVisible({ timeout: 10000 })
+
+    // The auto-accept effect fires, then redirects to the dashboard shortly.
+    await expect(page.getByText(/Successfully Joined/i)).toBeVisible({ timeout: 15000 })
+  })
+
+  test('already-enrolled student sees the success "Already Enrolled" panel, not an error', async ({
+    page,
+  }) => {
+    await mockStudentUser(page)
+    await mockValidateInvite(page)
+    await mockAcceptInvite(page, {
+      success: true,
+      cohort_id: 1,
+      already_enrolled: true,
+    })
+
+    await page.goto(`/invite/${TOKEN}`)
+
+    await expect(page.getByRole('heading', { name: /Already Enrolled/i })).toBeVisible({
+      timeout: 15000,
+    })
+    await expect(page.getByRole('button', { name: /Go to Dashboard/i })).toBeVisible()
+
+    // Regression: the old error panel must NOT render.
+    await expect(page.getByText(/Cannot Join/i)).toHaveCount(0)
+  })
+
+  test('logged-in professor sees Switch Account button that logs out', async ({ page }) => {
+    await mockProfessorUser(page)
+    await mockValidateInvite(page)
+
+    let logoutCalled = false
+    await page.route('**/api/auth/logout', route => {
+      logoutCalled = true
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto(`/invite/${TOKEN}`)
+
+    // Non-student panel rendered.
+    await expect(page.getByText(/Professors Cannot Join/i)).toBeVisible({ timeout: 10000 })
+
+    const switchBtn = page.getByTestId('invite-switch-account')
+    await expect(switchBtn).toBeVisible()
+    await switchBtn.click()
+
+    // Logout endpoint should have been hit.
+    await expect.poll(() => logoutCalled, { timeout: 5000 }).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Logged-in students previously had to log out before using a cohort invite link. The root cause was that the global `RoleBasedRedirect` wrapper bounced authenticated users away from `/invite/[token]` before the page's auto-accept effect could run.

Fixes #373 (Canny score=1, post_id=69acd4b9918d85aa8f8511c8)

## Changes
- `frontend/components/RoleBasedRedirect.tsx`: add `/invite` to `skipRedirectPaths` so authenticated users remain on the invite page.
- `frontend/app/invite/[token]/page.tsx`: when the backend returns `already_enrolled=true`, call `setAlreadyEnrolled(true)` so the existing green "Already Enrolled" success panel renders instead of treating it as an error. Applied to the auto-accept effect, its 401 retry path, both the post-login and post-registration explicit-accept branches, and `handleAccept`.
- `frontend/app/invite/[token]/page.tsx`: for authenticated non-student users, show the signed-in email and a new "Log in as Student" button wired to `logout()` from `useAuth()`, leaving the user on the same invite URL so they can sign in with a student account. The existing "Go to Cohorts" button is kept as a secondary action.

## Tests added
Playwright E2E tests in `frontend/e2e/invite-logged-in-student.spec.ts`:
- Authenticated student stays on `/invite/[token]` (not bounced by `RoleBasedRedirect`), auto-accept fires, "Successfully Joined" renders.
- `already_enrolled=true` response → green "Already Enrolled" panel with "Go to Dashboard" button (regression check: old "Cannot Join" error panel must not render).
- Authenticated professor sees "Professors Cannot Join" and a Switch Account button that calls the logout endpoint.

## Test plan
- [x] Playwright E2E tests pass in CI
- [ ] Manual: sign in as student in tab A, open invite link in tab B → auto-enroll succeeds without logout
- [ ] Manual: re-open same invite as already-enrolled student → green "Already Enrolled" panel shows
- [ ] Manual: sign in as professor, open invite link → "Log in as Student" button logs out and reveals login/signup forms on the same invite URL

Generated by Ralph Loop iteration 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved invite experience: clearer "Already Enrolled" state and success handling
  * Added "Log in as Student" account-switch action and a back button to professor cohorts

* **Bug Fixes**
  * Prevented role-based redirects from interfering with invite links

* **Tests**
  * Added end-to-end tests covering logged-in invite flows and account-switch behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->