### PR TITLE
phase-1.04: AI provider/model settings in common/config.py

### DIFF
--- a/backend_v2/common/config.py
+++ b/backend_v2/common/config.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -56,9 +56,14 @@ class Settings(BaseSettings):
     openai_model: str = "gpt-4o-mini"
     freepik_api_key: Optional[str] = None
 
-    # Image generation (see common/services/image_service.py)
-    image_provider: str = "gemini"
+    # AI Models / Providers
+    anthropic_api_key: Optional[str] = None
     google_genai_api_key: Optional[str] = None
+    persona_model: str = "claude-sonnet-4-6"
+    grading_model: str = "claude-haiku-4-5-20251001"
+    summarization_model: str = "claude-haiku-4-5-20251001"
+    image_provider: Literal["gemini", "openai"] = "gemini"
+    embedding_model: str = "text-embedding-3-small"
     
     # AWS S3 Configuration
     aws_access_key_id: Optional[str] = None

--- a/backend_v2/tests/common/test_config.py
+++ b/backend_v2/tests/common/test_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for ``common.config.Settings``.
+
+Settings are instantiated directly (not via the ``lru_cache``-backed
+``get_settings`` factory) so each test sees a fresh read of the
+environment without cross-test caching.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from common.config import Settings
+
+
+def _clear_ai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop AI-related env vars so defaults are observable."""
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_GENAI_API_KEY",
+        "PERSONA_MODEL",
+        "GRADING_MODEL",
+        "SUMMARIZATION_MODEL",
+        "IMAGE_PROVIDER",
+        "EMBEDDING_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_settings_reads_anthropic_api_key_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-value")
+
+    settings = Settings()
+
+    assert settings.anthropic_api_key == "sk-ant-test-value"
+
+
+def test_settings_default_persona_model_is_sonnet_4_6(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ai_env(monkeypatch)
+
+    settings = Settings()
+
+    assert settings.persona_model == "claude-sonnet-4-6"
+    assert settings.grading_model == "claude-haiku-4-5-20251001"
+    assert settings.summarization_model == "claude-haiku-4-5-20251001"
+    assert settings.image_provider == "gemini"
+    assert settings.embedding_model == "text-embedding-3-small"
+    assert settings.anthropic_api_key is None
+    assert settings.google_genai_api_key is None
+
+
+def test_settings_rejects_invalid_image_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("IMAGE_PROVIDER", "stable-diffusion")
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+
+    # Confirm the error is specifically about image_provider, not some
+    # unrelated required field, so the test can't pass for the wrong reason.
+    assert "image_provider" in str(exc_info.value).lower()
+
+
+def test_settings_env_override_wins_over_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("PERSONA_MODEL", "claude-opus-4-6")
+    monkeypatch.setenv("GRADING_MODEL", "claude-sonnet-4-6")
+    monkeypatch.setenv("SUMMARIZATION_MODEL", "claude-haiku-3-5")
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    monkeypatch.setenv("EMBEDDING_MODEL", "text-embedding-3-large")
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "google-key-from-env")
+
+    settings = Settings()
+
+    assert settings.persona_model == "claude-opus-4-6"
+    assert settings.grading_model == "claude-sonnet-4-6"
+    assert settings.summarization_model == "claude-haiku-3-5"
+    assert settings.image_provider == "openai"
+    assert settings.embedding_model == "text-embedding-3-large"
+    assert settings.google_genai_api_key == "google-key-from-env"

--- a/backend_v2/tests/common/test_config.py
+++ b/backend_v2/tests/common/test_config.py
@@ -13,7 +13,12 @@ from common.config import Settings
 
 
 def _clear_ai_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop AI-related env vars so defaults are observable."""
+    """Drop AI-related env vars so defaults are observable.
+
+    Also seeds ``SECRET_KEY`` deterministically because ``Settings`` marks
+    it as required; without this, tests would depend on ambient env.
+    """
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     for var in (
         "ANTHROPIC_API_KEY",
         "GOOGLE_GENAI_API_KEY",


### PR DESCRIPTION
Fixes #434

Implements ticket phase-1.04. See the issue for the full spec.

## Changes
- `backend_v2/common/config.py`: imported `Literal`, added an `# AI Models / Providers` section with seven settings — `anthropic_api_key`, `google_genai_api_key`, `persona_model`, `grading_model`, `summarization_model`, `image_provider` (now `Literal["gemini","openai"]`), `embedding_model`. All env-overridable; existing settings keep their defaults.
- `image_provider` was already a `str` with `"gemini"` default — tightened to a `Literal` constraint per the spec.

## Tests added
`backend_v2/tests/common/test_config.py` — the four required unit tests:
- `test_settings_reads_anthropic_api_key_from_env`
- `test_settings_default_persona_model_is_sonnet_4_6`
- `test_settings_rejects_invalid_image_provider`
- `test_settings_env_override_wins_over_default`

Tests instantiate `Settings()` directly (not the `lru_cache`-backed `get_settings()`) and use `monkeypatch.delenv` to drop AI env vars before each test so defaults are observable regardless of host environment.

## Verification
```
cd backend_v2 && uv run pytest tests/common/test_config.py -q
4 passed, 8 warnings in 0.02s
```
Existing `tests/common/services/test_image_service.py` (14 tests) still passes.

## Spec deviation note
The ticket spec writes `ANTHROPIC_API_KEY: str` (no default). Implemented as `Optional[str] = None` to match the existing convention for API keys (`openai_api_key`, `google_genai_api_key`, `llamaparse_api_key`). The scope rules forbid touching `tests/conftest.py`, where the analogous `SECRET_KEY: str` requirement is satisfied by `os.environ.setdefault`. Without that hook a non-Optional `anthropic_api_key` would raise `ValidationError` during conftest's `import app.main`, breaking the verification gate itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic as an additional AI provider.
  * Added configuration options for persona, grading, summarization, and embedding models.
  * Tightened image provider validation to only allow supported options.

* **Tests**
  * Added tests validating config defaults, environment-variable overrides, and validation errors for invalid image provider values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->