### PR TITLE
fix: validate scene ownership in save_message endpoint

### DIFF
--- a/backend/modules/simulation/router.py
+++ b/backend/modules/simulation/router.py
@@ -245,6 +245,10 @@ async def save_message(
             request.message_type,
             request.session_id
         )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ForbiddenError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     except ValueError as e:
         # session_id is required - fail loudly with clear error message
         logger.error(f"save_message failed: {e}", extra={"user_id": current_user.id, "user_progress_id": request.user_progress_id, "scene_id": request.scene_id})

--- a/backend/modules/simulation/service.py
+++ b/backend/modules/simulation/service.py
@@ -352,6 +352,12 @@ class SimulationService:
         if user_progress.user_id != user_id:
             raise ForbiddenError("Access denied: You can only save messages to your own simulation")
 
+        scene = self.repository.get_scene_by_id(scene_id)
+        if not scene:
+            raise NotFoundError("Scene not found")
+        if scene.simulation_id != user_progress.simulation_id:
+            raise ForbiddenError("scene_id does not belong to this simulation")
+
         next_message_order = self.repository.get_next_message_order(user_progress_id)
 
         # Generate a session_id for system messages if not provided by caller

--- a/backend/tests/modules/simulation/test_router.py
+++ b/backend/tests/modules/simulation/test_router.py
@@ -463,3 +463,57 @@ class TestSaveMessageEndpoint:
             assert data["message_id"] == 123
         finally:
             app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_save_message_maps_not_found_and_forbidden(
+        self, async_client, monkeypatch, mock_student_user
+    ):
+        """
+        Verify architecture rule: routers map domain exceptions to HTTP codes.
+        - `NotFoundError` → 404
+        - `ForbiddenError` → 403
+        """
+
+        async def override_get_current_user():
+            return mock_student_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+
+        class FailingService:
+            def __init__(self, db):
+                self.db = db
+
+            call_count = 0
+
+            def save_message(self, user_id, user_progress_id, scene_id,
+                             sender_name, message_content, message_type,
+                             session_id=None):
+                if FailingService.call_count == 0:
+                    FailingService.call_count += 1
+                    raise NotFoundError("Scene not found")
+                raise ForbiddenError("scene_id does not belong to this simulation")
+
+        import modules.simulation.router as simulation_router
+
+        monkeypatch.setattr(simulation_router, "SimulationService", FailingService)
+
+        try:
+            payload = {
+                "user_progress_id": 3,
+                "scene_id": 7,
+                "sender_name": "System",
+                "message_content": "Hello",
+                "message_type": "system",
+            }
+
+            # NotFoundError → 404
+            resp1 = await async_client.post("/api/simulation/save-message", json=payload)
+            assert resp1.status_code == status.HTTP_404_NOT_FOUND
+            assert "Scene not found" in resp1.json()["detail"]
+
+            # ForbiddenError → 403
+            resp2 = await async_client.post("/api/simulation/save-message", json=payload)
+            assert resp2.status_code == status.HTTP_403_FORBIDDEN
+            assert "does not belong" in resp2.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()

--- a/backend/tests/modules/simulation/test_router.py
+++ b/backend/tests/modules/simulation/test_router.py
@@ -482,14 +482,13 @@ class TestSaveMessageEndpoint:
         class FailingService:
             def __init__(self, db):
                 self.db = db
-
-            call_count = 0
+                self.call_count = 0
 
             def save_message(self, user_id, user_progress_id, scene_id,
                              sender_name, message_content, message_type,
                              session_id=None):
-                if FailingService.call_count == 0:
-                    FailingService.call_count += 1
+                if self.call_count == 0:
+                    self.call_count += 1
                     raise NotFoundError("Scene not found")
                 raise ForbiddenError("scene_id does not belong to this simulation")
 

--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -57,8 +57,6 @@ interface TimelineBucket {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
-
 function adminFetch<T>(path: string): Promise<T> {
   return fetch(buildApiUrl(`/api/admin/dashboard${path}`), {
     credentials: "include",


### PR DESCRIPTION
## Summary
- Add scene existence and ownership validation in the `save_message` service method to prevent cross-simulation access
- Fix missing `NotFoundError`/`ForbiddenError` exception handlers in the router's `save_message` endpoint
- Add test coverage for both new error paths

Fixes #311

## Changes
- **service.py**: After user ownership check, validate scene exists (`get_scene_by_id`) and belongs to the same simulation as `user_progress`
- **router.py**: Add `NotFoundError → 404` and `ForbiddenError → 403` handlers before the existing `ValueError` handler
- **test_router.py**: Add `test_save_message_maps_not_found_and_forbidden` covering both 404 and 403 responses

## Tests added
- Scene not found → 404 response with "Scene not found" detail
- Scene from different simulation → 403 response with "does not belong" detail

## Test plan
- [x] Unit tests added following existing patterns
- [ ] Unit tests pass (CI)
- [ ] Lint passes (CI)
- [ ] Manual verification: attempt save_message with invalid scene_id returns 404
- [ ] Manual verification: attempt save_message with scene from another simulation returns 403

Generated by Ralph Loop iteration 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise error responses for simulation message saves, returning appropriate 404 and 403 statuses and clearer details
  * Validation added to ensure scenes belong to the caller’s simulation before saving messages

* **Tests**
  * Added tests verifying the new error-to-HTTP mappings for missing or unauthorized scenes

* **Chores**
  * Removed an unused environment-derived constant from the admin dashboard code
<!-- end of auto-generated comment: release notes by coderabbit.ai -->