### PR TITLE
fix: resolve session_id from orchestrator_data in save_message

### DIFF
--- a/backend/modules/simulation/service.py
+++ b/backend/modules/simulation/service.py
@@ -8,6 +8,7 @@ Delegates to specialized services for lifecycle, grading, and progress operation
 from typing import Dict, Any, Optional, AsyncGenerator
 import json
 import logging
+import secrets
 
 from sqlalchemy.orm import Session
 
@@ -343,7 +344,6 @@ class SimulationService:
         session_id: str = None
     ) -> Dict[str, Any]:
         """Save a system message to conversation history."""
-        import secrets
         user_progress = self.repository.get_user_progress_by_id(user_progress_id)
         if not user_progress:
             raise NotFoundError("User progress not found")
@@ -359,8 +359,12 @@ class SimulationService:
 
         next_message_order = self.repository.get_next_message_order(user_progress_id)
 
-        # Generate a session_id for system messages if not provided by caller
-        effective_session_id = session_id or f"system_{user_progress_id}_{scene_id}_{secrets.token_urlsafe(8)}"
+        # Resolve session_id: caller-provided > active session from orchestrator_data > synthetic fallback
+        effective_session_id = (
+            session_id
+            or (user_progress.orchestrator_data or {}).get('state', {}).get('session_id')
+            or f"system_{user_progress_id}_{scene_id}_{secrets.token_urlsafe(8)}"
+        )
 
         log = self.repository.create_conversation_log(
             user_progress_id=user_progress_id,

--- a/backend/modules/simulation/service.py
+++ b/backend/modules/simulation/service.py
@@ -360,9 +360,13 @@ class SimulationService:
         next_message_order = self.repository.get_next_message_order(user_progress_id)
 
         # Resolve session_id: caller-provided > active session from orchestrator_data > synthetic fallback
+        orchestrator_data = user_progress.orchestrator_data or {}
+        state = orchestrator_data.get("state") if isinstance(orchestrator_data, dict) else None
+        state_session_id = state.get("session_id") if isinstance(state, dict) else None
+
         effective_session_id = (
             session_id
-            or (user_progress.orchestrator_data or {}).get('state', {}).get('session_id')
+            or state_session_id
             or f"system_{user_progress_id}_{scene_id}_{secrets.token_urlsafe(8)}"
         )
 

--- a/backend/tests/modules/simulation/test_save_message_session_id.py
+++ b/backend/tests/modules/simulation/test_save_message_session_id.py
@@ -1,0 +1,123 @@
+"""
+Tests for save_message session ID resolution in SimulationService.
+
+Verifies the three-tier session ID priority:
+1. Caller-provided session_id
+2. Active session from user_progress.orchestrator_data
+3. Synthetic fallback
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from modules.simulation.service import SimulationService
+
+
+def _make_user_progress(user_id, simulation_id, orchestrator_data=None):
+    """Create a mock UserProgress with the given orchestrator_data."""
+    up = MagicMock()
+    up.user_id = user_id
+    up.simulation_id = simulation_id
+    up.orchestrator_data = orchestrator_data
+    return up
+
+
+def _make_scene(simulation_id):
+    """Create a mock scene belonging to the given simulation."""
+    scene = MagicMock()
+    scene.simulation_id = simulation_id
+    return scene
+
+
+def _make_log(log_id=1, message_order=1):
+    """Create a mock conversation log."""
+    log = MagicMock()
+    log.id = log_id
+    log.message_order = message_order
+    return log
+
+
+class TestSaveMessageSessionIdResolution:
+    """Verify that save_message resolves session_id with correct priority."""
+
+    def _call_save_message(self, db_session, orchestrator_data=None, session_id=None):
+        """Helper: call save_message and return the session_id passed to create_conversation_log."""
+        service = SimulationService(db_session)
+
+        user_progress = _make_user_progress(
+            user_id=10, simulation_id=100, orchestrator_data=orchestrator_data
+        )
+        scene = _make_scene(simulation_id=100)
+
+        service.repository.get_user_progress_by_id = MagicMock(return_value=user_progress)
+        service.repository.get_scene_by_id = MagicMock(return_value=scene)
+        service.repository.get_next_message_order = MagicMock(return_value=1)
+        service.repository.create_conversation_log = MagicMock(return_value=_make_log())
+        service.repository.db = MagicMock()
+
+        service.save_message(
+            user_id=10,
+            user_progress_id=1,
+            scene_id=5,
+            sender_name="system",
+            message_content="Hello",
+            message_type="system",
+            session_id=session_id,
+        )
+
+        call_kwargs = service.repository.create_conversation_log.call_args
+        return call_kwargs.kwargs.get("session_id") or call_kwargs[1].get("session_id")
+
+    def test_caller_provided_session_id_takes_priority(self, db_session):
+        """When caller provides session_id, it should be used regardless of orchestrator_data."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data={"state": {"session_id": "orch-session-123"}},
+            session_id="caller-session-456",
+        )
+        assert result == "caller-session-456"
+
+    def test_orchestrator_data_session_id_used_when_no_caller_id(self, db_session):
+        """When no caller session_id, should use the active session from orchestrator_data."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data={"state": {"session_id": "orch-session-123"}},
+            session_id=None,
+        )
+        assert result == "orch-session-123"
+
+    def test_synthetic_fallback_when_no_session_available(self, db_session):
+        """When no caller session_id and no orchestrator_data session, should generate synthetic ID."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data=None,
+            session_id=None,
+        )
+        assert result.startswith("system_1_5_")
+
+    def test_synthetic_fallback_when_orchestrator_data_has_no_state(self, db_session):
+        """When orchestrator_data exists but has no 'state' key, should fall back to synthetic."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data={"some_other_key": "value"},
+            session_id=None,
+        )
+        assert result.startswith("system_1_5_")
+
+    def test_synthetic_fallback_when_state_has_no_session_id(self, db_session):
+        """When orchestrator_data has 'state' but no 'session_id', should fall back to synthetic."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data={"state": {"turn_count": 3}},
+            session_id=None,
+        )
+        assert result.startswith("system_1_5_")
+
+    def test_empty_orchestrator_data_dict(self, db_session):
+        """When orchestrator_data is an empty dict, should fall back to synthetic."""
+        result = self._call_save_message(
+            db_session,
+            orchestrator_data={},
+            session_id=None,
+        )
+        assert result.startswith("system_1_5_")


### PR DESCRIPTION
## Summary
- System messages in `save_message` now join the existing active session instead of generating a new synthetic session ID
- Uses three-tier session ID resolution: caller-provided → orchestrator_data → synthetic fallback

Fixes #317

## Changes
- `backend/modules/simulation/service.py`: Replace immediate synthetic session ID generation with three-tier resolution that first checks `user_progress.orchestrator_data['state']['session_id']`
- Moved `import secrets` to top-level import

## Tests added
- `test_caller_provided_session_id_takes_priority` — caller ID overrides orchestrator_data
- `test_orchestrator_data_session_id_used_when_no_caller_id` — uses active session from orchestrator_data
- `test_synthetic_fallback_when_no_session_available` — generates synthetic when no session exists
- `test_synthetic_fallback_when_orchestrator_data_has_no_state` — safe handling of missing state key
- `test_synthetic_fallback_when_state_has_no_session_id` — safe handling of missing session_id
- `test_empty_orchestrator_data_dict` — safe handling of empty orchestrator_data

## Test plan
- [x] Unit tests cover all three resolution tiers
- [x] Edge cases for None/empty/missing orchestrator_data covered
- [ ] CI passes

Generated by Ralph Loop iteration 23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session ID resolution and safer handling of stored session data—now prioritizes caller-provided IDs, then stored orchestrator state, with automatic generation as a final fallback to avoid missing/invalid session IDs.

* **Tests**
  * Added comprehensive tests covering session ID resolution across caller-provided IDs, orchestrator-state extraction, and synthetic fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->