### PR TITLE
feat(rewrite): loop phase-event telemetry + log backfill (PR-B)

### DIFF
--- a/env_template.txt
+++ b/env_template.txt
@@ -13,7 +13,9 @@ ANTHROPIC_API_KEY=REPLACE_WITH_YOUR_ANTHROPIC_API_KEY_HERE
 
 # Redis Configuration (REQUIRED)
 # Redis is required for session management, caching, and performance optimization
-REDIS_URL=REPLACE_WITH_YOUR_REDIS_URL
+# Local Docker (docker-compose): use redis://localhost:6379 — do not use http:// inside the URL
+# If the backend runs inside Compose on the same network, use redis://redis:6379
+REDIS_URL=redis://localhost:6379
 
 # Security - Change this to a strong random key
 # This is a dummy value - generate a proper random secret and never commit it to version control
@@ -119,3 +121,9 @@ NEXT_PUBLIC_CANNY_BOARD_TOKEN=REPLACE_WITH_YOUR_CANNY_BOARD_TOKEN
 # Canny Feedback Widget (Frontend)
 NEXT_PUBLIC_CANNY_APP_ID=REPLACE_WITH_YOUR_CANNY_APP_ID
 NEXT_PUBLIC_CANNY_BOARD_TOKEN=REPLACE_WITH_YOUR_CANNY_BOARD_TOKEN
+# Ralph rewrite-loop pipeline telemetry (PR-B)
+# The loop POSTs phase-transition events to the admin dashboard's ingest
+# endpoint. Leave blank to disable telemetry (loop still works, just no
+# dashboard visibility).
+RALPH_EVENT_URL=https://backend-experimental-246c.up.railway.app
+RALPH_EVENT_TOKEN=REPLACE_WITH_RALPH_EVENT_TOKEN_SHARED_WITH_RAILWAY

--- a/scripts/rewrite/backfill-events.py
+++ b/scripts/rewrite/backfill-events.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Backfill Ralph-pipeline events from historical log files.
+
+The loop didn't emit events before PR-B landed, but it left behind
+rich master logs at `scripts/rewrite/logs/rewrite_*.log`. This script
+parses those logs for phase-transition signatures and POSTs synthetic
+events to the admin dashboard's ingest endpoint so the grid has data
+from the very first run the dashboard sees.
+
+Idempotent enough for overnight use: the dashboard's /event endpoint
+accepts duplicates — if you run this twice you'll see double rows for
+the same transition. To avoid that, back up + truncate the
+`ralph_pipeline_events` table before a fresh backfill, or use the
+optional `--since` flag to only re-ingest recent runs.
+
+Usage:
+    # env vars (can also live in backend/.env)
+    export RALPH_EVENT_URL=https://backend-experimental-246c.up.railway.app
+    export RALPH_EVENT_TOKEN=<bearer>
+
+    python3 scripts/rewrite/backfill-events.py                    # all logs
+    python3 scripts/rewrite/backfill-events.py --dry-run          # parse + print, no POST
+    python3 scripts/rewrite/backfill-events.py --since 2026-04-13 # one day
+    python3 scripts/rewrite/backfill-events.py --file <one.log>   # just that log
+
+Exit 0 on success; 2 on config error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = REPO_ROOT / "scripts" / "rewrite" / "logs"
+
+
+# ── .env loader (same keys the loop's config.sh looks for) ────────────────
+def _load_env() -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for candidate in (REPO_ROOT / ".env", REPO_ROOT / "backend" / ".env"):
+        if not candidate.is_file():
+            continue
+        for line in candidate.read_text().splitlines():
+            if "=" not in line or line.lstrip().startswith("#"):
+                continue
+            k, _, v = line.partition("=")
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k and k not in out:
+                out[k] = v
+    return out
+
+
+ENV = _load_env()
+RALPH_EVENT_URL = os.environ.get("RALPH_EVENT_URL", ENV.get("RALPH_EVENT_URL", ""))
+RALPH_EVENT_TOKEN = os.environ.get("RALPH_EVENT_TOKEN", ENV.get("RALPH_EVENT_TOKEN", ""))
+
+
+# ── log parser ────────────────────────────────────────────────────────────
+# Matches lines like "[14:37:26]   picked: #430  phase-0.01  ..."
+# or "[14:49:27]   PR opened: #457" etc. The loop logs timestamp as HH:MM:SS
+# so we reconstruct the date from the log filename.
+LINE_RE = re.compile(r"^\[(\d\d:\d\d:\d\d)\]\s+(.*)$")
+
+# Phase markers we know how to derive an event from. Order matters — first match wins per line.
+# Each entry: (regex, phase, status, detail_group_or_None, context_json_fn)
+PHASE_MARKERS = [
+    (re.compile(r"picked:\s+#(\d+)\s+(phase-\d+(?:\.\d+)?)"), None, None, None, None),  # context only
+    (re.compile(r"→ invoking Claude for implementation"), "A-implement", "started", None, None),
+    (re.compile(r"PR opened:\s*#?(\d+)"), "A-implement", "passed", None, None),
+    (re.compile(r"no PR produced"), "A-implement", "failed", "no PR produced", None),
+    (re.compile(r"waiting for first CodeRabbit"), "B-review", "started", None, lambda m: {"round": 1}),
+    (re.compile(r"round (\d+)/\d+ — addressing CR feedback"), "B-review", "started", None, lambda m: {"round": int(m.group(1))}),
+    (re.compile(r"CR approved PR"), "B-review", "passed", None, None),
+    (re.compile(r"no new CR comments after push — treating as resolved"), "B-review", "passed", "no new feedback", None),
+    (re.compile(r"hit CR_MAX_ROUNDS"), "B-review", "failed", "hit CR_MAX_ROUNDS", None),
+    (re.compile(r"→ invoking Claude for testing"), "C-testing", "started", None, None),
+    (re.compile(r"ALL_TESTS_PASSED"), "C-testing", "passed", None, None),
+    (re.compile(r"tests failed — leaving PR"), "C-testing", "failed", "tests did not report pass", None),
+    (re.compile(r"^\s*TESTS_FAILED:(.+)"), "C-testing", "failed", 1, None),
+    (re.compile(r"polling CI "), "D-merge", "started", None, None),
+    (re.compile(r"CI green — merging"), "D-merge", "passed", None, None),
+    (re.compile(r"CI not green after polls"), "D-merge", "failed", "CI not green after polls", None),
+    (re.compile(r"Canny post ok"), "E-canny", "passed", None, None),
+    (re.compile(r"Canny.*(skipping|env vars not set)"), "E-canny", "skipped", "env not configured", None),
+]
+
+
+@dataclass
+class ParsedEvent:
+    ticket_id: str
+    iteration: int
+    loop_run_id: str
+    pr_number: Optional[int]
+    phase: str
+    status: str
+    detail: Optional[str] = None
+    duration_sec: Optional[int] = None
+    context: Optional[Dict[str, Any]] = None
+    created_at: Optional[datetime] = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "ticket_id":    self.ticket_id,
+            "iteration":    max(1, self.iteration),
+            "loop_run_id":  self.loop_run_id,
+            "pr_number":    self.pr_number,
+            "phase":        self.phase,
+            "status":       self.status,
+            "detail":       self.detail,
+            "duration_sec": self.duration_sec,
+            "context":      self.context,
+        }
+
+
+def parse_log(path: Path) -> List[ParsedEvent]:
+    """Pull phase events out of one master log."""
+    # Log filename encodes the date as YYYYMMDD_HHMMSS.
+    m = re.search(r"rewrite_(\d{8}_\d{6})\.log$", path.name)
+    if not m:
+        return []
+    loop_run_id = m.group(1)
+    log_date = datetime.strptime(loop_run_id, "%Y%m%d_%H%M%S").replace(tzinfo=timezone.utc)
+
+    events: List[ParsedEvent] = []
+    current_ticket = "phase-0.0"
+    current_iter = 0
+    current_pr: Optional[int] = None
+
+    for raw in path.read_text(errors="replace").splitlines():
+        m = LINE_RE.match(raw)
+        if not m:
+            continue
+        ts_str, body = m.groups()
+        hh, mm, ss = (int(x) for x in ts_str.split(":"))
+        # Rebuild absolute time from filename date + log-line HH:MM:SS.
+        ts = log_date.replace(hour=hh, minute=mm, second=ss)
+        # If we've crossed midnight within the log (HH regressed), bump date.
+        if events and ts < (events[-1].created_at or ts):
+            ts = ts.replace(day=ts.day + 1) if ts.day < 28 else ts  # cheap heuristic
+
+        # Track ticket + iteration + PR from context lines.
+        mi = re.search(r"─── iteration (\d+)/\d+ ───", body)
+        if mi:
+            current_iter = int(mi.group(1))
+            continue
+
+        mp = re.search(r"picked: #(\d+)\s+(phase-\d+(?:\.\d+)?)", body)
+        if mp:
+            # NOTE: the log prints ticket_id like "phase-0.01". Normalize to "phase-0.1".
+            current_pr = None  # new ticket = new PR forthcoming
+            tid = mp.group(2)
+            tid = re.sub(r"phase-(\d+)\.0(\d)", r"phase-\1.\2", tid)
+            current_ticket = tid
+            continue
+
+        mpr = re.search(r"PR opened: ?#?(\d+)", body)
+        if mpr:
+            current_pr = int(mpr.group(1))
+
+        # Scan phase markers.
+        for regex, phase, status, detail_spec, ctx_fn in PHASE_MARKERS:
+            mm2 = regex.search(body)
+            if not mm2:
+                continue
+            if phase is None:
+                continue  # context-only markers already handled above
+            detail = None
+            if detail_spec is not None:
+                if isinstance(detail_spec, int):
+                    detail = mm2.group(detail_spec).strip()
+                else:
+                    detail = detail_spec
+            ctx = ctx_fn(mm2) if ctx_fn else None
+            events.append(ParsedEvent(
+                ticket_id=current_ticket,
+                iteration=current_iter or 1,
+                loop_run_id=loop_run_id,
+                pr_number=current_pr,
+                phase=phase,
+                status=status,
+                detail=detail,
+                context=ctx,
+                created_at=ts,
+            ))
+            break
+    return events
+
+
+# ── POST to /event ────────────────────────────────────────────────────────
+def post_event(payload: Dict[str, Any]) -> bool:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{RALPH_EVENT_URL.rstrip('/')}/api/admin/ralph-pipeline/event",
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {RALPH_EVENT_TOKEN}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status in (200, 201, 202)
+    except Exception as exc:
+        print(f"  WARN: POST failed for {payload['ticket_id']}/{payload['phase']}: {exc}",
+              file=sys.stderr)
+        return False
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="parse + print, no POST")
+    ap.add_argument("--since", help="YYYY-MM-DD — only logs modified on/after this date")
+    ap.add_argument("--file", help="single log file (overrides --since + auto-discovery)")
+    args = ap.parse_args()
+
+    if not args.dry_run:
+        if not RALPH_EVENT_URL or not RALPH_EVENT_TOKEN:
+            print("ERROR: RALPH_EVENT_URL and RALPH_EVENT_TOKEN must be set "
+                  "(env vars or .env / backend/.env)", file=sys.stderr)
+            return 2
+
+    # Gather input logs.
+    if args.file:
+        logs = [Path(args.file)]
+    else:
+        logs = sorted(LOG_DIR.glob("rewrite_*.log"))
+        if args.since:
+            cutoff = datetime.strptime(args.since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            logs = [p for p in logs
+                    if datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc) >= cutoff]
+    if not logs:
+        print("No logs to backfill.", file=sys.stderr)
+        return 0
+
+    total_events = 0
+    total_posted = 0
+    for p in logs:
+        events = parse_log(p)
+        total_events += len(events)
+        print(f"  {p.name}: {len(events)} events")
+        if args.dry_run:
+            for e in events[:5]:
+                print(f"    {e.created_at} {e.ticket_id} iter{e.iteration} "
+                      f"{e.phase} {e.status} pr={e.pr_number}")
+            if len(events) > 5:
+                print(f"    … +{len(events) - 5} more")
+            continue
+        for e in events:
+            if post_event(e.to_payload()):
+                total_posted += 1
+
+    mode = "parsed (dry-run)" if args.dry_run else "posted"
+    print(f"\nDone. {total_events} events {mode}; "
+          f"{total_posted} POST succeeded"
+          + (" (run without --dry-run to ingest)" if args.dry_run else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -148,7 +148,6 @@ phase_address_feedback() {
 
     log "  round ${round}/${CR_MAX_ROUNDS} — addressing CR feedback"
     PR_NUM="$pr_num" emit_event "B-review" "started" "" "" "{\"round\":$round}"
-    local round_start; round_start=$(date +%s)
 
     local prompt_file="${LOG_DIR}/prompt_${ticket_id}_round${round}.md"
     local run_log="${LOG_DIR}/review_${ticket_id}_iter${ITER}_r${round}.log"

--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -42,6 +42,10 @@ done
 mkdir -p "$LOG_DIR" "$WORKTREE_BASE"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 MASTER_LOG="${LOG_DIR}/rewrite_${TIMESTAMP}.log"
+# One loop run = one loop_run_id. Every event emitted during this run groups
+# under this id so the dashboard can show "iterations from one kickoff" cleanly.
+LOOP_RUN_ID="$TIMESTAMP"
+export LOOP_RUN_ID
 
 log "════════════════════════════════════════════════════════════════"
 log "Ralph Rewrite Loop  ·  $(date)"
@@ -89,11 +93,20 @@ phase_implement() {
          BASE_BRANCH ANCHOR_BRANCH LABEL GH_REPO
   render_prompt "${PROMPTS_DIR}/implement.md" > "$prompt_file"
 
+  local start; start=$(date +%s)
+  emit_event "A-implement" "started"
   log "  → invoking Claude for implementation (log: $(basename "$run_log"))"
   run_claude_in "$work_dir" "$prompt_file" "$run_log" >/dev/null
 
   # Extract PR number; Claude is prompted to print PR_NUMBER=<n>.
-  grep -oE 'PR_NUMBER=[0-9]+' "$run_log" | tail -1 | cut -d= -f2
+  local pr; pr=$(grep -oE 'PR_NUMBER=[0-9]+' "$run_log" | tail -1 | cut -d= -f2)
+  local dur=$(( $(date +%s) - start ))
+  if [ -n "$pr" ]; then
+    PR_NUM="$pr" emit_event "A-implement" "passed" "" "$dur"
+  else
+    emit_event "A-implement" "failed" "no PR produced" "$dur"
+  fi
+  printf '%s' "$pr"
 }
 
 # Phase B: run CR-review loop on the open PR. Returns 0 when there's no
@@ -121,6 +134,7 @@ phase_address_feedback() {
     # Fast path: CR approved.
     if cr_approved "$pr_num"; then
       log "  CR approved PR #${pr_num} (round ${round})"
+      PR_NUM="$pr_num" emit_event "B-review" "passed" "approved at round ${round}" "" "{\"round\":$round}"
       return 0
     fi
 
@@ -128,10 +142,13 @@ phase_address_feedback() {
     local now_count; now_count=$(count_cr_pr_comments "$pr_num")
     if [ "$round" -gt 1 ] && [ "$now_count" -eq "$prev_count" ]; then
       log "  no new CR comments after push — treating as resolved"
+      PR_NUM="$pr_num" emit_event "B-review" "passed" "no new feedback" "" "{\"round\":$round}"
       return 0
     fi
 
     log "  round ${round}/${CR_MAX_ROUNDS} — addressing CR feedback"
+    PR_NUM="$pr_num" emit_event "B-review" "started" "" "" "{\"round\":$round}"
+    local round_start; round_start=$(date +%s)
 
     local prompt_file="${LOG_DIR}/prompt_${ticket_id}_round${round}.md"
     local run_log="${LOG_DIR}/review_${ticket_id}_iter${ITER}_r${round}.log"
@@ -156,6 +173,7 @@ phase_address_feedback() {
   done
 
   log "  hit CR_MAX_ROUNDS=${CR_MAX_ROUNDS} without clean state"
+  PR_NUM="$pr_num" emit_event "B-review" "failed" "hit CR_MAX_ROUNDS=${CR_MAX_ROUNDS}" "" "{\"round\":$round}"
   return 1
 }
 
@@ -170,15 +188,20 @@ phase_run_tests() {
          FEATURE_BRANCH="$feature_branch" BASE_BRANCH GH_REPO
   render_prompt "${PROMPTS_DIR}/run-tests.md" > "$prompt_file"
 
+  local start; start=$(date +%s)
+  PR_NUM="$pr_num" emit_event "C-testing" "started"
   log "  → invoking Claude for testing (log: $(basename "$run_log"))"
   run_claude_in "$work_dir" "$prompt_file" "$run_log" >/dev/null
 
+  local dur=$(( $(date +%s) - start ))
   if grep -q '^ALL_TESTS_PASSED' "$run_log"; then
     log "  ✅ ALL_TESTS_PASSED"
+    PR_NUM="$pr_num" emit_event "C-testing" "passed" "" "$dur"
     return 0
   fi
   local reason; reason=$(grep -oE '^TESTS_FAILED:.*' "$run_log" | head -1)
   log "  ❌ ${reason:-tests did not report pass}"
+  PR_NUM="$pr_num" emit_event "C-testing" "failed" "${reason:-tests did not report pass}" "$dur"
   return 1
 }
 
@@ -186,17 +209,21 @@ phase_run_tests() {
 phase_merge() {
   local pr_num=$1
   log "  polling CI (every ${CI_POLL_SEC}s, up to ${CI_MAX_POLLS} times)"
+  local start; start=$(date +%s)
+  PR_NUM="$pr_num" emit_event "D-merge" "started"
   local i
   for i in $(seq 1 "$CI_MAX_POLLS"); do
     if ci_checks_pass "$pr_num"; then
       log "  CI green — merging PR #${pr_num}"
       gh pr merge "$pr_num" --repo "$GH_REPO" --squash --delete-branch 2>&1 | tee -a "$MASTER_LOG"
+      PR_NUM="$pr_num" emit_event "D-merge" "passed" "" "$(( $(date +%s) - start ))"
       return 0
     fi
     log "  CI poll ${i}/${CI_MAX_POLLS} — not green yet"
     sleep "$CI_POLL_SEC"
   done
   log "  CI not green after polls — leaving PR #${pr_num} open"
+  PR_NUM="$pr_num" emit_event "D-merge" "failed" "CI not green after ${CI_MAX_POLLS} polls" "$(( $(date +%s) - start ))"
   return 1
 }
 

--- a/scripts/rewrite/resources/config.sh
+++ b/scripts/rewrite/resources/config.sh
@@ -38,3 +38,25 @@ PROMPTS_DIR="${RESOURCES_DIR}/prompts"
 REPO_DIR="$(cd "${RESOURCES_DIR}/../../.." && pwd)"
 WORKTREE_BASE="${WORKTREE_BASE:-$(cd "$REPO_DIR/.." && pwd)/work-trees}"
 LOG_DIR="${LOG_DIR:-$REPO_DIR/scripts/rewrite/logs}"
+
+# --- Pipeline telemetry (PR-B) ---------------------------------------------
+# Loop POSTs phase-transition events to the admin dashboard's ingest
+# endpoint. Both vars must be set for events to fire; otherwise the
+# loop runs silently without telemetry (no error, no block). Values
+# are grep-loaded from .env (same token also lives on Railway so the
+# backend can verify the bearer).
+_load_env_var() {
+  local key=$1
+  for file in "${REPO_DIR}/.env" "${REPO_DIR}/backend/.env"; do
+    [ -f "$file" ] || continue
+    local val
+    val=$(grep -E "^${key}=" "$file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'")
+    if [ -n "$val" ]; then
+      printf '%s' "$val"
+      return 0
+    fi
+  done
+  return 0
+}
+RALPH_EVENT_URL="${RALPH_EVENT_URL:-$(_load_env_var RALPH_EVENT_URL)}"
+RALPH_EVENT_TOKEN="${RALPH_EVENT_TOKEN:-$(_load_env_var RALPH_EVENT_TOKEN)}"

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -17,6 +17,53 @@ log() {
 die() { log "ERROR: $*"; exit 1; }
 
 # ===========================================================================
+# Pipeline telemetry — fire-and-forget POST to admin dashboard (PR-B)
+# ===========================================================================
+# emit_event <phase> <status> [detail] [duration_sec] [context_json]
+# Never blocks the loop (posts in a detached subshell, always returns 0).
+# Silent no-op if RALPH_EVENT_URL or RALPH_EVENT_TOKEN unset — lets dev
+# runs not require telemetry config.
+emit_event() {
+  [ -n "${RALPH_EVENT_URL:-}" ] || return 0
+  [ -n "${RALPH_EVENT_TOKEN:-}" ] || return 0
+  local phase=$1 status=$2 detail=${3:-} duration=${4:-} ctx=${5:-}
+  local payload
+  payload=$(
+    TICKET_ID="${TICKET_ID:-}" ITER="${ITER:-0}" \
+    LOOP_RUN_ID="${LOOP_RUN_ID:-${TIMESTAMP:-unknown}}" \
+    PR_NUM="${PR_NUM:-}" \
+    _P="$phase" _S="$status" _D="$detail" _DU="$duration" _C="$ctx" \
+    python3 - <<'PY'
+import json, os
+def _int(v):
+    try: return int(v) if v else None
+    except ValueError: return None
+body = {
+    "ticket_id":   os.environ.get("TICKET_ID", "") or "phase-0.0",
+    "iteration":   max(1, _int(os.environ.get("ITER")) or 1),
+    "loop_run_id": os.environ.get("LOOP_RUN_ID") or "unknown",
+    "pr_number":   _int(os.environ.get("PR_NUM")),
+    "phase":       os.environ["_P"],
+    "status":      os.environ["_S"],
+    "detail":      os.environ.get("_D") or None,
+    "duration_sec": _int(os.environ.get("_DU")),
+    "context":     json.loads(os.environ["_C"]) if os.environ.get("_C") else None,
+}
+print(json.dumps(body))
+PY
+  )
+  (
+    curl -sfL -X POST "${RALPH_EVENT_URL%/}/api/admin/ralph-pipeline/event" \
+      -H "Authorization: Bearer ${RALPH_EVENT_TOKEN}" \
+      -H "Content-Type: application/json" \
+      --max-time 5 \
+      -d "$payload" >/dev/null 2>&1 || true
+  ) &
+  disown 2>/dev/null || true
+  return 0
+}
+
+# ===========================================================================
 # GitHub API helpers (all read against $GH_REPO)
 # ===========================================================================
 gh_issue_list_open() {


### PR DESCRIPTION
## Summary

Second of three PRs for admin-dashboard pipeline visibility. PR-A (#465) shipped the backend endpoints; this feeds them.

- **\`emit_event\`** helper in \`resources/lib.sh\` — fire-and-forget POST, silent no-op if env missing, never blocks loop
- **12 call sites** in \`ralph-rewrite-loop.sh\` across phases A/B/C/D
- **\`backfill-events.py\`** — parses historical master logs to backfill events from before PR-B landed
- **\`env_template.txt\`** — new \`RALPH_EVENT_URL\` / \`RALPH_EVENT_TOKEN\` entries

PR-C (frontend grid) is next.

## Environment

- \`RALPH_EVENT_TOKEN\` already set on Railway experimental + \`backend/.env\` locally
- \`RALPH_EVENT_URL\` points at experimental backend

## Test plan

- [x] All 4 shell+python files pass syntax checks
- [x] \`backfill-events.py --dry-run\` parses 41 events from existing logs
- [x] Clean-subshell \`emit_event\` POSTs successfully → row lands in \`ralph_pipeline_events\` table with correct fields (verified by direct DB query on experimental-v2)
- [x] POST /event endpoint returns 202 (via emit_event); DB has the smoke-test row
- [ ] CodeRabbit passes — hold merge until review closure
- [ ] Railway experimental deploy green — verify post-merge via \`railway logs -s Backend\` before claiming done
- [ ] Run \`python3 scripts/rewrite/backfill-events.py\` post-merge to populate historical events for the dashboard

## Merge discipline

Following the policy from the #465 post-mortem:
1. wait for CR comments to be either addressed in code or replied with a reason
2. verify Railway deploy after merge with \`railway logs -s Backend --lines 30\`
3. tick the checkboxes above with evidence before claiming done

Will not admin-merge unless something is blocking the entire track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry event tracking added for rewrite pipeline phases (start/finish/status/duration and context).
  * New backfill utility to reconstruct and post historical pipeline events from existing logs.

* **Chores**
  * Environment template updated with a usable Redis URL and cleaned formatting.
  * New telemetry configuration variables added (can be left blank to disable posting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->