### PR TITLE
feat(admin): ralph-pipeline events — backend schema + router (PR-A/C)

### DIFF
--- a/backend/common/db/migrations/versions/2026_04_13_1500-add_ralph_pipeline_events.py
+++ b/backend/common/db/migrations/versions/2026_04_13_1500-add_ralph_pipeline_events.py
@@ -1,0 +1,99 @@
+"""Add ralph_pipeline_events table
+
+Revision ID: add_ralph_pipeline_events
+Revises: add_code_language_to_scenes
+Create Date: 2026-04-13 15:00:00.000000
+
+One row per phase transition in the Ralph rewrite loop. Feeds the
+admin dashboard's pipeline visibility grid — shows per-ticket × per-
+phase pass/fail state so we can see WHERE in the pipeline things are
+breaking, not just what the final outcome was.
+
+Schema:
+    id           bigserial PK
+    ticket_id    "phase-0.1" / "phase-1.4" / etc.
+    iteration    iteration number within a loop run (1-indexed)
+    loop_run_id  loop invocation timestamp (groups iterations from one run)
+    pr_number    null until Phase A opens one
+    phase        "A-implement" | "B-review" | "C-testing" | "D-merge" | "E-canny"
+    status       "started" | "passed" | "failed" | "skipped" | "warn"
+    detail       error message / reason (nullable)
+    duration_sec how long the phase took (null on "started")
+    context      jsonb — extensible key-value for phase-specific data
+    created_at   timestamptz (NOT NULL, default now())
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision: str = "add_ralph_pipeline_events"
+down_revision: Union[str, None] = "add_code_language_to_scenes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create ralph_pipeline_events table + indexes."""
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    def _table_exists() -> bool:
+        if dialect == "postgresql":
+            result = conn.execute(
+                sa.text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_name = 'ralph_pipeline_events'"
+                )
+            ).fetchone()
+            return result is not None
+        return False
+
+    if _table_exists():
+        return
+
+    jsonb_col = sa.dialects.postgresql.JSONB if dialect == "postgresql" else sa.JSON
+
+    op.create_table(
+        "ralph_pipeline_events",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("ticket_id", sa.String(32), nullable=False),
+        sa.Column("iteration", sa.Integer, nullable=False),
+        sa.Column("loop_run_id", sa.String(64), nullable=False),
+        sa.Column("pr_number", sa.Integer, nullable=True),
+        sa.Column("phase", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("detail", sa.Text, nullable=True),
+        sa.Column("duration_sec", sa.Integer, nullable=True),
+        sa.Column("context", jsonb_col, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if dialect == "postgresql" else sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "ix_ralph_pipeline_events_ticket_created",
+        "ralph_pipeline_events",
+        ["ticket_id", sa.text("created_at DESC")],
+    )
+    op.create_index(
+        "ix_ralph_pipeline_events_loop_run",
+        "ralph_pipeline_events",
+        ["loop_run_id"],
+    )
+    op.create_index(
+        "ix_ralph_pipeline_events_phase_status",
+        "ralph_pipeline_events",
+        ["phase", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ralph_pipeline_events_phase_status", table_name="ralph_pipeline_events")
+    op.drop_index("ix_ralph_pipeline_events_loop_run", table_name="ralph_pipeline_events")
+    op.drop_index("ix_ralph_pipeline_events_ticket_created", table_name="ralph_pipeline_events")
+    op.drop_table("ralph_pipeline_events")

--- a/backend/common/db/models/__init__.py
+++ b/backend/common/db/models/__init__.py
@@ -41,6 +41,9 @@ from .simulation import (
     PromptTrace,
 )
 
+# Admin-only models
+from .admin import RalphPipelineEvent
+
 # Backwards compatibility aliases (old names -> new names)
 Scenario = Simulation
 ScenarioPersona = SimulationPersona
@@ -79,6 +82,8 @@ __all__ = [
     "GradingMaterial",
     "GradingMaterialChunk",
     "PromptTrace",
+    # Admin-only models
+    "RalphPipelineEvent",
     # Aliases for backward compatibility
     "Scenario",
     "ScenarioScene",

--- a/backend/common/db/models/admin/__init__.py
+++ b/backend/common/db/models/admin/__init__.py
@@ -1,0 +1,4 @@
+"""Admin-only models."""
+from .ralph_pipeline_event import RalphPipelineEvent
+
+__all__ = ["RalphPipelineEvent"]

--- a/backend/common/db/models/admin/ralph_pipeline_event.py
+++ b/backend/common/db/models/admin/ralph_pipeline_event.py
@@ -1,0 +1,45 @@
+"""Ralph rewrite-loop pipeline event model.
+
+Each row is one phase transition during a loop iteration. The admin
+dashboard queries this table to render the per-ticket × per-phase
+pipeline grid and the aggregate phase success-rate bars.
+
+Phases correspond to scripts/rewrite/WORKFLOW.md:
+  A-implement, B-review, C-testing, D-merge, E-canny.
+
+Statuses: started | passed | failed | skipped | warn.
+"""
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy import BigInteger, DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from common.db.base import Base
+
+
+class RalphPipelineEvent(Base):
+    __tablename__ = "ralph_pipeline_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    # Ticket + iteration identity
+    ticket_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    iteration: Mapped[int] = mapped_column(Integer, nullable=False)
+    loop_run_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    pr_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # What happened
+    phase: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    detail: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    duration_sec: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # Flexible per-phase data (round number for B, check name for D, etc.)
+    context: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -1,0 +1,375 @@
+"""Admin — Ralph rewrite-loop pipeline visibility.
+
+Exposes the event stream + aggregate stats the admin dashboard renders
+as a per-ticket × per-phase grid. The loop's `emit_event` helper POSTs
+to /event (shared-secret bearer auth). Everything else is read-only
+for the dashboard.
+
+See plan/REWRITE_BREAKDOWN.md for the ticket graph and
+scripts/rewrite/WORKFLOW.md for the phase definitions driving this
+schema.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.dependencies import require_admin
+from common.db.core import get_db
+from common.db.models import RalphPipelineEvent, User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/ralph-pipeline", tags=["Admin - Ralph Pipeline"])
+
+# Phases in the order they appear in the grid.
+PHASES: List[str] = ["A-implement", "B-review", "C-testing", "D-merge", "E-canny"]
+
+# In-process fan-out for SSE /stream. Every POST /event pushes into every
+# active subscriber's queue. Lightweight — single-process only, which is
+# fine for Railway's single-instance backend service.
+_SSE_SUBSCRIBERS: "List[asyncio.Queue[str]]" = []
+
+
+# ── Auth for POST /event ───────────────────────────────────────────────
+def _verify_ingest_token(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+) -> None:
+    """Shared-secret bearer auth for the loop's event ingestion POST.
+
+    The token lives in `RALPH_EVENT_TOKEN` env var (set on Railway + in
+    the loop runner's local .env). Missing env var → ingestion is disabled
+    (returns 503) so an unconfigured deploy never accepts anonymous writes.
+    """
+    expected = os.environ.get("RALPH_EVENT_TOKEN", "")
+    if not expected:
+        raise HTTPException(503, "ralph-pipeline ingestion not configured")
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(401, "missing bearer token")
+    provided = authorization.removeprefix("Bearer ").strip()
+    if not secrets.compare_digest(provided, expected):
+        raise HTTPException(401, "invalid bearer token")
+
+
+# ── Schemas ────────────────────────────────────────────────────────────
+class EventIn(BaseModel):
+    ticket_id: str = Field(..., pattern=r"^phase-\d+(\.\d+)?$")
+    iteration: int = Field(..., ge=1)
+    loop_run_id: str = Field(..., min_length=1, max_length=64)
+    pr_number: Optional[int] = None
+    phase: str
+    status: str
+    detail: Optional[str] = None
+    duration_sec: Optional[int] = Field(None, ge=0)
+    context: Optional[Dict[str, Any]] = None
+
+
+class PhaseState(BaseModel):
+    status: str
+    duration_sec: Optional[int] = None
+    detail: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class TicketRow(BaseModel):
+    ticket_id: str
+    pr_number: Optional[int]
+    state: str  # pending | running | merged | failed | blocked
+    phases: Dict[str, Optional[PhaseState]]
+    started_at: Optional[str]
+    completed_at: Optional[str]
+
+
+class PhaseStat(BaseModel):
+    phase: str
+    runs: int
+    passed: int
+    failed: int
+    warned: int
+    success_rate: float  # 0.0 .. 1.0
+
+
+class FailureSignature(BaseModel):
+    phase: str
+    detail: str
+    count: int
+
+
+class StatsResponse(BaseModel):
+    phases: List[PhaseStat]
+    failure_signatures: List[FailureSignature]
+    merged_total: int
+    open_total: int
+
+
+# ── POST /event — loop ingest ──────────────────────────────────────────
+@router.post("/event", status_code=202)
+async def ingest_event(
+    event: EventIn,
+    request: Request,
+    _: None = Depends(_verify_ingest_token),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Accept one phase-transition event from the Ralph loop."""
+    row = RalphPipelineEvent(
+        ticket_id=event.ticket_id,
+        iteration=event.iteration,
+        loop_run_id=event.loop_run_id,
+        pr_number=event.pr_number,
+        phase=event.phase,
+        status=event.status,
+        detail=event.detail,
+        duration_sec=event.duration_sec,
+        context=event.context,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    # Fan out to SSE subscribers. Non-blocking — drop on any subscriber
+    # whose queue is full (we don't want one slow client to back-pressure
+    # ingestion).
+    payload = json.dumps(
+        {
+            "id": row.id,
+            "ticket_id": row.ticket_id,
+            "iteration": row.iteration,
+            "phase": row.phase,
+            "status": row.status,
+            "detail": row.detail,
+            "duration_sec": row.duration_sec,
+            "pr_number": row.pr_number,
+            "created_at": row.created_at.isoformat(),
+        }
+    )
+    for q in list(_SSE_SUBSCRIBERS):
+        try:
+            q.put_nowait(payload)
+        except asyncio.QueueFull:
+            pass
+
+    return {"id": row.id}
+
+
+# ── GET /tickets — main grid data ──────────────────────────────────────
+@router.get("/tickets", response_model=List[TicketRow])
+def list_tickets(
+    loop_run_id: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> List[TicketRow]:
+    """Latest phase state per ticket. Default: across all loop runs."""
+    q = db.query(RalphPipelineEvent)
+    if loop_run_id:
+        q = q.filter(RalphPipelineEvent.loop_run_id == loop_run_id)
+    events = q.order_by(RalphPipelineEvent.created_at.asc()).all()
+
+    by_ticket: Dict[str, Dict[str, Any]] = {}
+    for e in events:
+        t = by_ticket.setdefault(
+            e.ticket_id,
+            {
+                "pr_number": None,
+                "phases": {p: None for p in PHASES},
+                "started_at": e.created_at,
+                "completed_at": None,
+                "events": [],
+            },
+        )
+        t["events"].append(e)
+        if e.pr_number and not t["pr_number"]:
+            t["pr_number"] = e.pr_number
+
+        # Collapse "started" + later terminal to show the terminal state
+        # when present. If only "started" exists, show "running".
+        state = PhaseState(
+            status="running" if e.status == "started" else e.status,
+            duration_sec=e.duration_sec,
+            detail=e.detail,
+            updated_at=e.created_at.isoformat(),
+        )
+        t["phases"][e.phase] = state
+        if e.status in ("passed", "failed", "warn", "skipped"):
+            t["completed_at"] = e.created_at
+
+    rows: List[TicketRow] = []
+    for ticket_id, t in sorted(by_ticket.items(), key=lambda kv: kv[0]):
+        rows.append(
+            TicketRow(
+                ticket_id=ticket_id,
+                pr_number=t["pr_number"],
+                state=_infer_state(t["phases"]),
+                phases=t["phases"],
+                started_at=t["started_at"].isoformat() if t["started_at"] else None,
+                completed_at=t["completed_at"].isoformat() if t["completed_at"] else None,
+            )
+        )
+    return rows
+
+
+def _infer_state(phases: Dict[str, Optional[PhaseState]]) -> str:
+    """Derive the ticket's rollup state from its phase grid."""
+    any_running = any(p and p.status == "running" for p in phases.values())
+    if any_running:
+        return "running"
+    merge_phase = phases.get("D-merge")
+    if merge_phase and merge_phase.status in ("passed", "warn"):
+        return "merged"
+    any_failed = any(p and p.status == "failed" for p in phases.values())
+    if any_failed:
+        return "failed"
+    any_seen = any(p is not None for p in phases.values())
+    return "pending" if any_seen else "blocked"
+
+
+# ── GET /tickets/{ticket_id} — drill-down ──────────────────────────────
+@router.get("/tickets/{ticket_id}")
+def get_ticket_history(
+    ticket_id: str,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> Dict[str, Any]:
+    events = (
+        db.query(RalphPipelineEvent)
+        .filter(RalphPipelineEvent.ticket_id == ticket_id)
+        .order_by(RalphPipelineEvent.created_at.asc())
+        .all()
+    )
+    if not events:
+        raise HTTPException(404, f"no events for ticket {ticket_id}")
+    return {
+        "ticket_id": ticket_id,
+        "events": [
+            {
+                "id": e.id,
+                "iteration": e.iteration,
+                "loop_run_id": e.loop_run_id,
+                "phase": e.phase,
+                "status": e.status,
+                "detail": e.detail,
+                "duration_sec": e.duration_sec,
+                "context": e.context,
+                "pr_number": e.pr_number,
+                "created_at": e.created_at.isoformat(),
+            }
+            for e in events
+        ],
+    }
+
+
+# ── GET /stats — phase success rates + failure clusters ────────────────
+@router.get("/stats", response_model=StatsResponse)
+def stats(
+    since_hours: int = Query(24, ge=1, le=168),
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> StatsResponse:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=since_hours)
+    terminal_statuses = ("passed", "failed", "warn")
+    rows = (
+        db.query(RalphPipelineEvent)
+        .filter(RalphPipelineEvent.created_at >= cutoff)
+        .filter(RalphPipelineEvent.status.in_(terminal_statuses))
+        .all()
+    )
+
+    by_phase: Dict[str, Dict[str, int]] = {p: {"passed": 0, "failed": 0, "warned": 0} for p in PHASES}
+    for r in rows:
+        bucket = by_phase.get(r.phase)
+        if not bucket:
+            continue
+        if r.status == "passed":
+            bucket["passed"] += 1
+        elif r.status == "failed":
+            bucket["failed"] += 1
+        elif r.status == "warn":
+            bucket["warned"] += 1
+
+    phase_stats = []
+    for p in PHASES:
+        b = by_phase[p]
+        total = b["passed"] + b["failed"] + b["warned"]
+        phase_stats.append(
+            PhaseStat(
+                phase=p,
+                runs=total,
+                passed=b["passed"],
+                failed=b["failed"],
+                warned=b["warned"],
+                success_rate=(b["passed"] / total) if total else 0.0,
+            )
+        )
+
+    # Cluster failure signatures by (phase, first 80 chars of detail).
+    signatures: Dict[tuple, int] = {}
+    for r in rows:
+        if r.status == "failed" and r.detail:
+            key = (r.phase, r.detail[:80])
+            signatures[key] = signatures.get(key, 0) + 1
+    top_sigs = sorted(signatures.items(), key=lambda kv: kv[1], reverse=True)[:5]
+    fail_sigs = [FailureSignature(phase=k[0], detail=k[1], count=v) for k, v in top_sigs]
+
+    # Merged/open counts (D-merge terminal statuses).
+    merge_rows = db.query(RalphPipelineEvent).filter(
+        RalphPipelineEvent.phase == "D-merge",
+        RalphPipelineEvent.status.in_(("passed", "warn")),
+    ).count()
+    open_count = (
+        db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
+        .filter(RalphPipelineEvent.status.in_(("started", "failed")))
+        .scalar()
+        or 0
+    )
+
+    return StatsResponse(
+        phases=phase_stats,
+        failure_signatures=fail_sigs,
+        merged_total=merge_rows,
+        open_total=max(open_count - merge_rows, 0),
+    )
+
+
+# ── GET /stream — SSE live events ──────────────────────────────────────
+@router.get("/stream")
+async def stream_events(_admin: User = Depends(require_admin)) -> StreamingResponse:
+    """Server-sent events: one message per new /event ingestion."""
+
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=100)
+    _SSE_SUBSCRIBERS.append(queue)
+
+    async def _event_gen():
+        try:
+            # Initial hello so the client knows the stream is live.
+            yield 'event: hello\ndata: {"ok": true}\n\n'
+            while True:
+                try:
+                    payload = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    yield f"event: phase\ndata: {payload}\n\n"
+                except asyncio.TimeoutError:
+                    # Heartbeat so intermediaries don't close the stream.
+                    yield ": keepalive\n\n"
+        finally:
+            try:
+                _SSE_SUBSCRIBERS.remove(queue)
+            except ValueError:
+                pass
+
+    return StreamingResponse(
+        _event_gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # disable proxy buffering
+        },
+    )

--- a/backend/modules/admin/router.py
+++ b/backend/modules/admin/router.py
@@ -5,7 +5,9 @@ Includes all admin-facing endpoints.
 from fastapi import APIRouter
 from .traces_router import router as traces_router
 from .dashboard_router import router as dashboard_router
+from .ralph_pipeline_router import router as ralph_pipeline_router
 
 router = APIRouter(tags=["Admin"])
 router.include_router(traces_router)
 router.include_router(dashboard_router)
+router.include_router(ralph_pipeline_router)


### PR DESCRIPTION
## Summary

PR-A of 3 for the Ralph-loop pipeline visibility feature. Backend-only:
new DB table + SQLAlchemy model + FastAPI router with bearer-auth
ingest, admin read endpoints, and SSE stream.

No loop instrumentation (PR-B) and no frontend (PR-C) yet — this
stands on its own because nothing calls the endpoints until PR-B
lands.

## Surface

- Migration \`add_ralph_pipeline_events\` — indexed for ticket lookups, loop-run grouping, and phase/status aggregates.
- \`/api/admin/ralph-pipeline/event\`  bearer auth (\`RALPH_EVENT_TOKEN\`), 503 if not configured.
- \`/api/admin/ralph-pipeline/tickets\`  admin read, per-ticket grid.
- \`/api/admin/ralph-pipeline/tickets/{id}\`  admin drill-down.
- \`/api/admin/ralph-pipeline/stats\`  phase success rates + clustered failure signatures.
- \`/api/admin/ralph-pipeline/stream\`  admin SSE fan-out.

## Test plan
- [x] \`uv run alembic heads\` → new revision is head
- [x] \`uv run python -c 'from app.main import app'\` loads; 5 new routes
- [ ] CodeRabbit passes
- [ ] Railway experimental deploy green

## Follow-ups
- **PR-B**: loop's \`emit_event\` helper + call sites + backfill script
- **PR-C**: \`RalphPipelineGrid.tsx\` ASCII-art component + mount on /admin/dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ralph pipeline event tracking with authenticated ingestion endpoint for phase transitions.
  * Added admin dashboard providing ticket state grids, event histories, and pipeline performance statistics.
  * Added real-time event stream for monitoring pipeline activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->