### PR TITLE
fix: detect unrecoverable sandbox error in runCode

### DIFF
--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -189,7 +189,7 @@ export default function CodeEditor({
           !state &&
           /websocket|http 400|connection refused|connect call failed|server rejected/i.test(errStr)
 
-        if (state === 'destroyed' || state === 'error_unrecoverable') {
+        if (state === 'destroyed' || state === 'error_unrecoverable' || (state === 'error' && errStr === 'sandbox_error_unrecoverable')) {
           setSandboxStatus('destroyed')
           setError(null)
         } else if (state === 'archived' || state === 'stopped' || isTransientError) {

--- a/frontend/e2e/code-editor-sandbox-recovery.spec.ts
+++ b/frontend/e2e/code-editor-sandbox-recovery.spec.ts
@@ -34,7 +34,7 @@ function classifyResponse(response: {
   const isTransientError =
     !state && TRANSIENT_ERROR_REGEX.test(errStr)
 
-  if (state === 'destroyed' || state === 'error_unrecoverable') return 'destroyed'
+  if (state === 'destroyed' || state === 'error_unrecoverable' || (state === 'error' && errStr === 'sandbox_error_unrecoverable')) return 'destroyed'
   if (state === 'archived' || state === 'stopped' || isTransientError) return 'transient_poll'
   return 'show_error'
 }
@@ -102,6 +102,18 @@ test.describe('Response classification — sandbox_state handling', () => {
     expect(
       classifyResponse({ success: false, error: 'fatal', sandbox_state: 'error_unrecoverable' }),
     ).toBe('destroyed')
+  })
+
+  test('sandbox_state=error + sandbox_error_unrecoverable → destroyed', () => {
+    expect(
+      classifyResponse({ success: false, error: 'sandbox_error_unrecoverable', sandbox_state: 'error' }),
+    ).toBe('destroyed')
+  })
+
+  test('sandbox_state=error + other error → show_error (not destroyed)', () => {
+    expect(
+      classifyResponse({ success: false, error: 'some_other_error', sandbox_state: 'error' }),
+    ).toBe('show_error')
   })
 
   test('no sandbox_state + WebSocket error → transient_poll (fallback regex)', () => {
@@ -201,6 +213,30 @@ test.describe('CodeEditor component — sandbox recovery UI', () => {
     await page.click('button:has-text("Run")')
 
     // The destroyed/expired banner with Reload button should appear
+    await expect(page.locator('text=sandbox session has expired')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('button:has-text("Reload")')).toBeVisible()
+  })
+
+  test('sandbox_state=error with sandbox_error_unrecoverable shows reload banner', async ({ page }) => {
+    await page.route('**/api/proxy/api/simulation/execute-code', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          output: '',
+          error: 'sandbox_error_unrecoverable',
+          sandbox_state: 'error',
+        }),
+      })
+    })
+
+    await page.goto('/test/code-editor')
+    await page.waitForLoadState('networkidle')
+
+    await page.click('button:has-text("Run")')
+
+    // Should show destroyed/expired banner, not a generic error
     await expect(page.locator('text=sandbox session has expired')).toBeVisible({ timeout: 5000 })
     await expect(page.locator('button:has-text("Reload")')).toBeVisible()
   })


### PR DESCRIPTION
## Summary
- Extends `runCode` error detection to handle `sandbox_state='error'` + `error='sandbox_error_unrecoverable'`, which previously fell through to the generic error branch instead of showing the reload banner
- Aligns `runCode` with the polling function's existing `TERMINAL_STATES` logic

Fixes #318

## Changes
- `frontend/components/CodeEditor.tsx`: Added `(state === 'error' && errStr === 'sandbox_error_unrecoverable')` to the destroyed-detection conditional in `runCode`
- `frontend/e2e/code-editor-sandbox-recovery.spec.ts`: Updated `classifyResponse` helper to match, added unit tests and E2E test for the new case

## Tests added
- Unit: `sandbox_state=error + sandbox_error_unrecoverable → destroyed`
- Unit: `sandbox_state=error + other error → show_error` (negative case)
- E2E: Component shows reload banner (not generic error) for this error combination

## Test plan
- [x] Unit tests pass
- [x] Lint passes
- [x] Playwright E2E tests added
- [ ] Manual verification: trigger sandbox_state=error with sandbox_error_unrecoverable and confirm reload banner appears

Generated by Ralph Loop iteration 9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unrecoverable sandbox states. Users will now see a "sandbox session has expired" banner with a reload option instead of generic error messages when the sandbox encounters an unrecoverable condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->