### PR TITLE
fix: align professor_regrade_simulation auth with cohort-based pattern

### DIFF
--- a/backend/modules/professor/routers/professor_grading.py
+++ b/backend/modules/professor/routers/professor_grading.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 from datetime import datetime, timezone
 
 from common.db.core import get_db
-from common.db.models import User, StudentSimulationInstance, GradeHistory, UserProgress, ConversationLog, Scenario
+from common.db.models import User, StudentSimulationInstance, GradeHistory, UserProgress, ConversationLog
 from common.db.models.cohorts.cohort import CohortSimulation
 from common.services.cache_service import redis_manager
 from app.dependencies import require_professor, require_admin
@@ -526,27 +526,26 @@ async def professor_regrade_simulation(
         if not user_progress:
             raise HTTPException(status_code=404, detail="User progress not found")
 
-        # Get the simulation to check ownership
-        simulation = db.query(Scenario).filter(
-            Scenario.id == user_progress.simulation_id
+        # Get the instance with cohort relationship for authorization
+        existing_instance = db.query(StudentSimulationInstance).options(
+            selectinload(StudentSimulationInstance.cohort_assignment).joinedload(CohortSimulation.cohort)
+        ).filter(
+            StudentSimulationInstance.user_progress_id == user_progress_id
         ).first()
 
-        if not simulation:
-            raise HTTPException(status_code=404, detail="Simulation not found")
+        if not existing_instance:
+            raise HTTPException(status_code=404, detail="Simulation instance not found")
 
-        # Check if professor owns the simulation or is admin
-        if current_user.role != "admin" and simulation.created_by != current_user.id:
-            raise HTTPException(status_code=403, detail="Not authorized to regrade this simulation")
+        # Verify the professor has access through cohort ownership
+        if (not existing_instance.cohort_assignment or
+            not existing_instance.cohort_assignment.cohort or
+            existing_instance.cohort_assignment.cohort.created_by != current_user.id):
+            raise HTTPException(status_code=403, detail="Access denied")
 
         # Clear Redis cache
         cache_key = f"grading:{user_progress_id}"
         redis_manager.delete(cache_key)
         logger.info(f"Cleared Redis grading cache for user_progress_id={user_progress_id}")
-
-        # Clear existing AI grade from database
-        existing_instance = db.query(StudentSimulationInstance).filter(
-            StudentSimulationInstance.user_progress_id == user_progress_id
-        ).first()
 
         old_grade = None
         if existing_instance and existing_instance.ai_grade is not None:

--- a/backend/tests/test_professor_regrade_auth.py
+++ b/backend/tests/test_professor_regrade_auth.py
@@ -1,0 +1,244 @@
+"""
+Tests for professor_regrade_simulation cohort-based authorization.
+
+Verifies that:
+1. Professors can regrade simulations for students in their own cohorts
+2. Professors cannot regrade simulations for students in other professors' cohorts
+3. Missing cohort assignment results in access denied
+4. Missing instance returns 404
+5. Missing user progress returns 404
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import datetime, timezone
+
+
+class TestProfessorRegradeAuthorization:
+    """Tests for cohort-based auth in professor_regrade_simulation endpoint."""
+
+    def _make_user(self, id=1, role="professor", email="prof@test.com"):
+        user = MagicMock()
+        user.id = id
+        user.role = role
+        user.email = email
+        return user
+
+    def _make_user_progress(self, id=1, user_id=10, simulation_id=100):
+        up = MagicMock()
+        up.id = id
+        up.user_id = user_id
+        up.simulation_id = simulation_id
+        return up
+
+    def _make_instance(self, cohort_created_by=None, has_cohort_assignment=True, has_cohort=True):
+        instance = MagicMock()
+        instance.ai_grade = 85.0
+        instance.ai_feedback = "Good work"
+        instance.ai_graded_at = datetime.now(timezone.utc)
+        instance.user_progress_id = 1
+
+        if not has_cohort_assignment:
+            instance.cohort_assignment = None
+        elif not has_cohort:
+            instance.cohort_assignment = MagicMock()
+            instance.cohort_assignment.cohort = None
+        else:
+            instance.cohort_assignment = MagicMock()
+            instance.cohort_assignment.cohort = MagicMock()
+            instance.cohort_assignment.cohort.created_by = cohort_created_by
+
+        return instance
+
+    @pytest.mark.asyncio
+    async def test_regrade_allowed_for_cohort_owner(self):
+        """Professor who owns the cohort can regrade."""
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+        user_progress = self._make_user_progress()
+        instance = self._make_instance(cohort_created_by=1)
+
+        mock_db = MagicMock()
+
+        # First query returns user_progress, second returns instance
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = user_progress
+            elif model.__name__ == "StudentSimulationInstance":
+                q.options.return_value.filter.return_value.first.return_value = instance
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        mock_grading = {"overall_score": 90, "overall_feedback": "Great", "scenes": []}
+
+        with patch("modules.professor.routers.professor_grading.redis_manager") as mock_redis, \
+             patch("modules.simulation.services.grading_service.GradingService") as MockGS, \
+             patch("modules.simulation.repository.SimulationRepository"):
+            mock_gs_instance = MockGS.return_value
+            mock_gs_instance.get_simulation_grading = AsyncMock(return_value=mock_grading)
+
+            result = await professor_regrade_simulation(
+                user_progress_id=1,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert result["success"] is True
+        assert result["new_grade"] == 90
+
+    @pytest.mark.asyncio
+    async def test_regrade_denied_for_non_cohort_owner(self):
+        """Professor who does NOT own the cohort is denied."""
+        from fastapi import HTTPException
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+        user_progress = self._make_user_progress()
+        instance = self._make_instance(cohort_created_by=999)  # Different professor
+
+        mock_db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = user_progress
+            elif model.__name__ == "StudentSimulationInstance":
+                q.options.return_value.filter.return_value.first.return_value = instance
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await professor_regrade_simulation(
+                user_progress_id=1,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Access denied"
+
+    @pytest.mark.asyncio
+    async def test_regrade_denied_when_no_cohort_assignment(self):
+        """Access denied when instance has no cohort_assignment."""
+        from fastapi import HTTPException
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+        user_progress = self._make_user_progress()
+        instance = self._make_instance(has_cohort_assignment=False)
+
+        mock_db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = user_progress
+            elif model.__name__ == "StudentSimulationInstance":
+                q.options.return_value.filter.return_value.first.return_value = instance
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await professor_regrade_simulation(
+                user_progress_id=1,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Access denied"
+
+    @pytest.mark.asyncio
+    async def test_regrade_denied_when_cohort_is_none(self):
+        """Access denied when cohort_assignment.cohort is None."""
+        from fastapi import HTTPException
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+        user_progress = self._make_user_progress()
+        instance = self._make_instance(has_cohort=False)
+
+        mock_db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = user_progress
+            elif model.__name__ == "StudentSimulationInstance":
+                q.options.return_value.filter.return_value.first.return_value = instance
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await professor_regrade_simulation(
+                user_progress_id=1,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Access denied"
+
+    @pytest.mark.asyncio
+    async def test_regrade_404_when_no_instance(self):
+        """404 when no StudentSimulationInstance found for user_progress_id."""
+        from fastapi import HTTPException
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+        user_progress = self._make_user_progress()
+
+        mock_db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = user_progress
+            elif model.__name__ == "StudentSimulationInstance":
+                q.options.return_value.filter.return_value.first.return_value = None
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await professor_regrade_simulation(
+                user_progress_id=1,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Simulation instance not found"
+
+    @pytest.mark.asyncio
+    async def test_regrade_404_when_no_user_progress(self):
+        """404 when user_progress_id doesn't exist."""
+        from fastapi import HTTPException
+        from modules.professor.routers.professor_grading import professor_regrade_simulation
+
+        professor = self._make_user(id=1)
+
+        mock_db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model.__name__ == "UserProgress":
+                q.filter.return_value.first.return_value = None
+            return q
+
+        mock_db.query.side_effect = query_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await professor_regrade_simulation(
+                user_progress_id=999,
+                current_user=professor,
+                db=mock_db
+            )
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "User progress not found"


### PR DESCRIPTION
## Summary
- Replace scenario creator-based authorization in `professor_regrade_simulation` with the cohort-based pattern used by the other four endpoints in the same router
- Remove admin bypass and `Scenario` query that were inconsistent with the rest of the router

Fixes #265

## Changes
- Moved `StudentSimulationInstance` query before auth check with eager loading for `cohort_assignment -> cohort`
- Added 404 check for missing simulation instance
- Replaced `simulation.created_by` check with `cohort.created_by == current_user.id` pattern
- Removed unused `Scenario` import
- Removed admin role bypass to match other endpoints

## Tests added
- Regrade allowed for cohort owner (happy path)
- Regrade denied for non-cohort owner (403)
- Regrade denied when no cohort_assignment (403)
- Regrade denied when cohort is None (403)
- 404 when no simulation instance found
- 404 when user progress not found

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Manual verification: professor can regrade student in own cohort
- [ ] Manual verification: professor cannot regrade student in another professor's cohort

Generated by Ralph Loop iteration 8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated professor simulation regrading authorization to use cohort-based access control for improved security and consistency.
  * Improved error handling with more specific error messages for unauthorized access and missing simulation instances.

* **Tests**
  * Added comprehensive test coverage for simulation regrading authorization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->