### PR TITLE
fix: add Send text label to chat button for discoverability

### DIFF
--- a/frontend/app/student/run-simulation/[instanceId]/page.tsx
+++ b/frontend/app/student/run-simulation/[instanceId]/page.tsx
@@ -3311,9 +3311,16 @@ ${availablePersonas.map(persona => `• @${persona.name.toLowerCase().replace(/\
                         <button
                           onClick={() => sendMessage()}
                           disabled={inputBlocked || isLoading || isTyping || !input.trim() || gradingInProgress}
-                          className="flex items-center justify-center h-8 w-8 rounded-lg bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-30 transition-colors"
+                          className="flex items-center justify-center h-8 gap-1.5 px-3 rounded-lg bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-30 transition-colors"
                         >
-                          {isLoading ? <RefreshCw className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                          {isLoading ? (
+                            <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                          ) : (
+                            <>
+                              <Send className="w-3.5 h-3.5" />
+                              <span className="text-xs font-medium">Send</span>
+                            </>
+                          )}
                         </button>
                       </div>
                     </div>

--- a/frontend/e2e/send-button-visibility.spec.ts
+++ b/frontend/e2e/send-button-visibility.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E tests for send button visibility in the simulation chat (issue #380).
+ *
+ * Verifies that the send button displays a "Send" text label alongside
+ * the icon so users can easily identify the primary action.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Send button visibility', () => {
+  const SIM_URL = '/student/run-simulation/test-instance-1'
+
+  // Minimal simulation data to render the chat interface
+  function makeSimulationData() {
+    return {
+      simulation: {
+        id: 1,
+        title: 'Test Simulation',
+        description: 'A test simulation',
+        case_study_url: null,
+        scenes: [
+          {
+            id: 1,
+            scene_order: 1,
+            title: 'Scene 1',
+            description: 'First scene',
+            personas: [{ id: 1, name: 'Alice', role: 'Manager' }],
+          },
+        ],
+      },
+      current_scene: {
+        id: 1,
+        scene_order: 1,
+        title: 'Scene 1',
+        description: 'First scene',
+      },
+      user_progress: {
+        id: 1,
+        current_scene_id: 1,
+        current_scene_order: 1,
+        completion_percentage: 0,
+      },
+      conversation_history: [],
+    }
+  }
+
+  test('send button displays "Send" text label', async ({ page }) => {
+    // Mock the simulation API to return test data
+    await page.route('**/api/student/simulation/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSimulationData()),
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    // The send button should contain the text "Send"
+    const sendButton = page.locator('button', { hasText: 'Send' })
+    await expect(sendButton).toBeVisible()
+
+    // Verify the button has the expected styling classes
+    await expect(sendButton).toHaveClass(/bg-gray-900/)
+    await expect(sendButton).toHaveClass(/rounded-lg/)
+  })
+
+  test('send button shows icon alongside text', async ({ page }) => {
+    await page.route('**/api/student/simulation/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSimulationData()),
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    // The send button should contain both an SVG icon and "Send" text
+    const sendButton = page.locator('button', { hasText: 'Send' })
+    await expect(sendButton).toBeVisible()
+
+    const icon = sendButton.locator('svg')
+    await expect(icon).toBeVisible()
+
+    const label = sendButton.locator('span', { hasText: 'Send' })
+    await expect(label).toBeVisible()
+  })
+
+  test('send button is disabled when input is empty', async ({ page }) => {
+    await page.route('**/api/student/simulation/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSimulationData()),
+      })
+    })
+
+    await page.goto(SIM_URL)
+
+    const sendButton = page.locator('button', { hasText: 'Send' })
+    await expect(sendButton).toBeDisabled()
+  })
+})

--- a/frontend/e2e/send-button-visibility.spec.ts
+++ b/frontend/e2e/send-button-visibility.spec.ts
@@ -10,50 +10,73 @@ import { test, expect } from '@playwright/test'
 test.describe('Send button visibility', () => {
   const SIM_URL = '/student/run-simulation/test-instance-1'
 
-  // Minimal simulation data to render the chat interface
+  // Simulation data matching the SimulationData interface from page.tsx
   function makeSimulationData() {
     return {
+      user_progress_id: 1,
+      instance_id: 1,
+      simulation_status: 'in_progress',
       simulation: {
         id: 1,
         title: 'Test Simulation',
         description: 'A test simulation',
+        challenge: 'Test challenge',
+        learning_objectives: [],
+        student_role: 'Analyst',
+        total_scenes: 1,
         case_study_url: null,
-        scenes: [
-          {
-            id: 1,
-            scene_order: 1,
-            title: 'Scene 1',
-            description: 'First scene',
-            personas: [{ id: 1, name: 'Alice', role: 'Manager' }],
-          },
-        ],
       },
       current_scene: {
         id: 1,
         scene_order: 1,
         title: 'Scene 1',
         description: 'First scene',
-      },
-      user_progress: {
-        id: 1,
-        current_scene_id: 1,
-        current_scene_order: 1,
-        completion_percentage: 0,
+        timeout_turns: 15,
+        personas: [
+          {
+            id: 1,
+            name: 'Alice',
+            role: 'Manager',
+            background: 'Test background',
+            correlation: null,
+            primary_goals: [],
+            personality_traits: {},
+          },
+        ],
       },
       conversation_history: [],
+      all_scenes: [],
+      turn_count: 0,
+      completed_scene_ids: [],
     }
   }
 
-  test('send button displays "Send" text label', async ({ page }) => {
-    // Mock the simulation API to return test data
-    await page.route('**/api/student/simulation/**', (route) => {
-      route.fulfill({
+  /** Mock auth and simulation API routes before each test */
+  async function setupRoutes(page: import('@playwright/test').Page) {
+    await page.route('**/api/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 1,
+          email: 'student@test.com',
+          full_name: 'Test Student',
+          role: 'student',
+        }),
+      })
+    })
+
+    await page.route('**/student-simulation-instances/*/start-simulation', async (route) => {
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(makeSimulationData()),
       })
     })
+  }
 
+  test('send button displays "Send" text label', async ({ page }) => {
+    await setupRoutes(page)
     await page.goto(SIM_URL)
 
     // The send button should contain the text "Send"
@@ -66,14 +89,7 @@ test.describe('Send button visibility', () => {
   })
 
   test('send button shows icon alongside text', async ({ page }) => {
-    await page.route('**/api/student/simulation/**', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(makeSimulationData()),
-      })
-    })
-
+    await setupRoutes(page)
     await page.goto(SIM_URL)
 
     // The send button should contain both an SVG icon and "Send" text
@@ -88,14 +104,7 @@ test.describe('Send button visibility', () => {
   })
 
   test('send button is disabled when input is empty', async ({ page }) => {
-    await page.route('**/api/student/simulation/**', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(makeSimulationData()),
-      })
-    })
-
+    await setupRoutes(page)
     await page.goto(SIM_URL)
 
     const sendButton = page.locator('button', { hasText: 'Send' })


### PR DESCRIPTION
## Summary
- Added a "Send" text label alongside the paper-plane icon on the chat input button in the simulation page
- Makes the primary action immediately recognizable for users who couldn't identify the icon-only button
- During loading state, only the spinner shows (no text) to avoid layout issues

Fixes #380
canny_post_id: 69c34b7096f1a85bc296e790

## Changes
- Modified `frontend/app/student/run-simulation/[instanceId]/page.tsx`: expanded send button from icon-only (`h-8 w-8`) to include "Send" text label with `gap-1.5 px-3` padding
- Preserved all existing disabled conditions, dark styling, and loading spinner behavior

## Tests added
- `frontend/e2e/send-button-visibility.spec.ts`:
  - Send button displays "Send" text label
  - Send button shows SVG icon alongside text
  - Send button is disabled when input is empty

## Test plan
- [ ] Unit tests pass
- [ ] Lint passes
- [ ] Playwright E2E tests pass
- [ ] Manual verification: open a simulation and confirm the send button now shows "Send" text next to the icon

Generated by Ralph Loop iteration 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send control in the conversation input bar now shows an icon plus a "Send" text label and has a wider, more prominent layout for improved usability.

* **Tests**
  * Added end-to-end tests verifying the send button’s visibility, presence of icon and text, styling, and disabled state when input is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->