### PR TITLE
fix: make Read documentation card clickable on professor dashboard

### DIFF
--- a/frontend/app/professor/dashboard/page.tsx
+++ b/frontend/app/professor/dashboard/page.tsx
@@ -28,6 +28,7 @@ import {
 import RoleBasedSidebar from "@/components/RoleBasedSidebar"
 import { useAuth } from "@/lib/auth-context"
 import { apiClient, Agent, Scenario } from "@/lib/api"
+import { DOCUMENTATION_URL } from "@/lib/constants"
 
 
 export default function Dashboard() {
@@ -696,18 +697,25 @@ export default function Dashboard() {
               </Link>
 
               {/* Read our documentation */}
-              <Card className="card-elevated bg-white/90 backdrop-blur-sm border-gray-200/60 cursor-pointer overflow-hidden h-full hover:shadow-lg transition-shadow">
-                <div className="w-full h-30 overflow-hidden rounded-t-lg">
-                  <img src="/createsim.png" alt="Read documentation" className="h-full w-full object-cover" />
-                </div>
-                <CardHeader className="pb-3 pt-3">
-                  <CardTitle className="text-base text-gray-800">Read documentation</CardTitle>
-                  <p className="text-sm text-gray-700 font-medium mt-1">Read our documentation</p>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-xs text-gray-600">Get guides, and further understand the platform</p>
-                </CardContent>
-              </Card>
+              <a
+                href={DOCUMENTATION_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="read-documentation-link"
+              >
+                <Card className="card-elevated bg-white/90 backdrop-blur-sm border-gray-200/60 cursor-pointer overflow-hidden h-full hover:shadow-lg transition-shadow">
+                  <div className="w-full h-30 overflow-hidden rounded-t-lg">
+                    <img src="/createsim.png" alt="Read documentation" className="h-full w-full object-cover" />
+                  </div>
+                  <CardHeader className="pb-3 pt-3">
+                    <CardTitle className="text-base text-gray-800">Read documentation</CardTitle>
+                    <p className="text-sm text-gray-700 font-medium mt-1">Read our documentation</p>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-xs text-gray-600">Get guides, and further understand the platform</p>
+                  </CardContent>
+                </Card>
+              </a>
             </div>
           </div>
 

--- a/frontend/e2e/documentation-card-link.spec.ts
+++ b/frontend/e2e/documentation-card-link.spec.ts
@@ -13,17 +13,18 @@ import { test, expect } from '@playwright/test'
 const DASHBOARD_URL = '/professor/dashboard'
 
 test.describe('Professor dashboard "Read documentation" card (issue #375)', () => {
-  test('renders as an external link with the documentation URL and safe rel attrs', async ({
-    page,
-  }) => {
+  // Shared auth/navigation setup. If middleware redirects us away from the
+  // dashboard, skip — the assertions below require the dashboard to render.
+  test.beforeEach(async ({ page }) => {
     await page.goto(DASHBOARD_URL)
-
-    // If auth middleware redirected us away from the dashboard, skip — the
-    // positive assertion requires the dashboard to actually render.
     if (!page.url().includes('/professor/dashboard')) {
       test.skip(true, 'Not authenticated in test env; dashboard not reachable.')
     }
+  })
 
+  test('renders as an external link with the documentation URL and safe rel attrs', async ({
+    page,
+  }) => {
     const link = page.getByTestId('read-documentation-link')
     await expect(link).toBeVisible({ timeout: 5000 })
 
@@ -45,12 +46,6 @@ test.describe('Professor dashboard "Read documentation" card (issue #375)', () =
   test('regression: documentation card is not a bare, non-navigating <Card>', async ({
     page,
   }) => {
-    await page.goto(DASHBOARD_URL)
-
-    if (!page.url().includes('/professor/dashboard')) {
-      test.skip(true, 'Not authenticated in test env; dashboard not reachable.')
-    }
-
     // There must be exactly one "Read documentation" anchor wrapper — the old
     // broken behavior rendered the title without any enclosing <a>.
     const anchors = page.locator('a[data-testid="read-documentation-link"]')

--- a/frontend/e2e/documentation-card-link.spec.ts
+++ b/frontend/e2e/documentation-card-link.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E test for issue #375 — the "Read documentation" card on the Professor
+ * Dashboard must be a clickable external link that opens the docs site in a
+ * new tab. Previously the card was rendered as a bare <Card> with no link
+ * wrapper, so clicking it did nothing.
+ *
+ * The fix wraps the card in an <a target="_blank" rel="noopener noreferrer">
+ * pointing at DOCUMENTATION_URL from frontend/lib/constants.ts.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const DASHBOARD_URL = '/professor/dashboard'
+
+test.describe('Professor dashboard "Read documentation" card (issue #375)', () => {
+  test('renders as an external link with the documentation URL and safe rel attrs', async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL)
+
+    // If auth middleware redirected us away from the dashboard, skip — the
+    // positive assertion requires the dashboard to actually render.
+    if (!page.url().includes('/professor/dashboard')) {
+      test.skip(true, 'Not authenticated in test env; dashboard not reachable.')
+    }
+
+    const link = page.getByTestId('read-documentation-link')
+    await expect(link).toBeVisible({ timeout: 5000 })
+
+    // Must be a real anchor pointing to an external https URL.
+    const href = await link.getAttribute('href')
+    expect(href).toBeTruthy()
+    expect(href).toMatch(/^https?:\/\//)
+
+    // Must open in a new tab with safe rel attributes.
+    await expect(link).toHaveAttribute('target', '_blank')
+    const rel = (await link.getAttribute('rel')) ?? ''
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+
+    // The card title should still be rendered inside the link wrapper.
+    await expect(link.getByText('Read documentation')).toBeVisible()
+  })
+
+  test('regression: documentation card is not a bare, non-navigating <Card>', async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL)
+
+    if (!page.url().includes('/professor/dashboard')) {
+      test.skip(true, 'Not authenticated in test env; dashboard not reachable.')
+    }
+
+    // There must be exactly one "Read documentation" anchor wrapper — the old
+    // broken behavior rendered the title without any enclosing <a>.
+    const anchors = page.locator('a[data-testid="read-documentation-link"]')
+    await expect(anchors).toHaveCount(1)
+  })
+})

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared application constants.
+ *
+ * Centralize values here so they can be updated in one place and reused
+ * across the frontend.
+ */
+
+// External Mintlify documentation site.
+// TODO: verify/update with the final deployed Mintlify URL once product confirms.
+export const DOCUMENTATION_URL = 'https://docs.naible.com'


### PR DESCRIPTION
## Summary
Fixes the Professor Dashboard "Read documentation" card, which had `cursor-pointer` styling but no link wrapper — clicking it did nothing. The card is now wrapped in an `<a target="_blank" rel="noopener noreferrer">` pointing at a new centralized `DOCUMENTATION_URL` constant, matching the pattern used by the sibling "Create simulation" and "Set up a cohort" cards.

Fixes #375

## Changes
- Add `frontend/lib/constants.ts` exporting `DOCUMENTATION_URL` (placeholder `https://docs.naible.com`, flagged with a TODO to verify the final Mintlify subdomain with product).
- Wrap the "Read documentation" `<Card>` in `frontend/app/professor/dashboard/page.tsx` with an external `<a>` tag using `target="_blank"` and `rel="noopener noreferrer"`.
- Add `data-testid="read-documentation-link"` on the anchor for stable E2E targeting.

## Tests added
- `frontend/e2e/documentation-card-link.spec.ts`:
  - Card renders as a real anchor with an https href
  - `target="_blank"` set and `rel` contains `noopener` + `noreferrer`
  - Card title text still visible inside the wrapper
  - Regression: exactly one `a[data-testid="read-documentation-link"]` wrapper exists
  - Tests skip gracefully if auth redirects away from the dashboard in the current env

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass (`documentation-card-link.spec.ts`)
- [ ] Manual: log in as professor, click "Read documentation" card → opens docs site in a new tab

Generated by Ralph Loop iteration 6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the "Read documentation" card on the Professor Dashboard to function as a proper external link that opens in a new tab.

* **Tests**
  * Added test coverage for the documentation link functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->