### PR TITLE
feat(rewrite): Phase E — Canny changelog auto-post on merge

### DIFF
--- a/scripts/rewrite/WORKFLOW.md
+++ b/scripts/rewrite/WORKFLOW.md
@@ -77,6 +77,16 @@ For the flow diagrams of the E2E test that runs inside step 6b, see
 │ 7. MERGE into ralph-looped   gh pr merge --squash → "Fixes #N" auto-closes  │
 └─────────────────────────────────────────────────────────────────────────────┘
                              │
+                             ▼   (merge-only; no Canny entry for closed-unmerged PRs)
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 8. PHASE E — Canny changelog (non-fatal)                                    │
+│    claude --print with post-to-canny prompt → non-tech {title, body}        │
+│    POST canny.io/api/v1/posts/create (authorID=CANNY_ADMIN_ID,              │
+│                                        boardID=CANNY_BOARD_ID,              │
+│                                        title="{CANNY_TITLE_PREFIX} ...")    │
+│    gh pr comment <PR> with Canny URL (linkback for admin dashboard)         │
+└─────────────────────────────────────────────────────────────────────────────┘
+                             │
                              ▼
                   outer loop: next ready ticket
 ```
@@ -92,6 +102,7 @@ For the flow diagrams of the E2E test that runs inside step 6b, see
 | step 6b | [e2e-simulation-flow](../../.claude/skills/e2e-simulation-flow/SKILL.md) | full professor + student round-trip |
 | step 6b | [neon-postgres](../../.claude/skills/neon-postgres/SKILL.md) | DB validation used by E2E |
 | cond. | [daytona-sandbox](../../.claude/skills/daytona-sandbox/SKILL.md) | only if the diff touches sandbox-related code |
+| step 8 | [resources/post-to-canny.py](resources/post-to-canny.py) + [resources/prompts/post-to-canny.md](resources/prompts/post-to-canny.md) | non-tech Canny changelog entry after squash merge |
 
 ## Environment scope
 

--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -196,6 +196,30 @@ phase_merge() {
   return 1
 }
 
+# Phase E: post a Canny changelog entry for the merged PR. Non-fatal on
+# any failure — a missed changelog never blocks the next iteration.
+# Only invoked after phase_merge returned 0 (successful squash merge).
+phase_post_canny() {
+  local pr_num=$1 ticket_id=$2 issue_num=$3
+  local run_log="${LOG_DIR}/canny_${ticket_id}_iter${ITER}.log"
+
+  if [ -z "$CANNY_API_KEY" ] || [ -z "$CANNY_BOARD_ID" ] || [ -z "$CANNY_ADMIN_ID" ]; then
+    log "  Canny env vars not set — skipping changelog post"
+    return 0
+  fi
+
+  log "  → posting Canny changelog for PR #${pr_num}"
+  export CANNY_API_KEY CANNY_BOARD_ID CANNY_ADMIN_ID CANNY_TITLE_PREFIX GH_REPO
+  if python3 "${RESOURCES_DIR}/post-to-canny.py" \
+       --pr "$pr_num" --ticket "$ticket_id" --issue "$issue_num" \
+       > "$run_log" 2>&1; then
+    local url; url=$(grep -oE 'CANNY_URL=.+' "$run_log" | tail -1 | cut -d= -f2-)
+    log "  Canny post ok${url:+ — $url}"
+  else
+    log "  WARN: Canny post failed (see $(basename "$run_log")) — not blocking loop"
+  fi
+}
+
 # ============================================================================
 # Main loop
 # ============================================================================
@@ -271,7 +295,12 @@ for ITER in $(seq 1 "$ITERATIONS"); do
   fi
 
   # --- Phase D: CI gate + merge -------------------------------------------
-  phase_merge "$PR_NUM" || log "  PR #${PR_NUM} left open (CI red)"
+  if phase_merge "$PR_NUM"; then
+    # --- Phase E: Canny changelog (merge-only, non-fatal on failure) ------
+    phase_post_canny "$PR_NUM" "$TICKET_ID" "$ISSUE_NUM"
+  else
+    log "  PR #${PR_NUM} left open (CI red) — skipping Canny changelog"
+  fi
 
   worktree_cleanup "$WORK_DIR"; WORK_DIR=""
   log "─── iteration ${ITER} done ─────────────────────────────────────"

--- a/scripts/rewrite/resources/config.sh
+++ b/scripts/rewrite/resources/config.sh
@@ -38,3 +38,16 @@ PROMPTS_DIR="${RESOURCES_DIR}/prompts"
 REPO_DIR="$(cd "${RESOURCES_DIR}/../../.." && pwd)"
 WORKTREE_BASE="${WORKTREE_BASE:-$(cd "$REPO_DIR/.." && pwd)/work-trees}"
 LOG_DIR="${LOG_DIR:-$REPO_DIR/scripts/rewrite/logs}"
+
+# --- Canny (phase E — changelog post on merge) -----------------------------
+# Values pulled from .env (grep, not sourced — avoids eval of untrusted lines).
+# Phase E skips cleanly if any of the three are missing.
+_load_env_var() {
+  local key=$1 file="${REPO_DIR}/.env"
+  [ -f "$file" ] || return 0
+  grep -E "^${key}=" "$file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"
+}
+CANNY_API_KEY="${CANNY_API_KEY:-$(_load_env_var CANNY_API_KEY)}"
+CANNY_BOARD_ID="${CANNY_BOARD_ID:-$(_load_env_var CANNY_BOARD_ID)}"
+CANNY_ADMIN_ID="${CANNY_ADMIN_ID:-$(_load_env_var CANNY_ADMIN_ID)}"
+CANNY_TITLE_PREFIX="${CANNY_TITLE_PREFIX:-[rewrite]}"   # dashboard filter hook

--- a/scripts/rewrite/resources/post-to-canny.py
+++ b/scripts/rewrite/resources/post-to-canny.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Phase E — post a Canny changelog entry for a merged PR.
+
+Triggered by ralph-rewrite-loop.sh only on successful `gh pr merge
+--squash`. Generates a non-technical summary via claude --print, POSTs
+it to the Canny board configured in .env (same board as user feedback;
+dashboard filters via the title prefix), and comments the Canny URL
+back onto the GitHub PR so the admin dashboard can render both sides
+of the link.
+
+Args:
+    --pr <number>       merged PR number (required)
+    --ticket <id>       phase-X.Y ticket id (required)
+    --issue <number>    issue number to reference (optional, derived from PR body if omitted)
+    --dry-run           render + print; don't POST or comment
+
+Exit codes:
+    0  — Canny post created + PR linkback comment posted
+    1  — Canny disabled (no env vars) — loop continues, no failure
+    2  — hard failure (API error, claude failed, etc.)
+
+Security:
+    - reads CANNY_API_KEY / CANNY_BOARD_ID / CANNY_ADMIN_ID from env
+    - never prints, logs, or persists those values
+    - GitHub `gh` CLI handles its own auth
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+RESOURCES_DIR = Path(__file__).resolve().parent
+PROMPT_FILE   = RESOURCES_DIR / "prompts" / "post-to-canny.md"
+
+CANNY_API_KEY   = os.environ.get("CANNY_API_KEY", "")
+CANNY_BOARD_ID  = os.environ.get("CANNY_BOARD_ID", "")
+CANNY_ADMIN_ID  = os.environ.get("CANNY_ADMIN_ID", "")
+CANNY_PREFIX    = os.environ.get("CANNY_TITLE_PREFIX", "[rewrite]")
+GH_REPO         = os.environ.get("GH_REPO", "Hendrik040/n-aible_edtech_sims")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def log(msg: str) -> None:
+    print(f"[post-to-canny] {msg}")
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[post-to-canny] ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+def canny_enabled() -> bool:
+    return bool(CANNY_API_KEY and CANNY_BOARD_ID and CANNY_ADMIN_ID)
+
+def gh_json(*args: str) -> dict | list:
+    try:
+        out = subprocess.run(
+            ["gh", *args], check=True, capture_output=True, text=True, timeout=30,
+        ).stdout
+        return json.loads(out) if out.strip() else {}
+    except subprocess.CalledProcessError as e:
+        die(f"gh failed: {e.stderr.strip()}")
+    except json.JSONDecodeError:
+        die(f"gh returned non-JSON: {out[:200]!r}")
+
+def fetch_pr_context(pr: int) -> dict:
+    pr_data = gh_json(
+        "pr", "view", str(pr), "--repo", GH_REPO,
+        "--json", "title,body,author,files,additions,deletions,mergedAt",
+    )
+    files = pr_data.get("files") or []
+    return {
+        "title":    pr_data.get("title", ""),
+        "body":     pr_data.get("body", "")[:4000],  # clip to keep prompt tight
+        "merged":   bool(pr_data.get("mergedAt")),
+        "added":    pr_data.get("additions", 0),
+        "removed":  pr_data.get("deletions", 0),
+        "files":    [f.get("path", "?") for f in files],
+    }
+
+def infer_issue_from_body(body: str) -> int | None:
+    m = re.search(r"(?:[Ff]ixes|[Cc]loses|[Rr]esolves)\s+#(\d+)", body or "")
+    return int(m.group(1)) if m else None
+
+# ---------------------------------------------------------------------------
+# Claude summary
+# ---------------------------------------------------------------------------
+def render_prompt(template: str, vars_: dict[str, str]) -> str:
+    def repl(m: re.Match) -> str:
+        k = m.group(1)
+        return str(vars_.get(k, m.group(0)))
+    return re.sub(r"\{\{([A-Z_][A-Z0-9_]*)\}\}", repl, template)
+
+def generate_summary(ticket_id: str, pr: int, issue_num: int, ctx: dict) -> dict:
+    template = PROMPT_FILE.read_text()
+    files = ctx["files"]
+    file_preview = "\n".join(f"  - {f}" for f in files[:30])
+    if len(files) > 30:
+        file_preview += f"\n  … +{len(files) - 30} more"
+
+    prompt = render_prompt(template, {
+        "PR_NUM":           str(pr),
+        "TICKET_ID":        ticket_id,
+        "ISSUE_NUM":        str(issue_num),
+        "PR_TITLE":         ctx["title"],
+        "PR_BODY":          ctx["body"] or "(empty)",
+        "DIFF_FILE_COUNT":  str(len(files)),
+        "DIFF_FILE_LIST":   file_preview or "  (no files listed)",
+        "DIFF_ADDED":       str(ctx["added"]),
+        "DIFF_REMOVED":     str(ctx["removed"]),
+        "GH_REPO":          GH_REPO,
+    })
+
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write(prompt)
+        prompt_path = f.name
+
+    try:
+        # claude --print returns Claude's full response on stdout. We don't
+        # need --dangerously-skip-permissions — this is pure text generation.
+        result = subprocess.run(
+            ["claude", "--print"],
+            stdin=open(prompt_path),
+            capture_output=True, text=True, timeout=180,
+        )
+    finally:
+        os.unlink(prompt_path)
+
+    if result.returncode != 0:
+        die(f"claude --print failed (rc={result.returncode}): {result.stderr[:500]}")
+
+    return parse_json_tail(result.stdout)
+
+def parse_json_tail(text: str) -> dict:
+    """Extract the trailing JSON object — Claude is prompted to emit it last."""
+    # Find the last {...} block that parses as JSON.
+    candidates = list(re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL))
+    for m in reversed(candidates):
+        try:
+            obj = json.loads(m.group(0))
+        except json.JSONDecodeError:
+            continue
+        if "title" in obj and "body" in obj:
+            return obj
+    die("could not parse JSON {title, body} from claude output")
+
+# ---------------------------------------------------------------------------
+# Canny API
+# ---------------------------------------------------------------------------
+def canny_create_post(title: str, body: str) -> dict:
+    import urllib.parse, urllib.request
+
+    full_title = f"{CANNY_PREFIX} {title}".strip()
+    payload = urllib.parse.urlencode({
+        "apiKey":   CANNY_API_KEY,
+        "authorID": CANNY_ADMIN_ID,
+        "boardID":  CANNY_BOARD_ID,
+        "title":    full_title,
+        "details":  body,
+    }).encode()
+    req = urllib.request.Request(
+        "https://canny.io/api/v1/posts/create",
+        data=payload, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as e:
+        die(f"Canny posts/create failed: {e}")
+
+    # The API returns the created post with `id` + `url`. The URL on the
+    # response can be user-facing (canny.io/p/...) or an admin URL. We'll
+    # attach whichever is present.
+    return data
+
+def gh_pr_comment(pr: int, body: str) -> None:
+    try:
+        subprocess.run(
+            ["gh", "pr", "comment", str(pr), "--repo", GH_REPO, "--body", body],
+            check=True, capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.CalledProcessError as e:
+        # Non-fatal — the Canny post is already up; we just lost the linkback.
+        print(f"[post-to-canny] WARN: could not comment on PR #{pr}: {e.stderr.strip()}",
+              file=sys.stderr)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pr",     type=int, required=True)
+    ap.add_argument("--ticket", required=True)
+    ap.add_argument("--issue",  type=int, default=0)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if not canny_enabled():
+        log("Canny env not configured (need CANNY_API_KEY, CANNY_BOARD_ID, "
+            "CANNY_ADMIN_ID) — skipping changelog post.")
+        return 1
+
+    log(f"fetching PR #{args.pr} context ...")
+    ctx = fetch_pr_context(args.pr)
+    if not ctx["merged"]:
+        die("PR is not merged — refusing to post Canny entry")
+
+    issue_num = args.issue or infer_issue_from_body(ctx["body"]) or 0
+
+    log(f"generating non-technical summary (ticket={args.ticket}, issue=#{issue_num})")
+    summary = generate_summary(args.ticket, args.pr, issue_num, ctx)
+
+    log(f"summary title: {summary['title']!r}")
+
+    if args.dry_run:
+        log("--dry-run — rendered summary only, not posting")
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    log("creating Canny post ...")
+    canny = canny_create_post(summary["title"], summary["body"])
+    canny_url = canny.get("url") or canny.get("urlWithID") or ""
+    canny_id  = canny.get("id", "?")
+    log(f"  → Canny post id={canny_id}  url={canny_url or '(no url returned)'}")
+
+    # Linkback comment on the GitHub PR so the dashboard can render both sides
+    linkback = (
+        f"Changelog posted to Canny: {canny_url}\n\n"
+        f"_(Posted automatically by Phase E of ralph-rewrite-loop after squash merge. "
+        f"Ticket {args.ticket}, issue #{issue_num or '?'}, Canny post id `{canny_id}`.)_"
+    )
+    gh_pr_comment(args.pr, linkback)
+    log(f"linkback comment posted on PR #{args.pr}")
+
+    print(f"CANNY_URL={canny_url}")
+    print(f"CANNY_POST_ID={canny_id}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rewrite/resources/prompts/post-to-canny.md
+++ b/scripts/rewrite/resources/prompts/post-to-canny.md
@@ -1,0 +1,71 @@
+You are writing a **changelog entry** that will be posted to our Canny
+board (non-technical users + stakeholders read this) for PR
+#{{PR_NUM}} which just merged into `ralph-looped`.
+
+The PR implements ticket **{{TICKET_ID}}** (issue #{{ISSUE_NUM}}).
+
+---
+
+## PR context
+
+**Title:** {{PR_TITLE}}
+
+**Body:**
+{{PR_BODY}}
+
+**Files touched ({{DIFF_FILE_COUNT}}):**
+{{DIFF_FILE_LIST}}
+
+**Diff size:** +{{DIFF_ADDED}} / -{{DIFF_REMOVED}} lines
+
+---
+
+## What to produce
+
+Emit **exactly one JSON object** at the end of your output — nothing
+else after it. Schema:
+
+```json
+{
+  "title": "<post title, 30–80 chars, non-technical>",
+  "body":  "<post body, 2–5 sentences, plain English>"
+}
+```
+
+### Writing rules for the title
+
+- **Non-technical.** If the PR talks about `pgvector`, say "search
+  index" / "AI memory". If it mentions `Alembic migration`, say
+  "database update". `MCP tool` → "AI helper tool". `SSE` → "live chat
+  streaming". Translate, don't transliterate.
+- **Benefit-framed** when possible — what does this unlock for users
+  or the business? ("Faster scene grading", "New PDF case-study
+  upload flow", etc.)
+- **Do not** include the ticket id, PR number, phase number, branch
+  name, or CodeRabbit verbiage in the title.
+
+### Writing rules for the body
+
+- 2–5 sentences. Plain English. Active voice.
+- Lead with the user / professor / student impact. Tech details go in
+  one trailing sentence at most.
+- Mention the ticket id once at the very end for traceability:
+  `Tracked as {{TICKET_ID}}.`
+- **Always** finish the body with a linkback line on its own:
+  `→ Pull request: https://github.com/{{GH_REPO}}/pull/{{PR_NUM}}`
+- Do **not** mention API keys, connection strings, Neon branch names,
+  Railway env names, or other internal infra jargon. Those don't
+  belong on a user-facing changelog.
+
+## Output requirement
+
+Print your JSON object as the **last thing** in your output. The
+orchestrator will `json.loads` whatever trails the final ``` fence.
+Any preamble (thinking out loud) before the JSON is fine, but once
+the JSON block closes, print nothing else.
+
+Example of acceptable trailing JSON:
+
+```json
+{"title": "Faster onboarding for new cohorts", "body": "Professors can now create a cohort, upload a case study, and send invites in a single guided flow instead of three separate steps. The change also tightens the backend validation so students no longer see intermittent errors when joining right after a cohort is published. Tracked as phase-2.4.\n→ Pull request: https://github.com/Hendrik040/n-aible_edtech_sims/pull/438"}
+```


### PR DESCRIPTION
## Summary

Extends the Ralph rewrite loop with a new **Phase E** that auto-posts
a Canny changelog entry every time a rewrite ticket's PR squash-merges
into `ralph-looped`. Goal: give the admin dashboard a user-friendly
narrative layer alongside the technical GitHub PR / issue data it
already shows.

### How it works

1. Phase D (existing) does `gh pr merge --squash`. On exit 0 →
2. Phase E invokes `claude --print` with `prompts/post-to-canny.md`
   — the prompt feeds it the merged-PR title/body/diff summary and
   requires a trailing JSON `{title, body}` block written in plain
   English. No internal jargon (Alembic, pgvector, MCP, Neon branch
   names, Railway env names) is allowed in the output.
3. `post-to-canny.py` parses that JSON, POSTs to
   `canny.io/api/v1/posts/create` as `CANNY_ADMIN_ID` (your admin
   impersonation), and writes a linkback comment on the GitHub PR
   with the Canny URL.
4. The admin dashboard already has "linked to GitHub + Canny"
   plumbing — filtering posts by the `[rewrite]` title prefix
   (env-overridable via `CANNY_TITLE_PREFIX`) surfaces the changelog
   slice.

### Decisions (per thread)

- **Same board** as user feedback, differentiated by title prefix.
- **Author** = `CANNY_ADMIN_ID` impersonation.
- **Back-link both directions** — Canny post body links the PR,
  PR comment links the Canny post.
- **Merge-only trigger** — PRs that close unmerged get no Canny entry.
- Non-fatal on failure: a missed changelog never blocks the next
  iteration (loop logs a WARN and moves on).

### Security

- Canny creds read from env at runtime; never logged, never committed.
- `config.sh` uses grep-load (not `source`) on `.env` — avoids `eval`
  of untrusted file contents.
- No hardcoded tokens anywhere.

## Files changed

| File | Change |
| --- | --- |
| `scripts/rewrite/resources/prompts/post-to-canny.md` | NEW — the Claude prompt |
| `scripts/rewrite/resources/post-to-canny.py` | NEW — the orchestrator |
| `scripts/rewrite/resources/config.sh` | load CANNY_* from .env, title prefix default |
| `scripts/rewrite/ralph-rewrite-loop.sh` | new `phase_post_canny()` + gated call after `phase_merge` |
| `scripts/rewrite/WORKFLOW.md` | Phase E added to the diagram |

5 files changed, 370 insertions(+), 1 deletion(-).

## Test plan

- [x] Syntax-check all shell + python files
- [x] `python3 post-to-canny.py --pr 452 --ticket phase-0.1` with no
      Canny env — gracefully skips with exit 1 (distinguishable from
      exit 2 hard failure)
- [x] `config.sh` loads without .env — all CANNY_* vars empty, no crash
- [ ] CodeRabbit review of this PR passes
- [ ] First rewrite-ticket merge (coming out of iteration 1 of the
      live loop on 430 (phase-0.1)) produces a real Canny entry we can visually
      verify

## Follow-ups (not in this PR)

- Admin dashboard frontend: add a filter/card for `[rewrite]`-prefixed
  Canny posts so the changelog slice renders distinctly from user
  feedback.
- If the output gets too chatty (one entry per ticket = 22 entries
  during the rewrite track), we can batch — e.g., one Canny entry per
  phase group instead of per ticket. Easy change, wait for signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged pull requests now automatically generate and publish non-technical changelog entries with user-friendly summaries that highlight impact and benefits.

* **Documentation**
  * Updated merge workflow documentation to include new automated changelog posting phase.

* **Chores**
  * Added configuration support for changelog integration platform with environment-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
