### PR TITLE
fix: convert cohort tile to semantic button for keyboard accessibility

### DIFF
--- a/frontend/app/student/my-cohorts/page.tsx
+++ b/frontend/app/student/my-cohorts/page.tsx
@@ -263,10 +263,12 @@ export default function StudentMyCohorts() {
               </div>
             ) : (
               filteredCohorts.map(cohort => (
-                <div
+                <button
+                  type="button"
                   key={cohort.id}
                   onClick={() => setSelectedCohortId(cohort.id)}
-                  className={`p-4 rounded-xl border cursor-pointer transition-all duration-200 ${
+                  aria-pressed={selectedCohort?.id === cohort.id}
+                  className={`w-full text-left p-4 rounded-xl border cursor-pointer transition-all duration-200 ${
                     selectedCohort?.id === cohort.id
                       ? 'border-slate-400/60 bg-gradient-to-br from-slate-50 to-blue-50/40 shadow-md'
                       : 'border-gray-200/60 bg-white/90 hover:bg-gray-50/80 hover:border-gray-300/60 hover:shadow-sm'
@@ -281,7 +283,7 @@ export default function StudentMyCohorts() {
                     <span>{cohort.progress}</span>
                     <span>Joined {cohort.joinedDate}</span>
                   </div>
-                </div>
+                </button>
               ))
             )}
           </div>

--- a/frontend/e2e/cohort-tile-keyboard-a11y.spec.ts
+++ b/frontend/e2e/cohort-tile-keyboard-a11y.spec.ts
@@ -90,26 +90,26 @@ test.describe('Cohort tile keyboard accessibility', () => {
   })
 
   test('clicking a cohort tile sets aria-pressed="true"', async ({ page }) => {
-    const tile = page.locator('button:has-text("Intro to Business")')
+    const tile = page.locator('button:has-text("Advanced Strategy")')
+    await expect(tile).toHaveAttribute('aria-pressed', 'false')
     await tile.click()
     await expect(tile).toHaveAttribute('aria-pressed', 'true')
   })
 
   test('cohort tile is focusable via Tab key', async ({ page }) => {
     // Tab through the page until we reach a cohort tile
+    let foundViaTab = false
     for (let i = 0; i < 20; i++) {
       await page.keyboard.press('Tab')
       const focused = page.locator(':focus')
       const text = await focused.textContent().catch(() => '')
       if (text?.includes('Intro to Business')) {
         await expect(focused).toHaveAttribute('type', 'button')
-        return
+        foundViaTab = true
+        break
       }
     }
-    // If we didn't find it via tab, check it's at least focusable
-    const tile = page.locator('button:has-text("Intro to Business")')
-    await tile.focus()
-    await expect(tile).toBeFocused()
+    expect(foundViaTab).toBeTruthy()
   })
 
   test('pressing Enter on focused cohort tile selects it', async ({ page }) => {

--- a/frontend/e2e/cohort-tile-keyboard-a11y.spec.ts
+++ b/frontend/e2e/cohort-tile-keyboard-a11y.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E tests for cohort tile keyboard accessibility (issue #306).
+ *
+ * Verifies that cohort tiles on the My Cohorts page are semantic <button>
+ * elements with aria-pressed, enabling keyboard navigation and screen-reader
+ * support.
+ */
+
+import { test, expect, Page } from '@playwright/test'
+
+const MY_COHORTS_URL = '/student/my-cohorts'
+
+const MOCK_COHORTS = [
+  {
+    id: 1,
+    unique_id: 'cohort-aaa',
+    title: 'Intro to Business',
+    description: 'First cohort',
+    professor: { name: 'Dr. Smith' },
+    is_active: true,
+    student_count: 25,
+    enrollment_date: '2026-01-15T00:00:00Z',
+  },
+  {
+    id: 2,
+    unique_id: 'cohort-bbb',
+    title: 'Advanced Strategy',
+    description: 'Second cohort',
+    professor: { name: 'Prof. Jones' },
+    is_active: true,
+    student_count: 12,
+    enrollment_date: '2026-02-01T00:00:00Z',
+  },
+]
+
+/** Mock auth and cohort API endpoints so the page renders without a real backend. */
+async function setupMocks(page: Page) {
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 1,
+        email: 'student@example.com',
+        full_name: 'Test Student',
+        username: 'teststudent',
+        role: 'student',
+        is_active: true,
+      }),
+    }),
+  )
+
+  await page.route('**/api/student/cohorts**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_COHORTS),
+    }),
+  )
+
+  // Catch cohort detail / assignment routes so they don't error
+  await page.route('**/api/student/cohorts/*/assignments**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    }),
+  )
+}
+
+test.describe('Cohort tile keyboard accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page)
+    await page.goto(MY_COHORTS_URL)
+  })
+
+  test('cohort tiles are rendered as <button> elements', async ({ page }) => {
+    const tiles = page.locator('button:has-text("Intro to Business"), button:has-text("Advanced Strategy")')
+    await expect(tiles).toHaveCount(2)
+  })
+
+  test('cohort tiles have type="button"', async ({ page }) => {
+    const tile = page.locator('button:has-text("Intro to Business")')
+    await expect(tile).toHaveAttribute('type', 'button')
+  })
+
+  test('unselected cohort tile has aria-pressed="false"', async ({ page }) => {
+    const tile = page.locator('button:has-text("Advanced Strategy")')
+    await expect(tile).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('clicking a cohort tile sets aria-pressed="true"', async ({ page }) => {
+    const tile = page.locator('button:has-text("Intro to Business")')
+    await tile.click()
+    await expect(tile).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('cohort tile is focusable via Tab key', async ({ page }) => {
+    // Tab through the page until we reach a cohort tile
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('Tab')
+      const focused = page.locator(':focus')
+      const text = await focused.textContent().catch(() => '')
+      if (text?.includes('Intro to Business')) {
+        await expect(focused).toHaveAttribute('type', 'button')
+        return
+      }
+    }
+    // If we didn't find it via tab, check it's at least focusable
+    const tile = page.locator('button:has-text("Intro to Business")')
+    await tile.focus()
+    await expect(tile).toBeFocused()
+  })
+
+  test('pressing Enter on focused cohort tile selects it', async ({ page }) => {
+    const tile = page.locator('button:has-text("Advanced Strategy")')
+    await tile.focus()
+    await page.keyboard.press('Enter')
+    await expect(tile).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('pressing Space on focused cohort tile selects it', async ({ page }) => {
+    const tile = page.locator('button:has-text("Advanced Strategy")')
+    await tile.focus()
+    await page.keyboard.press('Space')
+    await expect(tile).toHaveAttribute('aria-pressed', 'true')
+  })
+})


### PR DESCRIPTION
## Summary
- Converted the cohort tile on the My Cohorts page from a plain `<div>` to a semantic `<button>` element for native keyboard accessibility
- Added `aria-pressed` attribute to expose selection state to screen readers and assistive technologies
- Added `w-full text-left` Tailwind classes to preserve layout within the button element

Fixes #306

## Changes
- `frontend/app/student/my-cohorts/page.tsx`: Replace `<div>` tile with `<button type="button">`, add `aria-pressed`, add layout classes

## Tests added
- `frontend/e2e/cohort-tile-keyboard-a11y.spec.ts`:
  - Cohort tiles render as `<button>` elements with `type="button"`
  - Unselected tile has `aria-pressed="false"`
  - Clicking a tile sets `aria-pressed="true"`
  - Tile is focusable via Tab key
  - Enter key activates tile selection
  - Space key activates tile selection

## Test plan
- [ ] Playwright E2E tests pass
- [ ] Lint passes
- [ ] Manual: Tab to cohort tiles, press Enter/Space to select, verify screen reader announces pressed state

Generated by Ralph Loop iteration 40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cohort tile accessibility by converting selection controls to semantic buttons with proper keyboard navigation (Tab, Enter, Space).
  * Enhanced selection state indication via accessibility attributes for screen reader compatibility.
* **Tests**
  * Added end-to-end accessibility tests validating keyboard interaction and selection behavior for cohort tiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->