### PR TITLE
fix: reset wake/poll state on scene change in CodeEditor

### DIFF
--- a/frontend/app/test/code-editor/page.tsx
+++ b/frontend/app/test/code-editor/page.tsx
@@ -5,19 +5,34 @@
  * Not linked from any navigation; only accessible at /test/code-editor.
  */
 
+import { useState } from 'react'
 import CodeEditor from '@/components/CodeEditor'
 
 export default function CodeEditorTestPage() {
+  const [sceneId, setSceneId] = useState(1)
+
   return (
-    <div style={{ height: '100vh' }}>
-      <CodeEditor
-        userProgressId={1}
-        sceneId={1}
-        starterCode={'print("hello world")'}
-        onSubmitToChat={() => {}}
-        sandboxAvailable={true}
-        personas={[{ id: 1, name: 'Test Persona' }]}
-      />
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '4px 8px', background: '#222', display: 'flex', gap: 8, alignItems: 'center' }}>
+        <span style={{ color: '#aaa', fontSize: 12 }}>Scene: {sceneId}</span>
+        <button
+          data-testid="switch-scene"
+          onClick={() => setSceneId((prev) => prev + 1)}
+          style={{ padding: '2px 8px', fontSize: 12, cursor: 'pointer' }}
+        >
+          Next Scene
+        </button>
+      </div>
+      <div style={{ flex: 1 }}>
+        <CodeEditor
+          userProgressId={1}
+          sceneId={sceneId}
+          starterCode={'print("hello world")'}
+          onSubmitToChat={() => {}}
+          sandboxAvailable={true}
+          personas={[{ id: 1, name: 'Test Persona' }]}
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -54,14 +54,16 @@ export default function CodeEditor({
   const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus>('ready')
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // Reset uncontrolled editor content when the scene or starter code changes
+  // Reset editor content and sandbox wake/poll state when the scene changes
   useEffect(() => {
     if (controlledCode === undefined) {
       setInternalCode(starterCode ?? '')
     }
     setOutput('')
     setError(null)
-  }, [sceneId, starterCode, controlledCode])
+    stopPolling()
+    setSandboxStatus('ready')
+  }, [sceneId, starterCode, controlledCode, stopPolling])
   const [showTargetDropdown, setShowTargetDropdown] = useState(false)
   const [submitTarget, setSubmitTarget] = useState<SubmitTarget>({
     type: 'all',

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -53,6 +53,8 @@ export default function CodeEditor({
   const [isRunning, setIsRunning] = useState(false)
   const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus>('ready')
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Incremented on every scene change; in-flight callbacks check this before mutating state
+  const sceneGenerationRef = useRef(0)
 
   // Stop polling for sandbox state
   const stopPolling = useCallback(() => {
@@ -62,16 +64,21 @@ export default function CodeEditor({
     }
   }, [])
 
-  // Reset editor content and sandbox wake/poll state when the scene changes
+  // Reset editor content when scene or starter code changes
   useEffect(() => {
     if (controlledCode === undefined) {
       setInternalCode(starterCode ?? '')
     }
     setOutput('')
     setError(null)
+  }, [sceneId, starterCode, controlledCode])
+
+  // Reset wake/poll state only when the scene changes (not on every keystroke)
+  useEffect(() => {
+    sceneGenerationRef.current += 1
     stopPolling()
     setSandboxStatus('ready')
-  }, [sceneId, starterCode, controlledCode, stopPolling])
+  }, [sceneId, stopPolling])
   const [showTargetDropdown, setShowTargetDropdown] = useState(false)
   const [submitTarget, setSubmitTarget] = useState<SubmitTarget>({
     type: 'all',
@@ -108,9 +115,13 @@ export default function CodeEditor({
     setSandboxStatus('waking')
     stopPolling()
 
+    const generation = sceneGenerationRef.current
     const TERMINAL_STATES = new Set(['sandbox_destroyed', 'sandbox_error_unrecoverable', 'destroyed', 'error'])
 
     pollIntervalRef.current = setInterval(async () => {
+      // Scene changed — discard this callback
+      if (sceneGenerationRef.current !== generation) { stopPolling(); return }
+
       try {
         const res = await fetch(
           `/api/proxy/api/simulation/sandbox-state?user_progress_id=${userProgressId}`,
@@ -118,6 +129,9 @@ export default function CodeEditor({
         )
         if (!res.ok) return
         const data = await res.json()
+
+        // Stale after await — bail
+        if (sceneGenerationRef.current !== generation) return
 
         // Terminal error — stop polling and surface the error
         if (TERMINAL_STATES.has(data.sandbox_state) || TERMINAL_STATES.has(data.error)) {
@@ -139,6 +153,8 @@ export default function CodeEditor({
               credentials: 'include',
               body: JSON.stringify({ user_progress_id: userProgressId, code: pendingCode, scene_id: sceneId }),
             })
+            // Stale after await — bail
+            if (sceneGenerationRef.current !== generation) { setIsRunning(false); return }
             const execResult = await execRes.json()
             if (execResult.success) {
               setOutput(execResult.output)
@@ -160,6 +176,7 @@ export default function CodeEditor({
   useEffect(() => () => stopPolling(), [stopPolling])
 
   const runCode = useCallback(async () => {
+    const generation = sceneGenerationRef.current
     setIsRunning(true)
     setError(null)
     setOutput('')
@@ -176,6 +193,9 @@ export default function CodeEditor({
           scene_id: sceneId,
         }),
       })
+
+      // Scene changed while awaiting — discard result
+      if (sceneGenerationRef.current !== generation) return
 
       const result = await response.json()
 
@@ -203,7 +223,9 @@ export default function CodeEditor({
         }
       }
     } catch {
-      setError('Failed to connect to code execution service')
+      if (sceneGenerationRef.current === generation) {
+        setError('Failed to connect to code execution service')
+      }
     } finally {
       setIsRunning(false)
     }

--- a/frontend/components/CodeEditor.tsx
+++ b/frontend/components/CodeEditor.tsx
@@ -54,6 +54,14 @@ export default function CodeEditor({
   const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus>('ready')
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
+  // Stop polling for sandbox state
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+    }
+  }, [])
+
   // Reset editor content and sandbox wake/poll state when the scene changes
   useEffect(() => {
     if (controlledCode === undefined) {
@@ -94,14 +102,6 @@ export default function CodeEditor({
       mentionId: p.name.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, ''),
     })),
   ]
-
-  // Stop polling for sandbox state
-  const stopPolling = useCallback(() => {
-    if (pollIntervalRef.current) {
-      clearInterval(pollIntervalRef.current)
-      pollIntervalRef.current = null
-    }
-  }, [])
 
   // Poll /sandbox-state until the sandbox is started, then re-run code
   const startPollingAndRetry = useCallback((pendingCode: string) => {

--- a/frontend/e2e/reset-poll-on-scene-change.spec.ts
+++ b/frontend/e2e/reset-poll-on-scene-change.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests that the CodeEditor resets its wake/poll state when the scene changes
+ * (issue #316).
+ *
+ * Uses the test harness at /test/code-editor which mounts CodeEditor with
+ * a "Next Scene" button to change sceneId.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('CodeEditor — reset poll state on scene change', () => {
+  test('scene change clears waking banner and stops polling', async ({ page }) => {
+    let pollCount = 0
+
+    // Intercept execute-code to return a "stopped" sandbox → triggers polling
+    await page.route('**/api/proxy/api/simulation/execute-code', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          output: '',
+          error: 'sandbox_not_ready',
+          sandbox_state: 'stopped',
+        }),
+      })
+    })
+
+    // Intercept sandbox-state polling — always return 'archived' to keep polling
+    await page.route('**/api/proxy/api/simulation/sandbox-state*', async (route) => {
+      pollCount++
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          sandbox_state: 'archived',
+          sandbox_id: 'test-sandbox-1',
+        }),
+      })
+    })
+
+    await page.goto('/test/code-editor')
+    await page.waitForLoadState('networkidle')
+
+    // Click Run — triggers stopped → waking banner + polling
+    await page.click('button:has-text("Run")')
+    await expect(page.locator('text=sandbox is waking up')).toBeVisible({ timeout: 5000 })
+
+    // Record poll count before scene switch
+    const pollsBefore = pollCount
+
+    // Switch scene — should clear waking state
+    await page.click('[data-testid="switch-scene"]')
+
+    // Waking banner should disappear
+    await expect(page.locator('text=sandbox is waking up')).not.toBeVisible({ timeout: 3000 })
+
+    // Wait to verify polling has stopped (no new polls after scene change)
+    const pollsAtSwitch = pollCount
+    await page.waitForTimeout(7000) // Wait longer than the 5s poll interval
+    expect(pollCount).toBe(pollsAtSwitch)
+
+    // Verify at least one poll happened before scene switch
+    expect(pollsBefore).toBeGreaterThan(0)
+  })
+
+  test('scene change clears destroyed banner', async ({ page }) => {
+    // Intercept execute-code to return destroyed sandbox
+    await page.route('**/api/proxy/api/simulation/execute-code', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          output: '',
+          error: 'sandbox_destroyed',
+          sandbox_state: 'destroyed',
+        }),
+      })
+    })
+
+    await page.goto('/test/code-editor')
+    await page.waitForLoadState('networkidle')
+
+    // Click Run — triggers destroyed banner
+    await page.click('button:has-text("Run")')
+    await expect(page.locator('text=sandbox session has expired')).toBeVisible({ timeout: 5000 })
+
+    // Switch scene — destroyed banner should clear
+    await page.click('[data-testid="switch-scene"]')
+    await expect(page.locator('text=sandbox session has expired')).not.toBeVisible({ timeout: 3000 })
+  })
+
+  test('scene change clears output and error from previous scene', async ({ page }) => {
+    let callCount = 0
+
+    await page.route('**/api/proxy/api/simulation/execute-code', async (route) => {
+      callCount++
+      if (callCount === 1) {
+        // First run: success with output
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            output: 'scene-1-output',
+            error: null,
+            sandbox_state: 'started',
+          }),
+        })
+      } else {
+        // After scene change: different output
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            output: 'scene-2-output',
+            error: null,
+            sandbox_state: 'started',
+          }),
+        })
+      }
+    })
+
+    await page.goto('/test/code-editor')
+    await page.waitForLoadState('networkidle')
+
+    // Run code on scene 1
+    await page.click('button:has-text("Run")')
+    await expect(page.locator('text=scene-1-output')).toBeVisible({ timeout: 5000 })
+
+    // Switch scene — previous output should be cleared
+    await page.click('[data-testid="switch-scene"]')
+    await expect(page.locator('text=scene-1-output')).not.toBeVisible({ timeout: 3000 })
+  })
+})

--- a/frontend/e2e/reset-poll-on-scene-change.spec.ts
+++ b/frontend/e2e/reset-poll-on-scene-change.spec.ts
@@ -46,7 +46,8 @@ test.describe('CodeEditor — reset poll state on scene change', () => {
     await page.click('button:has-text("Run")')
     await expect(page.locator('text=sandbox is waking up')).toBeVisible({ timeout: 5000 })
 
-    // Record poll count before scene switch
+    // Wait until at least one sandbox-state poll has fired before taking baseline
+    await expect.poll(() => pollCount, { timeout: 10000, intervals: [500] }).toBeGreaterThan(0)
     const pollsBefore = pollCount
 
     // Switch scene — should clear waking state
@@ -59,9 +60,6 @@ test.describe('CodeEditor — reset poll state on scene change', () => {
     const pollsAtSwitch = pollCount
     await page.waitForTimeout(7000) // Wait longer than the 5s poll interval
     expect(pollCount).toBe(pollsAtSwitch)
-
-    // Verify at least one poll happened before scene switch
-    expect(pollsBefore).toBeGreaterThan(0)
   })
 
   test('scene change clears destroyed banner', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fix stale polling interval surviving scene transitions in CodeEditor
- Clear `sandboxStatus` and stop polling when `sceneId` changes

Fixes #316

## Changes
- Added `stopPolling()` and `setSandboxStatus('ready')` to the scene-change `useEffect` in `CodeEditor.tsx`
- Updated test harness page to support dynamic scene switching via a "Next Scene" button
- Added E2E test file for scene-change poll reset scenarios

## Tests added
### Playwright E2E tests (`frontend/e2e/reset-poll-on-scene-change.spec.ts`)
- Waking banner clears and polling stops on scene switch
- Destroyed banner clears on scene switch
- Previous scene output/error clears on scene switch

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass
- [ ] Manual: start a sim, trigger sandbox wake polling, switch scene — verify banner disappears and no stale code re-execution

Generated by Ralph Loop iteration 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scene switching functionality now available with a dedicated button and visual scene indicator displaying the current active scene.

* **Improvements**
  * CodeEditor properly resets its state when switching scenes, including clearing active polling and sandbox status to ensure clean transitions and prevent data carryover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->