### PR TITLE
phase-1.02: direct-SQL pgvector store service

### DIFF
--- a/backend_v2/common/services/pgvector_store.py
+++ b/backend_v2/common/services/pgvector_store.py
@@ -1,0 +1,288 @@
+"""Direct SQL pgvector store for ``vector_embeddings`` and ``grading_material_chunks``.
+
+Replaces the LangChain ``PGVector`` wrapper with focused async helpers that
+execute parameterised SQL through the existing ``SessionLocal`` factory.
+The table schema is unchanged — embeddings live in JSON columns — so the
+queries cast ``(embedding_vector::text)::vector`` at read time to use
+pgvector's native ``<=>`` cosine-distance operator.
+
+Blocking DB work is dispatched through :func:`asyncio.to_thread` so the
+public API is ``async def`` without introducing an async driver.
+
+Public surface:
+
+    await similarity_search(query_embedding, namespace, k=5)
+    await upsert(embedding, metadata, namespace)
+
+Supported namespaces:
+
+    "memory" | "conversation" | "scene"  → ``vector_embeddings`` filtered by
+                                            ``entity_type``
+    "grading"                            → ``grading_material_chunks``
+                                            keyed by ``(material_id,
+                                            content_hash)``
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from common.db.connection import SessionLocal
+
+_VECTOR_EMBEDDING_NAMESPACES: frozenset[str] = frozenset(
+    {"memory", "conversation", "scene"}
+)
+_GRADING_NAMESPACE = "grading"
+SUPPORTED_NAMESPACES: frozenset[str] = (
+    _VECTOR_EMBEDDING_NAMESPACES | frozenset({_GRADING_NAMESPACE})
+)
+
+DEFAULT_K = 5
+
+SessionFactory = Callable[[], Session]
+
+
+class UnsupportedNamespaceError(ValueError):
+    """Raised when a namespace does not map to a known table."""
+
+
+def _validate_namespace(namespace: str) -> None:
+    if namespace not in SUPPORTED_NAMESPACES:
+        raise UnsupportedNamespaceError(
+            f"namespace {namespace!r} not in {sorted(SUPPORTED_NAMESPACES)}"
+        )
+
+
+def _format_vector_literal(vec: list[float]) -> str:
+    """Format a ``list[float]`` as a pgvector text literal (``[a,b,c]``)."""
+    return "[" + ",".join(format(float(x), ".17g") for x in vec) + "]"
+
+
+async def similarity_search(
+    query_embedding: list[float],
+    namespace: str,
+    k: int = DEFAULT_K,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> list[dict]:
+    """Return the ``k`` nearest rows for ``namespace``, ordered closest first.
+
+    Each result dict contains ``id``, identifier/content columns for the
+    backing table, and ``similarity_score`` = ``1 - cosine_distance``.
+    Returns ``[]`` when ``k <= 0``.
+    """
+    _validate_namespace(namespace)
+    if not query_embedding:
+        raise ValueError("query_embedding must be a non-empty list of floats")
+    if k <= 0:
+        return []
+
+    factory = session_factory or SessionLocal
+    return await asyncio.to_thread(
+        _similarity_search_sync, factory, query_embedding, namespace, k
+    )
+
+
+async def upsert(
+    embedding: list[float],
+    metadata: dict,
+    namespace: str,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> str:
+    """Insert or update a single embedding row and return its id as a string.
+
+    Idempotency keys (no schema change, so upsert is emulated in a single
+    transaction via DELETE + INSERT):
+      - ``vector_embeddings``   → ``(entity_type, entity_id)``
+        requires ``metadata['entity_id']``
+      - ``grading_material_chunks`` → ``(material_id, content_hash)``
+        requires ``metadata['material_id']`` and ``metadata['content_hash']``
+    """
+    _validate_namespace(namespace)
+    if not embedding:
+        raise ValueError("embedding must be a non-empty list of floats")
+    if not isinstance(metadata, dict):
+        raise TypeError("metadata must be a dict")
+
+    factory = session_factory or SessionLocal
+    return await asyncio.to_thread(
+        _upsert_sync, factory, embedding, metadata, namespace
+    )
+
+
+def _similarity_search_sync(
+    factory: SessionFactory,
+    query_embedding: list[float],
+    namespace: str,
+    k: int,
+) -> list[dict]:
+    vec = _format_vector_literal(query_embedding)
+    session = factory()
+    try:
+        if namespace == _GRADING_NAMESPACE:
+            sql = text(
+                """
+                SELECT id,
+                       material_id,
+                       chunk_index,
+                       content,
+                       content_hash,
+                       1 - ((embedding_vector::text)::vector
+                             <=> CAST(:vec AS vector)) AS similarity_score
+                FROM grading_material_chunks
+                WHERE embedding_vector IS NOT NULL
+                ORDER BY (embedding_vector::text)::vector
+                         <=> CAST(:vec AS vector)
+                LIMIT :k
+                """
+            )
+            params: dict[str, Any] = {"vec": vec, "k": k}
+        else:
+            sql = text(
+                """
+                SELECT id,
+                       entity_type,
+                       entity_id,
+                       embedding_metadata,
+                       1 - ((embedding_vector::text)::vector
+                             <=> CAST(:vec AS vector)) AS similarity_score
+                FROM vector_embeddings
+                WHERE entity_type = :ns
+                  AND embedding_vector IS NOT NULL
+                ORDER BY (embedding_vector::text)::vector
+                         <=> CAST(:vec AS vector)
+                LIMIT :k
+                """
+            )
+            params = {"vec": vec, "ns": namespace, "k": k}
+
+        rows = session.execute(sql, params).mappings().all()
+        return [dict(row) for row in rows]
+    finally:
+        session.close()
+
+
+def _upsert_sync(
+    factory: SessionFactory,
+    embedding: list[float],
+    metadata: dict,
+    namespace: str,
+) -> str:
+    session = factory()
+    try:
+        if namespace == _GRADING_NAMESPACE:
+            new_id = _upsert_grading_chunk(session, embedding, metadata)
+        else:
+            new_id = _upsert_vector_embedding(session, embedding, metadata, namespace)
+        session.commit()
+        return str(new_id)
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _upsert_vector_embedding(
+    session: Session,
+    embedding: list[float],
+    metadata: dict,
+    namespace: str,
+) -> int:
+    entity_id = metadata.get("entity_id")
+    if entity_id is None:
+        raise ValueError(
+            "vector_embeddings namespaces require 'entity_id' in metadata"
+        )
+
+    embedding_model = metadata.get("embedding_model")
+    extra_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if key not in {"entity_id", "embedding_model"}
+    }
+
+    session.execute(
+        text(
+            "DELETE FROM vector_embeddings "
+            "WHERE entity_type = :ns AND entity_id = :eid"
+        ),
+        {"ns": namespace, "eid": entity_id},
+    )
+    return session.execute(
+        text(
+            """
+            INSERT INTO vector_embeddings
+                (entity_type, entity_id, embedding_vector,
+                 embedding_model, embedding_metadata)
+            VALUES (:ns, :eid, CAST(:vec AS json),
+                    :model, CAST(:meta AS json))
+            RETURNING id
+            """
+        ),
+        {
+            "ns": namespace,
+            "eid": entity_id,
+            "vec": json.dumps(embedding),
+            "model": embedding_model,
+            "meta": json.dumps(extra_metadata) if extra_metadata else None,
+        },
+    ).scalar_one()
+
+
+def _upsert_grading_chunk(
+    session: Session,
+    embedding: list[float],
+    metadata: dict,
+) -> int:
+    material_id = metadata.get("material_id")
+    content_hash = metadata.get("content_hash")
+    if material_id is None or content_hash is None:
+        raise ValueError(
+            "grading namespace requires 'material_id' and 'content_hash' "
+            "in metadata"
+        )
+
+    session.execute(
+        text(
+            "DELETE FROM grading_material_chunks "
+            "WHERE material_id = :mid AND content_hash = :ch"
+        ),
+        {"mid": material_id, "ch": content_hash},
+    )
+    return session.execute(
+        text(
+            """
+            INSERT INTO grading_material_chunks
+                (material_id, chunk_index, content,
+                 embedding_vector, embedding_model, embedding_dimension,
+                 content_hash)
+            VALUES (:mid, :cidx, :content,
+                    CAST(:vec AS json), :model, :dim, :ch)
+            RETURNING id
+            """
+        ),
+        {
+            "mid": material_id,
+            "cidx": metadata.get("chunk_index", 0),
+            "content": metadata.get("content", ""),
+            "vec": json.dumps(embedding),
+            "model": metadata.get("embedding_model"),
+            "dim": len(embedding),
+            "ch": content_hash,
+        },
+    ).scalar_one()
+
+
+__all__ = [
+    "DEFAULT_K",
+    "SUPPORTED_NAMESPACES",
+    "UnsupportedNamespaceError",
+    "similarity_search",
+    "upsert",
+]

--- a/backend_v2/tests/common/services/test_pgvector_store.py
+++ b/backend_v2/tests/common/services/test_pgvector_store.py
@@ -1,0 +1,549 @@
+"""Tests for :mod:`common.services.pgvector_store`.
+
+These tests exercise the module against a real PostgreSQL instance with the
+``vector`` extension enabled. A disposable database is created per-session
+so that repeated runs do not leak state.
+
+The test database URL comes from the ``PGVECTOR_TEST_DATABASE_URL`` env var
+(falling back to ``TEST_DATABASE_URL``). When neither is set the tests skip
+cleanly — the module's verification gate is documented on the ticket as
+requiring a disposable Postgres fixture.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Iterator
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from common.services.pgvector_store import (
+    DEFAULT_K,
+    SUPPORTED_NAMESPACES,
+    UnsupportedNamespaceError,
+    _format_vector_literal,
+    similarity_search,
+    upsert,
+)
+
+
+def _resolve_test_database_url() -> str | None:
+    """Return the URL to a Postgres instance with pgvector, or None to skip."""
+    return (
+        os.environ.get("PGVECTOR_TEST_DATABASE_URL")
+        or os.environ.get("TEST_DATABASE_URL")
+    )
+
+
+_DB_URL = _resolve_test_database_url()
+
+pytestmark = pytest.mark.skipif(
+    _DB_URL is None,
+    reason=(
+        "Set PGVECTOR_TEST_DATABASE_URL (or TEST_DATABASE_URL) to a Postgres "
+        "instance with the pgvector extension to run pgvector_store tests."
+    ),
+)
+
+
+@pytest.fixture(scope="session")
+def pgvector_engine() -> Iterator[Engine]:
+    """Session-scoped engine against the disposable Postgres instance.
+
+    Creates the ``vector`` extension and a minimal schema mirroring
+    ``vector_embeddings`` and ``grading_material_chunks`` — including the
+    ``grading_materials`` parent row referenced by the FK. The schema uses
+    JSON columns (matching production) so that the service's JSON→vector
+    casts are exercised end-to-end.
+    """
+    assert _DB_URL is not None  # guarded by pytestmark
+    engine = create_engine(_DB_URL, future=True)
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    except OperationalError as exc:
+        pytest.skip(f"Postgres unavailable at {_DB_URL!r}: {exc}")
+
+    schema_prefix = f"pgvector_test_{uuid.uuid4().hex[:8]}"
+    ve_table = f"{schema_prefix}_vector_embeddings"
+    gm_table = f"{schema_prefix}_grading_materials"
+    gmc_table = f"{schema_prefix}_grading_material_chunks"
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                f"""
+                CREATE TABLE {ve_table} (
+                    id SERIAL PRIMARY KEY,
+                    entity_type VARCHAR NOT NULL,
+                    entity_id INTEGER NOT NULL,
+                    embedding_vector JSON,
+                    embedding_model VARCHAR,
+                    embedding_metadata JSON,
+                    created_at TIMESTAMP WITH TIME ZONE
+                        DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                f"""
+                CREATE TABLE {gm_table} (
+                    id SERIAL PRIMARY KEY,
+                    filename VARCHAR NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                f"""
+                CREATE TABLE {gmc_table} (
+                    id SERIAL PRIMARY KEY,
+                    material_id INTEGER NOT NULL REFERENCES {gm_table}(id),
+                    chunk_index INTEGER NOT NULL,
+                    content TEXT NOT NULL,
+                    embedding_vector JSON,
+                    embedding_model VARCHAR,
+                    embedding_dimension INTEGER,
+                    content_hash VARCHAR
+                )
+                """
+            )
+        )
+        # The service targets the canonical table names; point them at the
+        # per-session test tables via updatable views so multiple concurrent
+        # test runs can't stomp on each other.
+        conn.execute(text("DROP VIEW IF EXISTS vector_embeddings CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS vector_embeddings CASCADE"))
+        conn.execute(
+            text(f"CREATE VIEW vector_embeddings AS SELECT * FROM {ve_table}")
+        )
+        conn.execute(text("DROP VIEW IF EXISTS grading_material_chunks CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS grading_material_chunks CASCADE"))
+        conn.execute(
+            text(
+                "CREATE VIEW grading_material_chunks AS "
+                f"SELECT * FROM {gmc_table}"
+            )
+        )
+
+    engine.test_tables = {  # type: ignore[attr-defined]
+        "vector_embeddings": ve_table,
+        "grading_materials": gm_table,
+        "grading_material_chunks": gmc_table,
+    }
+
+    try:
+        yield engine
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text("DROP VIEW IF EXISTS vector_embeddings CASCADE"))
+            conn.execute(
+                text("DROP VIEW IF EXISTS grading_material_chunks CASCADE")
+            )
+            conn.execute(text(f"DROP TABLE IF EXISTS {gmc_table} CASCADE"))
+            conn.execute(text(f"DROP TABLE IF EXISTS {gm_table} CASCADE"))
+            conn.execute(text(f"DROP TABLE IF EXISTS {ve_table} CASCADE"))
+        engine.dispose()
+
+
+@pytest.fixture
+def session_factory(pgvector_engine: Engine):
+    """Per-test sessionmaker with tables truncated between tests."""
+    tables = pgvector_engine.test_tables  # type: ignore[attr-defined]
+    with pgvector_engine.begin() as conn:
+        conn.execute(
+            text(
+                f"TRUNCATE TABLE {tables['grading_material_chunks']} "
+                f"RESTART IDENTITY CASCADE"
+            )
+        )
+        conn.execute(
+            text(
+                f"TRUNCATE TABLE {tables['grading_materials']} "
+                f"RESTART IDENTITY CASCADE"
+            )
+        )
+        conn.execute(
+            text(
+                f"TRUNCATE TABLE {tables['vector_embeddings']} "
+                f"RESTART IDENTITY CASCADE"
+            )
+        )
+    return sessionmaker(bind=pgvector_engine, autoflush=False, future=True)
+
+
+@pytest.fixture
+def seed_grading_material(pgvector_engine: Engine) -> int:
+    tables = pgvector_engine.test_tables  # type: ignore[attr-defined]
+    with pgvector_engine.begin() as conn:
+        material_id = conn.execute(
+            text(
+                f"INSERT INTO {tables['grading_materials']} (filename) "
+                "VALUES ('rubric.pdf') RETURNING id"
+            )
+        ).scalar_one()
+    return int(material_id)
+
+
+def _unit_vector(dim: int, axis: int) -> list[float]:
+    vec = [0.0] * dim
+    vec[axis] = 1.0
+    return vec
+
+
+def test_format_vector_literal_round_trips() -> None:
+    assert _format_vector_literal([1.0, 0.0, -0.5]) == "[1,0,-0.5]"
+
+
+def test_unsupported_namespace_raises() -> None:
+    assert "memory" in SUPPORTED_NAMESPACES
+    with pytest.raises(UnsupportedNamespaceError):
+        import asyncio
+
+        asyncio.run(
+            similarity_search([0.1, 0.2], "not-a-real-namespace", k=1)
+        )
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_returns_topk_ordered(session_factory) -> None:
+    """Inserted vectors come back ordered by cosine similarity, capped to ``k``."""
+    # Seed five distinct unit vectors along different axes.
+    for axis in range(5):
+        await upsert(
+            embedding=_unit_vector(8, axis),
+            metadata={"entity_id": 100 + axis, "label": f"axis-{axis}"},
+            namespace="memory",
+            session_factory=session_factory,
+        )
+
+    query = _unit_vector(8, 2)  # closest to entity_id=102, exact match
+    results = await similarity_search(
+        query_embedding=query,
+        namespace="memory",
+        k=3,
+        session_factory=session_factory,
+    )
+
+    assert len(results) == 3
+    # Closest result is the exact unit vector at axis 2.
+    assert results[0]["entity_id"] == 102
+    assert results[0]["similarity_score"] == pytest.approx(1.0, abs=1e-6)
+    # All other axes are orthogonal — cosine similarity ≈ 0.
+    for row in results[1:]:
+        assert row["similarity_score"] == pytest.approx(0.0, abs=1e-6)
+    # Ordering is monotonically non-increasing.
+    scores = [row["similarity_score"] for row in results]
+    assert scores == sorted(scores, reverse=True)
+    # Requested result keys are present.
+    for row in results:
+        assert set(row).issuperset(
+            {"id", "entity_type", "entity_id", "similarity_score"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_filters_by_namespace(session_factory) -> None:
+    """Results must only include rows whose ``entity_type`` matches the namespace."""
+    # Same vector payload, three different namespaces.
+    vec = _unit_vector(4, 0)
+    for namespace, entity_id in (
+        ("memory", 1),
+        ("conversation", 2),
+        ("scene", 3),
+    ):
+        await upsert(
+            embedding=vec,
+            metadata={"entity_id": entity_id},
+            namespace=namespace,
+            session_factory=session_factory,
+        )
+
+    # Also insert an unrelated vector into the queried namespace to confirm
+    # the result comes from that namespace and not a cross-namespace leak.
+    await upsert(
+        embedding=_unit_vector(4, 1),
+        metadata={"entity_id": 99},
+        namespace="conversation",
+        session_factory=session_factory,
+    )
+
+    results = await similarity_search(
+        query_embedding=vec,
+        namespace="conversation",
+        k=DEFAULT_K,
+        session_factory=session_factory,
+    )
+
+    returned_namespaces = {row["entity_type"] for row in results}
+    assert returned_namespaces == {"conversation"}
+    returned_ids = {row["entity_id"] for row in results}
+    assert returned_ids == {2, 99}
+
+
+@pytest.mark.asyncio
+async def test_upsert_inserts_row_with_metadata(
+    session_factory, seed_grading_material: int
+) -> None:
+    """Upsert writes the embedding and metadata to the correct backing table."""
+    # vector_embeddings branch
+    row_id = await upsert(
+        embedding=[0.1, 0.2, 0.3, 0.4],
+        metadata={
+            "entity_id": 42,
+            "embedding_model": "text-embedding-3-small",
+            "origin": "unit-test",
+        },
+        namespace="scene",
+        session_factory=session_factory,
+    )
+    assert row_id.isdigit()
+
+    with session_factory() as session:  # type: Session
+        row = session.execute(
+            text(
+                "SELECT entity_type, entity_id, embedding_vector, "
+                "       embedding_model, embedding_metadata "
+                "FROM vector_embeddings WHERE id = :id"
+            ),
+            {"id": int(row_id)},
+        ).mappings().one()
+
+    assert row["entity_type"] == "scene"
+    assert row["entity_id"] == 42
+    assert row["embedding_model"] == "text-embedding-3-small"
+    # JSON column may come back as a parsed list or as a JSON string depending
+    # on the driver — normalise before comparing.
+    stored_vec = row["embedding_vector"]
+    if isinstance(stored_vec, str):
+        stored_vec = json.loads(stored_vec)
+    assert stored_vec == [0.1, 0.2, 0.3, 0.4]
+    stored_meta = row["embedding_metadata"]
+    if isinstance(stored_meta, str):
+        stored_meta = json.loads(stored_meta)
+    assert stored_meta == {"origin": "unit-test"}
+
+    # grading_material_chunks branch
+    grading_id = await upsert(
+        embedding=[0.5, 0.6, 0.7, 0.8],
+        metadata={
+            "material_id": seed_grading_material,
+            "content_hash": "sha256:abc123",
+            "chunk_index": 7,
+            "content": "rubric excerpt",
+            "embedding_model": "text-embedding-3-small",
+        },
+        namespace="grading",
+        session_factory=session_factory,
+    )
+    assert grading_id.isdigit()
+
+    with session_factory() as session:
+        chunk = session.execute(
+            text(
+                "SELECT material_id, chunk_index, content, content_hash, "
+                "       embedding_model, embedding_dimension "
+                "FROM grading_material_chunks WHERE id = :id"
+            ),
+            {"id": int(grading_id)},
+        ).mappings().one()
+
+    assert chunk["material_id"] == seed_grading_material
+    assert chunk["chunk_index"] == 7
+    assert chunk["content"] == "rubric excerpt"
+    assert chunk["content_hash"] == "sha256:abc123"
+    assert chunk["embedding_dimension"] == 4
+
+
+@pytest.mark.asyncio
+async def test_upsert_is_idempotent_on_same_key(
+    session_factory, seed_grading_material: int
+) -> None:
+    """Re-upserting the same idempotency key updates in place instead of duplicating."""
+    # vector_embeddings idempotency on (entity_type, entity_id)
+    first = await upsert(
+        embedding=[0.1, 0.2, 0.3],
+        metadata={"entity_id": 7, "version": 1},
+        namespace="memory",
+        session_factory=session_factory,
+    )
+    second = await upsert(
+        embedding=[0.9, 0.8, 0.7],
+        metadata={"entity_id": 7, "version": 2},
+        namespace="memory",
+        session_factory=session_factory,
+    )
+
+    assert first != second  # DELETE+INSERT yields a new SERIAL id
+
+    with session_factory() as session:
+        rows = session.execute(
+            text(
+                "SELECT id, embedding_metadata FROM vector_embeddings "
+                "WHERE entity_type = 'memory' AND entity_id = 7"
+            )
+        ).mappings().all()
+
+    assert len(rows) == 1
+    assert str(rows[0]["id"]) == second
+    stored_meta = rows[0]["embedding_metadata"]
+    if isinstance(stored_meta, str):
+        stored_meta = json.loads(stored_meta)
+    assert stored_meta == {"version": 2}
+
+    # grading idempotency on (material_id, content_hash)
+    g_first = await upsert(
+        embedding=[1.0, 0.0],
+        metadata={
+            "material_id": seed_grading_material,
+            "content_hash": "sha256:deadbeef",
+            "content": "v1",
+        },
+        namespace="grading",
+        session_factory=session_factory,
+    )
+    g_second = await upsert(
+        embedding=[0.0, 1.0],
+        metadata={
+            "material_id": seed_grading_material,
+            "content_hash": "sha256:deadbeef",
+            "content": "v2",
+        },
+        namespace="grading",
+        session_factory=session_factory,
+    )
+    assert g_first != g_second
+    with session_factory() as session:
+        grading_rows = session.execute(
+            text(
+                "SELECT id, content FROM grading_material_chunks "
+                "WHERE material_id = :mid AND content_hash = :ch"
+            ),
+            {"mid": seed_grading_material, "ch": "sha256:deadbeef"},
+        ).mappings().all()
+
+    assert len(grading_rows) == 1
+    assert str(grading_rows[0]["id"]) == g_second
+    assert grading_rows[0]["content"] == "v2"
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_grading_namespace(
+    session_factory, seed_grading_material: int
+) -> None:
+    """Grading namespace queries the grading_material_chunks table."""
+    # Seed two grading chunks with orthogonal unit vectors.
+    await upsert(
+        embedding=_unit_vector(4, 0),
+        metadata={
+            "material_id": seed_grading_material,
+            "content_hash": "hash-a",
+            "chunk_index": 0,
+            "content": "alpha",
+        },
+        namespace="grading",
+        session_factory=session_factory,
+    )
+    await upsert(
+        embedding=_unit_vector(4, 1),
+        metadata={
+            "material_id": seed_grading_material,
+            "content_hash": "hash-b",
+            "chunk_index": 1,
+            "content": "beta",
+        },
+        namespace="grading",
+        session_factory=session_factory,
+    )
+
+    results = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="grading",
+        k=2,
+        session_factory=session_factory,
+    )
+
+    assert len(results) == 2
+    # Closest is the identical unit vector → content "alpha".
+    assert results[0]["content"] == "alpha"
+    assert results[0]["similarity_score"] == pytest.approx(1.0, abs=1e-6)
+    assert results[1]["content"] == "beta"
+    # Each result dict carries grading-specific columns.
+    for row in results:
+        assert set(row).issuperset(
+            {"id", "material_id", "chunk_index", "content", "content_hash"}
+        )
+
+
+# ---- Non-DB argument validation (help push coverage ≥85%) --------------
+
+
+def test_similarity_search_rejects_empty_embedding() -> None:
+    import asyncio
+
+    with pytest.raises(ValueError):
+        asyncio.run(similarity_search([], "memory", k=3))
+
+
+def test_similarity_search_returns_empty_when_k_not_positive(session_factory) -> None:
+    import asyncio
+
+    assert asyncio.run(
+        similarity_search(
+            [0.1, 0.2],
+            "memory",
+            k=0,
+            session_factory=session_factory,
+        )
+    ) == []
+
+
+def test_upsert_rejects_empty_embedding() -> None:
+    import asyncio
+
+    with pytest.raises(ValueError):
+        asyncio.run(upsert([], {"entity_id": 1}, "memory"))
+
+
+def test_upsert_rejects_non_dict_metadata() -> None:
+    import asyncio
+
+    with pytest.raises(TypeError):
+        asyncio.run(upsert([0.1], "not-a-dict", "memory"))  # type: ignore[arg-type]
+
+
+def test_upsert_requires_entity_id_for_vector_embeddings(session_factory) -> None:
+    import asyncio
+
+    with pytest.raises(ValueError, match="entity_id"):
+        asyncio.run(
+            upsert(
+                [0.1, 0.2],
+                {},
+                "memory",
+                session_factory=session_factory,
+            )
+        )
+
+
+def test_upsert_requires_material_id_and_hash_for_grading(session_factory) -> None:
+    import asyncio
+
+    with pytest.raises(ValueError, match="material_id"):
+        asyncio.run(
+            upsert(
+                [0.1, 0.2],
+                {"content_hash": "abc"},
+                "grading",
+                session_factory=session_factory,
+            )
+        )

--- a/backend_v2/tests/common/services/test_pgvector_store.py
+++ b/backend_v2/tests/common/services/test_pgvector_store.py
@@ -62,7 +62,18 @@ def pgvector_engine() -> Iterator[Engine]:
     casts are exercised end-to-end.
     """
     assert _DB_URL is not None  # guarded by pytestmark
-    engine = create_engine(_DB_URL, future=True)
+    # Safeguard: this fixture runs destructive DROP TABLE/VIEW statements
+    # against canonical table names (``vector_embeddings`` /
+    # ``grading_material_chunks``). Refuse to run if the target database URL
+    # does not look like a disposable test database, to avoid wiping real data
+    # if someone points ``PGVECTOR_TEST_DATABASE_URL`` at a shared instance.
+    if "test" not in _DB_URL.lower() and os.environ.get("PGVECTOR_TEST_FORCE") != "1":
+        pytest.skip(
+            "Refusing to run destructive pgvector fixture against a database "
+            "whose URL does not contain 'test'. Set PGVECTOR_TEST_FORCE=1 to "
+            "override."
+        )
+    engine = create_engine(_DB_URL)
 
     try:
         with engine.begin() as conn:
@@ -178,7 +189,7 @@ def session_factory(pgvector_engine: Engine):
                 f"RESTART IDENTITY CASCADE"
             )
         )
-    return sessionmaker(bind=pgvector_engine, autoflush=False, future=True)
+    return sessionmaker(bind=pgvector_engine, autoflush=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #432

Implements ticket phase-1.02 — direct-SQL pgvector store for `vector_embeddings` and `grading_material_chunks`, replacing the LangChain `PGVector` wrapper. See the issue for the full spec.

## Changes

- `backend_v2/common/services/pgvector_store.py` — new module with the two required async functions:
  - `async def similarity_search(query_embedding, namespace, k=5) -> list[dict]`
  - `async def upsert(embedding, metadata, namespace) -> str`
- Namespaces `memory` / `conversation` / `scene` → `vector_embeddings` filtered by `entity_type`; `grading` → `grading_material_chunks`. Unknown namespaces raise `UnsupportedNamespaceError`.
- Similarity uses pgvector's native `<=>` cosine-distance operator. Embeddings live in the existing JSON columns and are cast to `vector` at query time, so **no schema change / no Alembic migration** (per the ticket).
- Upsert is emulated in a single transaction (`DELETE` + `INSERT ... RETURNING id`) because the schema has no unique constraint on the idempotency keys — staying in-scope of "table schema is unchanged".
- Blocking DB work is dispatched through `asyncio.to_thread` so the API is `async def` without adding a new DB driver dependency.
- The module accepts a `session_factory` keyword argument; it defaults to `SessionLocal` from `common.db.connection` when omitted.

## Tests added

All four tests named in the ticket spec, plus a small amount of non-DB validation coverage and a grading-namespace branch for `similarity_search`:

- `test_similarity_search_returns_topk_ordered`
- `test_similarity_search_filters_by_namespace`
- `test_upsert_inserts_row_with_metadata`
- `test_upsert_is_idempotent_on_same_key`
- `test_similarity_search_grading_namespace` (covers the second backing table)
- `test_similarity_search_rejects_empty_embedding`, `test_similarity_search_returns_empty_when_k_not_positive`
- `test_upsert_rejects_empty_embedding`, `test_upsert_rejects_non_dict_metadata`
- `test_upsert_requires_entity_id_for_vector_embeddings`, `test_upsert_requires_material_id_and_hash_for_grading`
- `test_format_vector_literal_round_trips`, `test_unsupported_namespace_raises`

A session-scoped fixture provisions disposable per-run tables in a real Postgres instance with the `vector` extension, exposes them as `vector_embeddings` / `grading_material_chunks` via views, truncates between tests, and drops everything on teardown. Tests skip cleanly when `PGVECTOR_TEST_DATABASE_URL` (or `TEST_DATABASE_URL`) is unset.

## Verification

Run against a Postgres instance with pgvector (e.g. the `pgvector/pgvector:pg15` container in `docker-compose.yml`):

```
cd backend_v2
PGVECTOR_TEST_DATABASE_URL="postgresql://username:password@localhost:5432/pgvector_test" \
DATABASE_URL="postgresql://username:password@localhost:5432/pgvector_test" \
SECRET_KEY=test OPENAI_API_KEY=test \
uv run pytest tests/common/services/test_pgvector_store.py -q \
  --cov=common.services.pgvector_store --cov-fail-under=85
```

Result: **13 passed, 100% coverage** of `common/services/pgvector_store.py`.

Note: the verification command in the ticket body uses `--cov=common/services/pgvector_store` (slash form); pytest-cov only wires coverage collection when the argument is given in dotted-module form (`common.services.pgvector_store`) or as the file path (`common/services/pgvector_store.py`). Using either form meets the `--cov-fail-under=85` gate.

## Non-goals (per ticket)

- No query-result caching
- No automatic re-embedding
- No schema changes / no Alembic migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async vector similarity search and upsert service supporting memory, conversation, scene, and grading namespaces with input validation, transactional upserts, and deterministic deduplication.

* **Tests**
  * Added end-to-end and unit tests validating similarity ranking, namespace isolation, persistence and idempotency of upserts, returned identifiers, and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->