### PR TITLE
fix: use atomic Redis list ops for conversation cache

### DIFF
--- a/backend/common/services/cache_service.py
+++ b/backend/common/services/cache_service.py
@@ -217,6 +217,37 @@ class RedisManager:
             logger.error(f"[REDIS] Error llen for {key}: {e}")
             return 0
     
+    def rpush(self, key: str, *values: Any) -> int:
+        """Push values to right of list (append to end)."""
+        if not self._ensure_connected():
+            return 0
+        try:
+            serialized = [json.dumps(v, default=_json_serializer) if isinstance(v, (dict, list)) else str(v) for v in values]
+            return self.redis.rpush(key, *serialized)
+        except RedisError as e:
+            # If WRONGTYPE error, key exists as different type - delete and retry
+            if "WRONGTYPE" in str(e):
+                logger.warning(f"[REDIS] Key {key} is wrong type, deleting and recreating as list")
+                try:
+                    self.redis.delete(key)
+                    return self.redis.rpush(key, *serialized)
+                except Exception as retry_error:
+                    logger.error(f"[REDIS] Error recreating key {key}: {retry_error}")
+                    return 0
+            logger.error(f"[REDIS] Error rpush to {key}: {e}")
+            return 0
+
+    def ltrim(self, key: str, start: int, end: int) -> bool:
+        """Trim list to keep only elements from index start to end (inclusive)."""
+        if not self._ensure_connected():
+            return False
+        try:
+            self.redis.ltrim(key, start, end)
+            return True
+        except RedisError as e:
+            logger.error(f"[REDIS] Error ltrim for {key}: {e}")
+            return False
+
     def lrange(self, key: str, start: int = 0, end: int = -1) -> List[Any]:
         """Get range of list values."""
         if not self._ensure_connected():

--- a/backend/common/services/conversation_cache_service.py
+++ b/backend/common/services/conversation_cache_service.py
@@ -101,38 +101,43 @@ class ConversationCacheService:
         cache_key = _get_cache_key(user_progress_id, scene_id)
         
         try:
-            cached_data = redis_manager.get(cache_key)
-            if cached_data is None:
+            # Fetch all list elements from Redis
+            raw_items = redis_manager.lrange(cache_key, 0, -1)
+            if not raw_items:
                 logger.info(f"[CONV_CACHE] Cache MISS for {cache_key}")
                 return None
-            
-            # Parse cached JSON
-            if isinstance(cached_data, str):
-                messages = json.loads(cached_data)
-            else:
-                messages = cached_data
-            
+
+            # Each element is a dict (already parsed by lrange) or a JSON string
+            messages = []
+            for item in raw_items:
+                if isinstance(item, dict):
+                    messages.append(item)
+                elif isinstance(item, str):
+                    messages.append(json.loads(item))
+                else:
+                    messages.append(item)
+
             # Filter by session_id if provided
             if session_id_filter:
                 base_session_id = session_id_filter
                 if "_persona_" in session_id_filter:
                     base_session_id = session_id_filter.rsplit("_persona_", 1)[0]
-                
+
                 messages = [
                     msg for msg in messages
                     if (msg.get("session_id") == base_session_id or
                         msg.get("session_id") == session_id_filter or
                         (msg.get("session_id") or "").startswith(f"{base_session_id}_"))
                 ]
-            
+
             # Convert to CachedMessage objects
             cached_messages = [_dict_to_cached_message(msg) for msg in messages]
-            
+
             logger.info(
                 f"[CONV_CACHE] Cache HIT for {cache_key}: {len(cached_messages)} messages"
             )
             return cached_messages
-            
+
         except Exception as e:
             logger.warning(f"[CONV_CACHE] Error reading cache: {e}")
             return None
@@ -159,23 +164,28 @@ class ConversationCacheService:
         try:
             # Serialize messages (handles ORM objects)
             serialized = [_serialize_conversation_log(msg) for msg in messages]
-            
+
             # Keep only last N messages
             if len(serialized) > MAX_CACHED_MESSAGES:
                 serialized = serialized[-MAX_CACHED_MESSAGES:]
-            
-            # Store in Redis with TTL
-            redis_manager.set(
-                cache_key,
-                json.dumps(serialized),
-                ttl=CACHE_TTL_SECONDS
-            )
-            
+
+            # Delete existing key first (clears old string-format or stale list data)
+            redis_manager.delete(cache_key)
+
+            # Push all messages as individual list elements
+            json_items = [json.dumps(msg) for msg in serialized]
+            if json_items:
+                redis_manager.rpush(cache_key, *json_items)
+
+            # Set TTL
+            if redis_manager.redis:
+                redis_manager.redis.expire(cache_key, CACHE_TTL_SECONDS)
+
             logger.info(
                 f"[CONV_CACHE] Cached {len(serialized)} messages for {cache_key}"
             )
             return True
-            
+
         except Exception as e:
             logger.warning(f"[CONV_CACHE] Error writing cache: {e}")
             return False
@@ -200,37 +210,23 @@ class ConversationCacheService:
         cache_key = _get_cache_key(user_progress_id, scene_id)
         
         try:
-            # Get existing cache
-            cached_data = redis_manager.get(cache_key)
-            
-            if cached_data is None:
-                # No cache exists - just store the single message
-                messages = [message_data]
-            else:
-                # Parse and append
-                if isinstance(cached_data, str):
-                    messages = json.loads(cached_data)
-                else:
-                    messages = cached_data
-                messages.append(message_data)
-                
-                # Trim to max size
-                if len(messages) > MAX_CACHED_MESSAGES:
-                    messages = messages[-MAX_CACHED_MESSAGES:]
-            
-            # Store back with fresh TTL
-            redis_manager.set(
-                cache_key,
-                json.dumps(messages),
-                ttl=CACHE_TTL_SECONDS
-            )
-            
+            # Atomic append: RPUSH adds to end of list (creates list if key doesn't exist)
+            redis_manager.rpush(cache_key, json.dumps(message_data))
+
+            # Trim to keep only the last MAX_CACHED_MESSAGES entries
+            redis_manager.ltrim(cache_key, -MAX_CACHED_MESSAGES, -1)
+
+            # Refresh TTL
+            if redis_manager.redis:
+                redis_manager.redis.expire(cache_key, CACHE_TTL_SECONDS)
+
+            new_len = redis_manager.llen(cache_key)
             logger.info(
                 f"[CONV_CACHE] Appended message to {cache_key}, "
-                f"total: {len(messages)} messages"
+                f"total: {new_len} messages"
             )
             return True
-            
+
         except Exception as e:
             logger.warning(f"[CONV_CACHE] Error appending to cache: {e}")
             return False

--- a/backend/tests/test_conversation_cache.py
+++ b/backend/tests/test_conversation_cache.py
@@ -1,0 +1,216 @@
+"""
+Tests for ConversationCacheService atomic Redis list operations.
+
+Verifies that conversation caching uses atomic RPUSH/LTRIM instead of
+the old non-atomic GET→modify→SET pattern (fixes race condition in #236).
+"""
+import json
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from common.services.conversation_cache_service import (
+    ConversationCacheService,
+    CachedMessage,
+    _dict_to_cached_message,
+    _get_cache_key,
+    CACHE_TTL_SECONDS,
+    MAX_CACHED_MESSAGES,
+)
+
+
+def _make_message(order: int, sender: str = "student", session_id: str = "sess1") -> dict:
+    """Helper to create a message dict."""
+    return {
+        "id": order,
+        "user_progress_id": 1,
+        "scene_id": 1,
+        "session_id": session_id,
+        "message_type": "user" if sender == "student" else "ai",
+        "sender_name": sender,
+        "message_content": f"Message {order}",
+        "message_order": order,
+        "persona_id": None,
+        "created_at": "2026-01-01T00:00:00",
+    }
+
+
+class _FakeORM:
+    """Minimal stand-in for a ConversationLog ORM object."""
+    def __init__(self, data: dict):
+        for k, v in data.items():
+            setattr(self, k, v)
+        # created_at needs .isoformat()
+        if isinstance(self.created_at, str):
+            self.created_at = type("dt", (), {"isoformat": lambda self_: data["created_at"]})()
+
+
+# ── append_message ────────────────────────────────────────────────────
+
+
+@patch("common.services.conversation_cache_service.redis_manager")
+class TestAppendMessage:
+
+    def test_append_uses_rpush_not_get_set(self, mock_rm):
+        """append_message must use atomic RPUSH, not GET→SET."""
+        mock_rm.rpush.return_value = 1
+        mock_rm.ltrim.return_value = True
+        mock_rm.llen.return_value = 1
+        mock_rm.redis = MagicMock()
+
+        msg = _make_message(1)
+        result = ConversationCacheService.append_message(1, 1, msg)
+
+        assert result is True
+        # RPUSH called with JSON-serialized message
+        mock_rm.rpush.assert_called_once()
+        pushed_json = mock_rm.rpush.call_args[0][1]
+        assert json.loads(pushed_json) == msg
+
+        # LTRIM called to enforce max size
+        mock_rm.ltrim.assert_called_once_with(
+            _get_cache_key(1, 1), -MAX_CACHED_MESSAGES, -1
+        )
+
+        # TTL refreshed
+        mock_rm.redis.expire.assert_called_once_with(
+            _get_cache_key(1, 1), CACHE_TTL_SECONDS
+        )
+
+        # Old GET/SET pattern must NOT be used
+        mock_rm.get.assert_not_called()
+        mock_rm.set.assert_not_called()
+
+    def test_append_returns_false_on_error(self, mock_rm):
+        """append_message returns False when RPUSH raises."""
+        mock_rm.rpush.side_effect = Exception("connection lost")
+
+        result = ConversationCacheService.append_message(1, 1, _make_message(1))
+        assert result is False
+
+
+# ── set_cached_history ────────────────────────────────────────────────
+
+
+@patch("common.services.conversation_cache_service.redis_manager")
+class TestSetCachedHistory:
+
+    def test_stores_as_list_elements(self, mock_rm):
+        """set_cached_history must delete old key, then RPUSH individual items."""
+        mock_rm.delete.return_value = True
+        mock_rm.rpush.return_value = 3
+        mock_rm.redis = MagicMock()
+
+        msgs = [_FakeORM(_make_message(i)) for i in range(3)]
+        result = ConversationCacheService.set_cached_history(1, 1, msgs)
+
+        assert result is True
+        mock_rm.delete.assert_called_once_with(_get_cache_key(1, 1))
+        mock_rm.rpush.assert_called_once()
+
+        # Verify each pushed item is a JSON string
+        pushed_args = mock_rm.rpush.call_args[0]
+        assert pushed_args[0] == _get_cache_key(1, 1)
+        for item in pushed_args[1:]:
+            parsed = json.loads(item)
+            assert "message_content" in parsed
+
+        # TTL set
+        mock_rm.redis.expire.assert_called_once()
+
+        # Old SET pattern must NOT be used
+        mock_rm.set.assert_not_called()
+
+    def test_trims_to_max_cached_messages(self, mock_rm):
+        """When more than MAX_CACHED_MESSAGES, only the last N are stored."""
+        mock_rm.delete.return_value = True
+        mock_rm.rpush.return_value = MAX_CACHED_MESSAGES
+        mock_rm.redis = MagicMock()
+
+        msgs = [_FakeORM(_make_message(i)) for i in range(MAX_CACHED_MESSAGES + 10)]
+        ConversationCacheService.set_cached_history(1, 1, msgs)
+
+        pushed_args = mock_rm.rpush.call_args[0]
+        # key + MAX_CACHED_MESSAGES items
+        assert len(pushed_args) == 1 + MAX_CACHED_MESSAGES
+
+    def test_empty_list_does_not_rpush(self, mock_rm):
+        """set_cached_history with empty messages should not RPUSH."""
+        mock_rm.delete.return_value = True
+        mock_rm.redis = MagicMock()
+
+        ConversationCacheService.set_cached_history(1, 1, [])
+        mock_rm.rpush.assert_not_called()
+
+
+# ── get_cached_history ────────────────────────────────────────────────
+
+
+@patch("common.services.conversation_cache_service.redis_manager")
+class TestGetCachedHistory:
+
+    def test_reads_from_lrange(self, mock_rm):
+        """get_cached_history must use lrange, not get."""
+        messages = [_make_message(i) for i in range(3)]
+        # lrange returns already-parsed dicts (RedisManager auto-parses JSON)
+        mock_rm.lrange.return_value = messages
+
+        result = ConversationCacheService.get_cached_history(1, 1)
+
+        mock_rm.lrange.assert_called_once_with(_get_cache_key(1, 1), 0, -1)
+        mock_rm.get.assert_not_called()
+
+        assert result is not None
+        assert len(result) == 3
+        assert all(isinstance(m, CachedMessage) for m in result)
+        assert result[0].message_content == "Message 0"
+
+    def test_empty_list_returns_none(self, mock_rm):
+        """Empty Redis list = cache miss → return None."""
+        mock_rm.lrange.return_value = []
+
+        result = ConversationCacheService.get_cached_history(1, 1)
+        assert result is None
+
+    def test_session_id_filtering(self, mock_rm):
+        """Session ID filtering still works with list storage."""
+        messages = [
+            _make_message(0, session_id="sess1"),
+            _make_message(1, session_id="sess2"),
+            _make_message(2, session_id="sess1_persona_X"),
+        ]
+        mock_rm.lrange.return_value = messages
+
+        result = ConversationCacheService.get_cached_history(1, 1, session_id_filter="sess1")
+
+        assert result is not None
+        assert len(result) == 2  # sess1 and sess1_persona_X
+        assert result[0].session_id == "sess1"
+        assert result[1].session_id == "sess1_persona_X"
+
+
+# ── Race condition regression ─────────────────────────────────────────
+
+
+@patch("common.services.conversation_cache_service.redis_manager")
+class TestRaceConditionRegression:
+
+    def test_concurrent_appends_are_safe(self, mock_rm):
+        """Two concurrent append_message calls should each independently RPUSH.
+
+        With the old GET→SET pattern, concurrent calls could overwrite each other.
+        With RPUSH, each call atomically appends without reading first.
+        """
+        mock_rm.rpush.return_value = 1
+        mock_rm.ltrim.return_value = True
+        mock_rm.llen.return_value = 2
+        mock_rm.redis = MagicMock()
+
+        msg_a = _make_message(1, sender="student")
+        msg_b = _make_message(2, sender="AI Persona")
+
+        ConversationCacheService.append_message(1, 1, msg_a)
+        ConversationCacheService.append_message(1, 1, msg_b)
+
+        # Two independent RPUSHes — neither reads existing state
+        assert mock_rm.rpush.call_count == 2
+        assert mock_rm.get.call_count == 0  # no GET at all


### PR DESCRIPTION
## Summary
- Replace non-atomic GET→modify→SET pattern in `ConversationCacheService.append_message` with atomic Redis RPUSH + LTRIM operations
- Eliminates race condition where concurrent chat messages could overwrite each other's cached history

Fixes #236

## Changes
- Added `rpush()` and `ltrim()` methods to `RedisManager` following existing list operation patterns
- `append_message`: now uses atomic RPUSH + LTRIM instead of GET→parse→append→SET
- `set_cached_history`: stores each message as individual Redis list element via RPUSH
- `get_cached_history`: reads via LRANGE instead of GET + JSON parse
- 30-minute TTL ensures natural migration of any old string-format cached data

## Tests added
- `test_append_uses_rpush_not_get_set` — verifies RPUSH is used, GET/SET are not
- `test_append_returns_false_on_error` — error handling
- `test_stores_as_list_elements` — set_cached_history uses delete + RPUSH
- `test_trims_to_max_cached_messages` — max 50 messages enforced
- `test_empty_list_does_not_rpush` — edge case
- `test_reads_from_lrange` — get uses LRANGE not GET
- `test_empty_list_returns_none` — cache miss behavior
- `test_session_id_filtering` — filtering still works with list storage
- `test_concurrent_appends_are_safe` — race condition regression test

## Test plan
- [x] Unit tests pass (9/9)
- [x] Lint passes
- [ ] Manual verification: concurrent chat messages no longer lose data

Generated by Ralph Loop iteration 24