### PR TITLE
fix: settings button backward compat with legacy scenario key

### DIFF
--- a/frontend/components/ProfessorGradingModal.tsx
+++ b/frontend/components/ProfessorGradingModal.tsx
@@ -855,8 +855,8 @@ export default function ProfessorGradingModal({
                       <Brain className="h-4 w-4 mr-2" />
                       {regrading ? "Re-grading..." : "Re-grade with AI"}
                     </Button>
-                    {submissionData?.simulation?.id && (
-                      <Link href={`/professor/edit-grading?id=${submissionData.simulation.id}&returnTo=${instanceId}`}>
+                    {simulation?.id && (
+                      <Link href={`/professor/edit-grading?id=${simulation.id}&returnTo=${instanceId}`}>
                         <Button
                           variant="outline"
                           className="border-violet-300 text-violet-700 hover:bg-violet-100 hover:text-violet-800"

--- a/frontend/e2e/settings-button-backward-compat.spec.ts
+++ b/frontend/e2e/settings-button-backward-compat.spec.ts
@@ -15,9 +15,14 @@ test.describe('Settings button backward compatibility', () => {
     const simObj = { id: 42, title: 'Test Simulation', scenes: [] }
     return {
       student_name: 'Test Student',
+      completion_percentage: 80,
+      professor_grade: null,
+      professor_feedback: null,
+      ai_grade: 85,
+      user_progress_id: 999,
       current_scene: { id: 1, scene_order: 1, title: 'Scene 1' },
       all_scenes: [],
-      conversation_log: [],
+      conversation_history: [],
       grades: { overall_grade: 85, feedback: 'Good work' },
       [simKey]: simObj,
     }
@@ -27,11 +32,18 @@ test.describe('Settings button backward compatibility', () => {
     page: import('@playwright/test').Page,
     simKey: 'simulation' | 'scenario',
   ) {
-    await page.route('**/professor/grading/**', route =>
+    await page.route('**/api/proxy/professor/grading/instances/*/submission', route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(makeSubmissionData(simKey)),
+      }),
+    )
+    await page.route('**/api/proxy/professor/grading/instances/*/history', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
       }),
     )
     // Also mock auth so the page doesn't redirect

--- a/frontend/e2e/settings-button-backward-compat.spec.ts
+++ b/frontend/e2e/settings-button-backward-compat.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * E2E tests for Settings button backward compatibility (issue #264).
+ *
+ * Verifies that the Settings button in ProfessorGradingModal renders
+ * correctly when the API response uses either the current `simulation`
+ * key or the legacy `scenario` key.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Settings button backward compatibility', () => {
+  const GRADING_URL = '/professor/grading/test-instance-123'
+
+  function makeSubmissionData(simKey: 'simulation' | 'scenario') {
+    const simObj = { id: 42, title: 'Test Simulation', scenes: [] }
+    return {
+      student_name: 'Test Student',
+      current_scene: { id: 1, scene_order: 1, title: 'Scene 1' },
+      all_scenes: [],
+      conversation_log: [],
+      grades: { overall_grade: 85, feedback: 'Good work' },
+      [simKey]: simObj,
+    }
+  }
+
+  async function mockGradingEndpoint(
+    page: import('@playwright/test').Page,
+    simKey: 'simulation' | 'scenario',
+  ) {
+    await page.route('**/professor/grading/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSubmissionData(simKey)),
+      }),
+    )
+    // Also mock auth so the page doesn't redirect
+    await page.route('**/auth/me', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1, email: 'prof@test.com', role: 'professor' }),
+      }),
+    )
+  }
+
+  test('renders Settings button when response uses "simulation" key', async ({ page }) => {
+    await mockGradingEndpoint(page, 'simulation')
+    await page.goto(GRADING_URL)
+
+    const settingsLink = page.locator('a[href*="/professor/edit-grading?id=42"]')
+    // The link should exist in the DOM (it may or may not be visible depending
+    // on whether the grading section renders, but its href should reference id=42)
+    await expect(settingsLink).toHaveCount(1)
+  })
+
+  test('renders Settings button when response uses legacy "scenario" key', async ({ page }) => {
+    await mockGradingEndpoint(page, 'scenario')
+    await page.goto(GRADING_URL)
+
+    const settingsLink = page.locator('a[href*="/professor/edit-grading?id=42"]')
+    await expect(settingsLink).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Settings button in ProfessorGradingModal now uses the derived `simulation` variable instead of accessing `submissionData?.simulation` directly
- This ensures the button renders correctly when the API response uses the legacy `scenario` key

Fixes #264

## Changes
- Replaced `submissionData?.simulation?.id` with `simulation?.id` in the conditional check (line 858)
- Replaced `submissionData.simulation.id` with `simulation.id` in the Link href (line 859)

## Tests added
- E2E: Settings button renders when API uses `simulation` key
- E2E: Settings button renders when API uses legacy `scenario` key

## Test plan
- [x] Lint passes
- [ ] Playwright E2E tests pass
- [ ] Manual verification: open grading modal with legacy scenario data, confirm Settings button appears

Generated by Ralph Loop iteration 11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the "edit grading criteria" link in the AI Grading section to reliably work with both current and legacy submission data formats, ensuring backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->