### PR TITLE
fix(rewrite): BSD awk + heartbeat logs + ralph-status.sh dashboard

### DIFF
--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -105,10 +105,11 @@ phase_address_feedback() {
 
   # Wait for the first CR-bot comment to appear.
   local polls=$((CR_REVIEW_WAIT_SEC / 60)) i
-  log "  waiting for first CodeRabbit review (up to ${CR_REVIEW_WAIT_SEC}s)"
+  log "  waiting for first CodeRabbit PR review (polling every 60s, up to ${polls} times / ${CR_REVIEW_WAIT_SEC}s)"
   for i in $(seq 1 "$polls"); do
     sleep 60
-    [ -n "$(get_cr_pr_comments "$pr_num")" ] && break
+    if [ -n "$(get_cr_pr_comments "$pr_num")" ]; then log "  CR review arrived (poll ${i}/${polls})"; break; fi
+    log "  CR PR-review poll ${i}/${polls} — no review yet"
   done
 
   local round=0 prev_count
@@ -144,11 +145,13 @@ phase_address_feedback() {
 
     # Give CR time to re-review after the push.
     local wait_polls=$((CR_FOLLOWUP_WAIT_SEC / 60)) j
+    log "  waiting for CR re-review after round ${round} (polling every 60s, up to ${wait_polls} times)"
     for j in $(seq 1 "$wait_polls"); do
       sleep 60
-      cr_approved "$pr_num" && { log "  CR approved after round ${round}"; return 0; }
+      cr_approved "$pr_num" && { log "  CR approved after round ${round} (poll ${j}/${wait_polls})"; return 0; }
       local n; n=$(count_cr_pr_comments "$pr_num")
-      [ "$n" -ne "$prev_count" ] && { log "  new CR feedback detected"; break; }
+      if [ "$n" -ne "$prev_count" ]; then log "  new CR feedback detected (poll ${j}/${wait_polls})"; break; fi
+      log "  CR re-review poll ${j}/${wait_polls} — no new feedback yet"
     done
   done
 
@@ -182,7 +185,7 @@ phase_run_tests() {
 # Phase D: wait for CI + squash merge.
 phase_merge() {
   local pr_num=$1
-  log "  polling CI (up to ${CI_MAX_POLLS} x ${CI_POLL_SEC}s)"
+  log "  polling CI (every ${CI_POLL_SEC}s, up to ${CI_MAX_POLLS} times)"
   local i
   for i in $(seq 1 "$CI_MAX_POLLS"); do
     if ci_checks_pass "$pr_num"; then
@@ -190,6 +193,7 @@ phase_merge() {
       gh pr merge "$pr_num" --repo "$GH_REPO" --squash --delete-branch 2>&1 | tee -a "$MASTER_LOG"
       return 0
     fi
+    log "  CI poll ${i}/${CI_MAX_POLLS} — not green yet"
     sleep "$CI_POLL_SEC"
   done
   log "  CI not green after polls — leaving PR #${pr_num} open"
@@ -240,13 +244,16 @@ for ITER in $(seq 1 "$ITERATIONS"); do
   TICKET_SPEC=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json body --jq .body)
   CR_PLAN=$(get_cr_plan "$ISSUE_NUM")
   if [ -z "$CR_PLAN" ]; then
-    log "  no CodeRabbit plan yet — triggering and waiting"
+    log "  no CodeRabbit plan yet — triggering and polling (every ${CR_PLAN_POLL_SEC}s, up to ${CR_PLAN_MAX_POLLS} times)"
     gh issue comment "$ISSUE_NUM" --repo "$GH_REPO" --body "@coderabbitai plan" >/dev/null 2>&1 || true
     for p in $(seq 1 "$CR_PLAN_MAX_POLLS"); do
       sleep "$CR_PLAN_POLL_SEC"
       CR_PLAN=$(get_cr_plan "$ISSUE_NUM")
-      [ -n "$CR_PLAN" ] && { log "  plan received (poll ${p})"; break; }
+      if [ -n "$CR_PLAN" ]; then log "  plan received (poll ${p}/${CR_PLAN_MAX_POLLS})"; break; fi
+      log "  CR plan poll ${p}/${CR_PLAN_MAX_POLLS} — still waiting"
     done
+  else
+    log "  CodeRabbit plan already present on issue — skipping poll"
   fi
   [ -z "$CR_PLAN" ] && CR_PLAN="(no CodeRabbit plan; proceed using the ticket spec as sole guide)"
 

--- a/scripts/rewrite/ralph-status.sh
+++ b/scripts/rewrite/ralph-status.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ralph-status.sh — at-a-glance dashboard for a running (or recent) Ralph
+#                   rewrite loop.
+#
+# Pulls answers to the four questions you actually care about when checking
+# in on the loop:
+#   1. is the loop even alive?
+#   2. which ticket is it on and what phase?
+#   3. is Claude actively doing something, or silently polling?
+#   4. is there an open PR, and what's CodeRabbit/CI/Railway saying?
+#
+# Usage:
+#   scripts/rewrite/ralph-status.sh             # one-shot snapshot
+#   scripts/rewrite/ralph-status.sh --watch     # refresh every 10s (Ctrl-C to stop)
+#   scripts/rewrite/ralph-status.sh --log       # also tail the last 30 log lines
+#   scripts/rewrite/ralph-status.sh --help
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=resources/config.sh
+. "$SCRIPT_DIR/resources/config.sh"
+
+WATCH=0; SHOW_LOG=0
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch|-w) WATCH=1; shift ;;
+    --log|-l)   SHOW_LOG=1; shift ;;
+    --help|-h)  sed -n '4,18p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *)          echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+hr() { printf '%s\n' "────────────────────────────────────────────────────────────"; }
+
+# --- Human-friendly elapsed since a unix timestamp -------------------------
+since() {
+  local then=$1 now
+  now=$(date +%s)
+  local d=$((now - then))
+  if   [ "$d" -lt 60 ];    then printf "%ds"       "$d"
+  elif [ "$d" -lt 3600 ];  then printf "%dm%02ds"  $((d/60)) $((d%60))
+  elif [ "$d" -lt 86400 ]; then printf "%dh%02dm"  $((d/3600)) $(((d%3600)/60))
+  else                         printf "%dd%02dh"   $((d/86400)) $(((d%86400)/3600))
+  fi
+}
+
+snapshot() {
+  clear 2>/dev/null
+  echo "Ralph loop status  ·  $(date '+%Y-%m-%d %H:%M:%S')"
+  hr
+
+  # 1. Loop process state --------------------------------------------------
+  local main_pid
+  main_pid=$(pgrep -f 'bash scripts/rewrite/ralph-rewrite-loop.sh' 2>/dev/null | head -1)
+  if [ -n "$main_pid" ]; then
+    local started_at
+    started_at=$(ps -o lstart= -p "$main_pid" 2>/dev/null | sed 's/^ *//;s/ *$//')
+    # BSD ps has no `etimes` — parse `etime` (DD-HH:MM:SS | HH:MM:SS | MM:SS).
+    local uptime_s
+    uptime_s=$(ps -o etime= -p "$main_pid" 2>/dev/null | awk '
+      { n = split($1, p, /[-:]/)
+        if (n == 2)      { s = p[1]*60 + p[2] }
+        else if (n == 3) { s = p[1]*3600 + p[2]*60 + p[3] }
+        else if (n == 4) { s = p[1]*86400 + p[2]*3600 + p[3]*60 + p[4] }
+        else             { s = 0 }
+        print s
+      }')
+    local subshells
+    subshells=$(pgrep -f 'bash scripts/rewrite/ralph-rewrite-loop.sh' 2>/dev/null | wc -l | tr -d ' ')
+    echo "  loop       ✅ alive   PID=${main_pid}  (+${subshells} subshells)"
+    [ -n "$uptime_s" ] && [ "$uptime_s" -gt 0 ] 2>/dev/null \
+        && echo "             uptime     $(since $(($(date +%s) - uptime_s)))"
+    [ -n "$started_at" ] && echo "             started    ${started_at}"
+  else
+    echo "  loop       ❌ not running"
+  fi
+
+  # 2. Master log — most recent entry + phase detection -------------------
+  local latest_log
+  latest_log=$(ls -t "${LOG_DIR}"/rewrite_*.log 2>/dev/null | head -1)
+  if [ -n "$latest_log" ]; then
+    local last_line; last_line=$(tail -1 "$latest_log" 2>/dev/null)
+    local last_mtime; last_mtime=$(stat -f '%m' "$latest_log" 2>/dev/null)
+    local phase="unknown"
+    # Walk the log bottom-up to find the most recent phase marker.
+    if grep -q '→ invoking Claude for testing'            "$latest_log"; then phase="C-testing"; fi
+    if grep -q '→ invoking Claude for implementation'     "$latest_log" \
+       && ! grep -q '→ invoking Claude for testing'       "$latest_log"; then phase="A-implement"; fi
+    if grep -q 'waiting for first CodeRabbit PR review'   "$latest_log" \
+       && ! grep -q '→ invoking Claude for testing'       "$latest_log"; then phase="B-review"; fi
+    if grep -q 'polling CI'                               "$latest_log" \
+       && ! grep -q 'CI green — merging'                  "$latest_log"; then phase="D-ci"; fi
+    if grep -q 'CI green — merging'                       "$latest_log" \
+       && ! grep -q 'Canny post ok\|Canny post failed'    "$latest_log"; then phase="E-canny"; fi
+    echo "  log file   ${latest_log/${REPO_DIR}\//}"
+    [ -n "$last_mtime" ] && echo "             last write $(since "$last_mtime") ago"
+    echo "             phase      ${phase}"
+    echo "             last line  ${last_line}"
+  else
+    echo "  log file   (none yet)"
+  fi
+
+  # 3. Claude subprocess ---------------------------------------------------
+  local claude_line
+  claude_line=$(ps -eo pid,etime,args | awk '/ claude --print/ && !/awk/ {print; exit}')
+  if [ -n "$claude_line" ]; then
+    echo "  claude     ✅ running"
+    echo "             $(echo "$claude_line" | awk '{printf "PID=%s  runtime=%s", $1, $2}')"
+    # Most recent bash subprocess Claude spawned (the actual work).
+    local worker
+    worker=$(ps -eo pid,etime,comm,args \
+             | grep -E 'uv sync|pytest|alembic|pip install' \
+             | grep -v 'grep ' | head -1)
+    [ -n "$worker" ] && echo "             worker     $(echo "$worker" | awk '{printf "%s (runtime %s)", $3, $2}')"
+  else
+    echo "  claude     ∅ not running (either between phases or loop finished)"
+  fi
+
+  # 4. Current worktree ----------------------------------------------------
+  local wt
+  wt=$(ls -dt "${WORKTREE_BASE}"/rewrite-* 2>/dev/null | head -1)
+  if [ -n "$wt" ]; then
+    local wt_size; wt_size=$(du -sh "$wt" 2>/dev/null | awk '{print $1}')
+    local wt_branch; wt_branch=$(git -C "$wt" branch --show-current 2>/dev/null)
+    echo "  worktree   ${wt/${WORKTREE_BASE}\//}"
+    echo "             size     ${wt_size:-?}"
+    echo "             branch   ${wt_branch:-<detached>}"
+    # Show any staged/unstaged work inside the worktree.
+    local wt_changes
+    wt_changes=$(git -C "$wt" status --short 2>/dev/null | wc -l | tr -d ' ')
+    echo "             changes  ${wt_changes} file(s) dirty"
+  fi
+
+  # 5. Open PR (if any) ---------------------------------------------------
+  local pr_json
+  pr_json=$(gh pr list --repo "$GH_REPO" --base "$BASE_BRANCH" --state open \
+              --label "$LABEL" --limit 5 --json number,title,mergeable,reviewDecision,statusCheckRollup 2>/dev/null)
+  if [ -n "$pr_json" ] && [ "$pr_json" != "[]" ]; then
+    echo ""
+    echo "  open rewrite-agent-sdk PRs on ${BASE_BRANCH}:"
+    echo "$pr_json" | python3 - <<'PY'
+import json, sys
+prs = json.load(sys.stdin)
+for pr in prs:
+    checks = pr.get("statusCheckRollup") or []
+    n_fail = sum(1 for c in checks if c.get("conclusion") == "FAILURE")
+    n_pass = sum(1 for c in checks if c.get("conclusion") == "SUCCESS")
+    n_pend = sum(1 for c in checks if c.get("conclusion") in (None, "PENDING"))
+    review = pr.get("reviewDecision") or "—"
+    mergeable = pr.get("mergeable") or "?"
+    print(f"    #{pr['number']}  {pr['title'][:60]}")
+    print(f"         review={review}  mergeable={mergeable}  CI=✅{n_pass}/❌{n_fail}/⏳{n_pend}")
+PY
+  fi
+
+  # 6. Tail recent log lines if asked -------------------------------------
+  if [ "$SHOW_LOG" = "1" ] && [ -n "$latest_log" ]; then
+    echo ""
+    echo "  recent log (last 30 lines):"
+    tail -30 "$latest_log" | sed 's/^/    /'
+  fi
+
+  hr
+}
+
+if [ "$WATCH" = "1" ]; then
+  while true; do snapshot; sleep 10; done
+else
+  snapshot
+fi

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -229,11 +229,14 @@ start_watchdog() {
   (
     while true; do
       sleep 300
+      # BSD awk (macOS) rejects chained ternaries — use if/else.
       ps -eo pid,etime,comm | awk -v max="$CLAUDE_TIMEOUT_SEC" '
         /claude/ {
           n = split($2, p, /[-:]/)
-          s = (n==2)?(p[1]*60+p[2]):(n==3)?(p[1]*3600+p[2]*60+p[3]):
-              (n==4)?(p[1]*86400+p[2]*3600+p[3]*60+p[4]):0
+          if (n == 2)      { s = p[1]*60 + p[2] }
+          else if (n == 3) { s = p[1]*3600 + p[2]*60 + p[3] }
+          else if (n == 4) { s = p[1]*86400 + p[2]*3600 + p[3]*60 + p[4] }
+          else             { s = 0 }
           if (s > max) print $1
         }
       ' | while read -r pid; do


### PR DESCRIPTION
## Summary

Three robustness fixes so the Ralph rewrite loop can be kicked off
overnight without looking dead. Triggered by investigating why the
in-flight iteration 1 appeared stuck — turned out it was healthy,
just silent (Phase A's Claude was 14 min into scaffolding backend_v2)
plus BSD awk was spamming noise from the watchdog.

## What changed

### 1. BSD awk portability (`resources/lib.sh`)
The watchdog used a chained ternary that BSD awk (macOS default)
rejects with "syntax error". Swapped for if/else if. Watchdog was
always functional (errors confined to the background subshell) but
was noisy — now silent.

### 2. Heartbeat logs (`ralph-rewrite-loop.sh`)
Every silent-poll section now emits one log line per poll. Covered:
- CR plan poll (up to 20 min)
- First-PR-review poll (up to 20 min)
- CR re-review poll after each round (up to 20 min)
- CI poll (up to 10 min)

Result: the master log is never quiet for more than ~60s during
normal operation. "Is it dead?" becomes trivially answerable.

### 3. `ralph-status.sh` — at-a-glance dashboard
New companion script. Answers the four questions you actually care
about when checking on the loop:

```
Ralph loop status  ·  2026-04-12 23:18:35
────────────────────────────────────────────────────────────
  loop       ✅ alive   PID=77203  (+5 subshells)
             uptime     14m57s
             started    Sun Apr 12 23:03:38 2026
  log file   scripts/rewrite/logs/rewrite_20260412_230338.log
             last write 14m41s ago
             phase      A-implement
             last line  [23:03:54]   → invoking Claude for implementation
  claude     ✅ running
             PID=78056  runtime=14:42
             worker     /bin/zsh (runtime 00:01)
  worktree   rewrite-phase-0.01-1776060233
             size     647M
             branch   ralph-looped-rewrite/phase-0.01-...
             changes  1 file(s) dirty
────────────────────────────────────────────────────────────
```

Flags:
- `--watch` / `-w` — refresh every 10s, Ctrl-C to stop
- `--log` / `-l` — also tail the last 30 master-log lines
- `--help` / `-h`

Phase inference walks the log bottom-up for phase markers, so even
a stale log tells you where the loop got to.

## Security / scope

Pure robustness fixes — no new capabilities, no new external calls,
no secret surfaces. `ralph-status.sh` reads from local processes and
`gh pr list` (public info). Never touches any API keys.

## Test plan

- [x] Syntax-check all three changed files (bash -n)
- [x] Run `ralph-status.sh` live against the in-flight iteration 1 —
      correctly identifies phase A-implement, live Claude subprocess,
      worktree size, branch, etc.
- [x] BSD awk watchdog logic verified with if/else form
- [ ] CodeRabbit review of this PR passes
- [ ] Once merged and next overnight run kicks off — verify heartbeat
      logs appear at the expected cadence

## Doesn't touch

- The currently-running iteration 1 — which is on the pre-fix code
  — continues as-is. These fixes apply to future iterations.
- Phase E (Canny) — that's a separate PR (#453) still in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a terminal dashboard tool for monitoring active Ralph rewrite loops with real-time status updates, including process details, current phase tracking, log tails, worktree information, and associated GitHub PR metadata.

* **Improvements**
  * Enhanced polling loops with more descriptive progress logging, displaying iteration counts and status messages at each step.
  * Improved code compatibility across Unix-like systems through refactored conditional logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->