### PR TITLE
fix(admin): ralph-pipeline /stats scope consistency (CR #465 follow-up)

### DIFF
--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -331,12 +331,18 @@ def stats(
     # Windowed merged/open counts — match the `since_hours` scope used
     # for phase_stats and failure_signatures above so the whole response
     # has one consistent time scope.
+    #
+    # Both merged_* and open_* count DISTINCT ticket_ids so the
+    # subtraction below has unit-consistent semantics: merge events
+    # can repeat per ticket (re-runs, warns followed by passes), so
+    # counting raw rows would double-count and make open_* go negative.
     merged_in_window = (
-        db.query(RalphPipelineEvent)
+        db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.created_at >= cutoff)
         .filter(RalphPipelineEvent.phase == "D-merge")
         .filter(RalphPipelineEvent.status.in_(("passed", "warn")))
-        .count()
+        .scalar()
+        or 0
     )
     open_in_window = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
@@ -348,12 +354,14 @@ def stats(
 
     # All-time counts — separate fields for the "4/22 merged overall"
     # headline so dashboards can show cumulative progress without
-    # mixing scopes with windowed rates.
+    # mixing scopes with windowed rates. Same distinct-ticket discipline
+    # as the windowed counts above.
     merged_all_time = (
-        db.query(RalphPipelineEvent)
+        db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.phase == "D-merge")
         .filter(RalphPipelineEvent.status.in_(("passed", "warn")))
-        .count()
+        .scalar()
+        or 0
     )
     open_all_time = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))

--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -107,10 +107,18 @@ class FailureSignature(BaseModel):
 
 
 class StatsResponse(BaseModel):
+    # Window for phase stats + failure signatures (matches `since_hours` query arg).
+    window_hours: int
     phases: List[PhaseStat]
     failure_signatures: List[FailureSignature]
-    merged_total: int
-    open_total: int
+    # Windowed counts — match the window above so the whole response has
+    # one consistent time scope.
+    merged_in_window: int
+    open_in_window: int
+    # All-time totals — explicit separate fields so dashboards can show
+    # overall project progress ("4/22 merged") without mixing scopes.
+    merged_all_time: int
+    open_all_time: int
 
 
 # ── POST /event — loop ingest ──────────────────────────────────────────
@@ -320,12 +328,34 @@ def stats(
     top_sigs = sorted(signatures.items(), key=lambda kv: kv[1], reverse=True)[:5]
     fail_sigs = [FailureSignature(phase=k[0], detail=k[1], count=v) for k, v in top_sigs]
 
-    # Merged/open counts (D-merge terminal statuses).
-    merge_rows = db.query(RalphPipelineEvent).filter(
-        RalphPipelineEvent.phase == "D-merge",
-        RalphPipelineEvent.status.in_(("passed", "warn")),
-    ).count()
-    open_count = (
+    # Windowed merged/open counts — match the `since_hours` scope used
+    # for phase_stats and failure_signatures above so the whole response
+    # has one consistent time scope.
+    merged_in_window = (
+        db.query(RalphPipelineEvent)
+        .filter(RalphPipelineEvent.created_at >= cutoff)
+        .filter(RalphPipelineEvent.phase == "D-merge")
+        .filter(RalphPipelineEvent.status.in_(("passed", "warn")))
+        .count()
+    )
+    open_in_window = (
+        db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
+        .filter(RalphPipelineEvent.created_at >= cutoff)
+        .filter(RalphPipelineEvent.status.in_(("started", "failed")))
+        .scalar()
+        or 0
+    )
+
+    # All-time counts — separate fields for the "4/22 merged overall"
+    # headline so dashboards can show cumulative progress without
+    # mixing scopes with windowed rates.
+    merged_all_time = (
+        db.query(RalphPipelineEvent)
+        .filter(RalphPipelineEvent.phase == "D-merge")
+        .filter(RalphPipelineEvent.status.in_(("passed", "warn")))
+        .count()
+    )
+    open_all_time = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.status.in_(("started", "failed")))
         .scalar()
@@ -333,10 +363,13 @@ def stats(
     )
 
     return StatsResponse(
+        window_hours=since_hours,
         phases=phase_stats,
         failure_signatures=fail_sigs,
-        merged_total=merge_rows,
-        open_total=max(open_count - merge_rows, 0),
+        merged_in_window=merged_in_window,
+        open_in_window=max(open_in_window - merged_in_window, 0),
+        merged_all_time=merged_all_time,
+        open_all_time=max(open_all_time - merged_all_time, 0),
     )
 
 

--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -332,10 +332,22 @@ def stats(
     # for phase_stats and failure_signatures above so the whole response
     # has one consistent time scope.
     #
-    # Both merged_* and open_* count DISTINCT ticket_ids so the
-    # subtraction below has unit-consistent semantics: merge events
-    # can repeat per ticket (re-runs, warns followed by passes), so
-    # counting raw rows would double-count and make open_* go negative.
+    # Open uses a SQL set-difference (NOT IN merged_ticket_ids) rather
+    # than open_count − merged_count. Count subtraction silently
+    # undercounts at window boundaries — e.g. a ticket whose D-merge
+    # passed event landed just outside the window but whose started
+    # event is inside would show both a "merged" hit AND stay in the
+    # started/failed set, driving open into negatives unless clamped.
+    # The subquery excludes any ticket already merged in the same
+    # scope, so the two numbers compose correctly.
+    merged_ticket_ids_in_window = (
+        select(RalphPipelineEvent.ticket_id)
+        .where(RalphPipelineEvent.created_at >= cutoff)
+        .where(RalphPipelineEvent.phase == "D-merge")
+        .where(RalphPipelineEvent.status.in_(("passed", "warn")))
+        .distinct()
+        .scalar_subquery()
+    )
     merged_in_window = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.created_at >= cutoff)
@@ -348,14 +360,22 @@ def stats(
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.created_at >= cutoff)
         .filter(RalphPipelineEvent.status.in_(("started", "failed")))
+        .filter(~RalphPipelineEvent.ticket_id.in_(merged_ticket_ids_in_window))
         .scalar()
         or 0
     )
 
     # All-time counts — separate fields for the "4/22 merged overall"
     # headline so dashboards can show cumulative progress without
-    # mixing scopes with windowed rates. Same distinct-ticket discipline
+    # mixing scopes with windowed rates. Same set-difference discipline
     # as the windowed counts above.
+    merged_ticket_ids_all_time = (
+        select(RalphPipelineEvent.ticket_id)
+        .where(RalphPipelineEvent.phase == "D-merge")
+        .where(RalphPipelineEvent.status.in_(("passed", "warn")))
+        .distinct()
+        .scalar_subquery()
+    )
     merged_all_time = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.phase == "D-merge")
@@ -366,6 +386,7 @@ def stats(
     open_all_time = (
         db.query(func.count(func.distinct(RalphPipelineEvent.ticket_id)))
         .filter(RalphPipelineEvent.status.in_(("started", "failed")))
+        .filter(~RalphPipelineEvent.ticket_id.in_(merged_ticket_ids_all_time))
         .scalar()
         or 0
     )
@@ -375,9 +396,9 @@ def stats(
         phases=phase_stats,
         failure_signatures=fail_sigs,
         merged_in_window=merged_in_window,
-        open_in_window=max(open_in_window - merged_in_window, 0),
+        open_in_window=open_in_window,
         merged_all_time=merged_all_time,
-        open_all_time=max(open_all_time - merged_all_time, 0),
+        open_all_time=open_all_time,
     )
 
 


### PR DESCRIPTION
Addresses CodeRabbit's comment on PR #465 (line 340) that Hendrik flagged as relevant after the merge. Splits the `/stats` response so no single response mixes windowed rates with all-time totals.

See commit message for the field-level diff.

## Test plan
- [x] Syntax check (python ast.parse)
- [x] `uv run python -c 'from app.main import app'` still loads, 5 routes
- [ ] CodeRabbit pass — will wait for review before merging
- [ ] Railway experimental deploy green — will verify post-merge before closing this PR as done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stats endpoint now returns separate time-scoped and all-time metrics: counts for merged and open issues both within the requested window and across all time.
  * Responses include the window size used for the query so reported in-window metrics are clearly tied to the selected time horizon, improving clarity and consistency of reported stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->