### PR TITLE
fix(ci+ralph): pytest --timeout + tighten loop PR-detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,7 @@ jobs:
         run: uv sync --extra test
 
       - name: Run tests
-        run: uv run pytest tests/ -x -q --tb=short
+        # --timeout=30 prevents a single hanging test from burning the
+        # whole job to the 6h GH Actions runner default. Requires
+        # pytest-timeout (in backend/pyproject.toml test extras).
+        run: uv run pytest tests/ -x -q --tb=short --timeout=30

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.uv]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2119,6 +2119,7 @@ dependencies = [
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
 ]
 
 [package.dev-dependencies]
@@ -2156,6 +2157,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.6.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.4.0" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "python-jose", extras = ["cryptography"], specifier = "==3.5.0" },
     { name = "python-multipart", specifier = "==0.0.20" },
@@ -2947,6 +2949,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -95,9 +95,15 @@ PY
 }
 
 pr_already_open_for() {
+  # Scope: only PRs labeled `rewrite-agent-sdk` (excludes tooling PRs that
+  # happen to mention a ticket number in their body). Match: strict regex
+  # on closing keywords, not loose full-text search — gh's --search matches
+  # any occurrence of "430", so unrelated PR bodies can false-positive.
   local issue=$1
   gh pr list --repo "$GH_REPO" --base "$BASE_BRANCH" --state open \
-    --search "Fixes #${issue}" --json number --jq '.[0].number' 2>/dev/null
+    --label "$LABEL" --limit 50 --json number,body \
+    --jq ".[] | select(.body | test(\"(?i)(?:fixes|closes|resolves)\\\\s+#${issue}\\\\b\")) | .number" \
+    2>/dev/null | head -1
 }
 
 get_cr_plan() {


### PR DESCRIPTION
Hotfix to unblock the overnight rewrite loop. See commit message for full context.

## Test plan
- [x] uv sync --extra test resolves pytest-timeout cleanly
- [x] CI line still parseable, just adds --timeout=30
- [x] Loop's pr_already_open_for() tested with stricter regex; no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added 30-second timeout handling to test execution in CI pipeline
  * Added pytest-timeout dependency to test environment
  * Improved PR detection logic for better accuracy in automation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->