### PR TITLE
docs(skills): embed CLI learnings from 2026-04-13 rewrite track

### DIFF
--- a/.claude/skills/daytona-sandbox/SKILL.md
+++ b/.claude/skills/daytona-sandbox/SKILL.md
@@ -58,16 +58,35 @@ Auto-invoke when the task involves:
 Do **not** use it for unrelated work — sandbox ops cost time and
 occupy a quota.
 
-## Prerequisites
+## Prerequisites — two auth modes, two different probes
 
-Before invoking any command, sanity-check:
+The Daytona CLI supports two auth modes and the right health-probe
+differs by mode:
 
-- `command -v daytona` returns a path.
-- `daytona organization list` (or `daytona sandbox list -f json`)
-  succeeds — this proves auth is in place.
+| Mode | How it authed | Auth probe that works | Commands that fail |
+| --- | --- | --- | --- |
+| **Browser (`daytona login`)** | OAuth, session in `~/.daytona/` | `daytona organization list` | — (full CLI works) |
+| **API key** (env var or keyring) | pre-provisioned token | **`daytona sandbox list`** | `daytona organization list` fails with "not available when using API key authentication" |
 
-If either fails, stop and tell the user; do not try to `daytona login`
-from an automated context.
+On this machine, auth is **API-key mode** (the user chose this because
+browser OAuth sessions drop frequently and only they can re-auth via
+browser). Use `daytona sandbox list` as the probe:
+
+```bash
+command -v daytona || { echo "daytona CLI missing"; exit 2; }
+# Works for BOTH auth modes, so it's the safe default probe.
+daytona sandbox list >/dev/null 2>&1 || {
+  echo "daytona CLI not authed — user must run 'daytona login' or set DAYTONA_API_KEY"
+  exit 2
+}
+```
+
+Do **not** fall back to `daytona organization list` — it will fail
+under API-key auth and you'll incorrectly report "not authed" when
+it's actually fine for every command this skill actually uses.
+
+If the probe fails, stop and tell the user — only they can complete
+the browser OAuth flow. Don't try `daytona login` from automation.
 
 ## Security
 

--- a/.claude/skills/daytona-sandbox/scripts/probe-sandboxes.sh
+++ b/.claude/skills/daytona-sandbox/scripts/probe-sandboxes.sh
@@ -10,8 +10,12 @@ if ! command -v daytona >/dev/null 2>&1; then
   echo "ERROR: daytona CLI not installed" >&2
   exit 2
 fi
-if ! daytona organization list >/dev/null 2>&1; then
-  echo "ERROR: daytona CLI not authed (run: daytona login)" >&2
+# `sandbox list` is the only auth probe that works for BOTH browser-login
+# and API-key auth modes. `organization list` fails under API-key auth with
+# "organization commands are not available when using API key authentication"
+# even when everything this skill actually uses works fine.
+if ! daytona sandbox list >/dev/null 2>&1; then
+  echo "ERROR: daytona CLI not authed (run: daytona login, or set DAYTONA_API_KEY)" >&2
   exit 2
 fi
 

--- a/.claude/skills/neon-postgres/PROJECT_NOTES.md
+++ b/.claude/skills/neon-postgres/PROJECT_NOTES.md
@@ -39,8 +39,12 @@ requires a browser.
 ```bash
 DB_URL=$(neonctl connection-string \
   --project-id super-cherry-83189326 \
-  --branch experimental-v2 2>/dev/null)
+  --branch experimental-v2)
 ```
+
+Leave `neonctl`'s stderr on — it's where auth expiry, wrong project
+id, and unknown-branch errors surface. Silencing it hides the
+diagnostic you need the moment the command starts failing.
 
 The returned URL contains a **password in cleartext** (`postgresql://user:password@host/db`).
 Rules:
@@ -69,7 +73,7 @@ repo is `backend/.venv`:
 
 ```bash
 cd /Users/hendrikkrack/n-aible/re-write/n-aible_edtech_sims/backend
-DB_URL=$(neonctl connection-string --project-id super-cherry-83189326 --branch experimental-v2 2>/dev/null)
+DB_URL=$(neonctl connection-string --project-id super-cherry-83189326 --branch experimental-v2)
 uv run python <<EOF
 import psycopg2
 conn = psycopg2.connect("$DB_URL", connect_timeout=10)

--- a/.claude/skills/neon-postgres/PROJECT_NOTES.md
+++ b/.claude/skills/neon-postgres/PROJECT_NOTES.md
@@ -47,8 +47,18 @@ Rules:
 
 - Never print the full `DB_URL` to logs, PR comments, or files
 - Never commit it to git
-- When showing to the user, mask the password: `${DB_URL%\?*}` gives
-  only the scheme + host portion
+- When showing to the user, mask the password with a regex that
+  replaces the `:password@` segment with `:****@` so the rest of the
+  URL (scheme + user + host + path + query) stays visible for
+  debugging:
+
+  ```bash
+  echo "$DB_URL" | sed -E 's#(postgres(ql)?://[^:]+):[^@]+@#\1:****@#'
+  # → postgresql://app_user:****@db.example.com/mydb?sslmode=require
+  ```
+
+  Do **not** use `${DB_URL%\?*}` — that only strips query args and
+  leaves the password in the output.
 - When passing to `psycopg2.connect(...)`, pass the variable
   directly — don't log the connect call
 

--- a/.claude/skills/neon-postgres/PROJECT_NOTES.md
+++ b/.claude/skills/neon-postgres/PROJECT_NOTES.md
@@ -90,7 +90,7 @@ There's a latent bug in the experimental-v2 DB: the
 `VARCHAR(32)` at some point, but pre-existing rows weren't backfilled.
 Symptoms:
 
-```
+```text
 ERROR [alembic.util.messaging] Requested revision X overlaps with
   other requested revisions Y
 FAILED: Requested revision X overlaps with ...
@@ -107,14 +107,17 @@ occurrence is instantly recognizable):
 import psycopg2
 conn = psycopg2.connect(DB_URL, connect_timeout=10)
 cur = conn.cursor()
-cur.execute("SELECT version_num FROM alembic_version ORDER BY version_num")
-rows = [r[0] for r in cur.fetchall()]
-# Identify any truncated rows — they'll be shorter than the
-# corresponding file's revision id. Delete them. Keep only the
-# full, valid head.
+# Delete the known truncated row. Keep only the full, valid head.
+# (The truncation happens because `alembic_version.version_num` was
+# once VARCHAR(17); rows written then were silently chopped.)
 cur.execute("DELETE FROM alembic_version WHERE version_num = 'add_code_language'")
 conn.commit()
 ```
+
+If you hit this again with a *different* truncated revision, first
+run `SELECT version_num FROM alembic_version` to see what's in there
+— the truncated row is whichever entry is missing the tail of its
+real filename under `backend/common/db/migrations/versions/`.
 
 After cleanup, redeploy via Railway. The backend should start cleanly
 on the next try. See `.claude/skills/railway-deploy-check/SKILL.md`

--- a/.claude/skills/neon-postgres/PROJECT_NOTES.md
+++ b/.claude/skills/neon-postgres/PROJECT_NOTES.md
@@ -1,0 +1,147 @@
+# Neon — n-aible project notes (companion to SKILL.md)
+
+The upstream `SKILL.md` covers Neon generally. This file captures
+n-aible-specific learnings and the exact commands that worked (or
+didn't) during the rewrite track.
+
+## Project + branch identifiers (safe to hardcode)
+
+These are stable, non-secret identifiers. Commands that pin them are
+reliable across sessions:
+
+| Thing | Value |
+| --- | --- |
+| Project id | `super-cherry-83189326` |
+| Parent branch (stable) | `production` |
+| **Target branch for rewrite work** | `experimental-v2` (note the `-v2` suffix) |
+| Other branches | `develop-v2`, `staging-v2`, `pr-*` |
+
+**Gotcha**: the Neon branch is `experimental-v2`, not `experimental`.
+Railway's environment is called `experimental` (no `-v2`). Mixing
+these up fails pre-flight checks with confusing errors.
+
+## Auth probe that actually works
+
+```bash
+neonctl me
+```
+
+Returns a one-row table showing email + project limit when authed.
+Anything else means the user needs to run `neonctl auth`. Token
+lives at `~/.config/neonctl/` — never read or print its contents.
+
+If `neonctl me` times out or returns an OAuth error, **stop and tell
+the user**. Don't try to auth from automation — the OAuth flow
+requires a browser.
+
+## Connection strings — treat as secrets
+
+```bash
+DB_URL=$(neonctl connection-string \
+  --project-id super-cherry-83189326 \
+  --branch experimental-v2 2>/dev/null)
+```
+
+The returned URL contains a **password in cleartext** (`postgresql://user:password@host/db`).
+Rules:
+
+- Never print the full `DB_URL` to logs, PR comments, or files
+- Never commit it to git
+- When showing to the user, mask the password: `${DB_URL%\?*}` gives
+  only the scheme + host portion
+- When passing to `psycopg2.connect(...)`, pass the variable
+  directly — don't log the connect call
+
+## Direct SQL with psycopg2 (from the backend's venv)
+
+The only Python env that has `psycopg2` readily available in this
+repo is `backend/.venv`:
+
+```bash
+cd /Users/hendrikkrack/n-aible/re-write/n-aible_edtech_sims/backend
+DB_URL=$(neonctl connection-string --project-id super-cherry-83189326 --branch experimental-v2 2>/dev/null)
+uv run python <<EOF
+import psycopg2
+conn = psycopg2.connect("$DB_URL", connect_timeout=10)
+cur = conn.cursor()
+cur.execute("SELECT COUNT(*) FROM users")
+print(f"users: {cur.fetchone()[0]}")
+conn.close()
+EOF
+```
+
+`psql` is NOT installed on this machine — trying `psql "$DB_URL"`
+fails with `command not found`. Use the `uv run python` approach instead.
+
+## alembic_version — watch out for column truncation
+
+There's a latent bug in the experimental-v2 DB: the
+`alembic_version.version_num` column was widened from `VARCHAR(17)` to
+`VARCHAR(32)` at some point, but pre-existing rows weren't backfilled.
+Symptoms:
+
+```
+ERROR [alembic.util.messaging] Requested revision X overlaps with
+  other requested revisions Y
+FAILED: Requested revision X overlaps with ...
+```
+
+This appears at backend startup during `alembic upgrade heads` when
+the alembic_version table contains a TRUNCATED version string (e.g.
+`add_code_language` instead of `add_code_language_to_scenes`).
+
+**Fix** (already applied on 2026-04-13; document so the next
+occurrence is instantly recognizable):
+
+```python
+import psycopg2
+conn = psycopg2.connect(DB_URL, connect_timeout=10)
+cur = conn.cursor()
+cur.execute("SELECT version_num FROM alembic_version ORDER BY version_num")
+rows = [r[0] for r in cur.fetchall()]
+# Identify any truncated rows — they'll be shorter than the
+# corresponding file's revision id. Delete them. Keep only the
+# full, valid head.
+cur.execute("DELETE FROM alembic_version WHERE version_num = 'add_code_language'")
+conn.commit()
+```
+
+After cleanup, redeploy via Railway. The backend should start cleanly
+on the next try. See `.claude/skills/railway-deploy-check/SKILL.md`
+for the redeploy recipe.
+
+## Branch management commands we actually use
+
+```bash
+# list branches (project_id is stable)
+neonctl branches list --project-id super-cherry-83189326
+
+# create a temp branch for migration testing
+neonctl branches create \
+  --project-id super-cherry-83189326 \
+  --parent experimental-v2 \
+  --name migration-test-$(date +%s)
+
+# delete a temp branch
+neonctl branches delete <temp-branch-name> \
+  --project-id super-cherry-83189326
+```
+
+Always clean up temp branches — they count against the project's
+branch limit.
+
+## Ralph loop usage
+
+The Ralph rewrite loop's `emit_event` helper writes to
+`ralph_pipeline_events` on `experimental-v2`. For dashboard
+validation queries (count events, verify schema, spot-check phase
+distributions), use the psycopg2 recipe above.
+
+Related tables on `experimental-v2`:
+- `users` — test professors + students from E2E runs
+- `simulations` — drafts from parse-pdf flow
+- `prompt_traces` — LLM call traces (empty until simulations
+  actually run on experimental)
+- `ralph_pipeline_events` — phase-transition events (populated by
+  the loop + backfill script)
+- `alembic_version` — migration head (see truncation gotcha above)

--- a/.claude/skills/neon-postgres/SKILL.md
+++ b/.claude/skills/neon-postgres/SKILL.md
@@ -5,6 +5,12 @@ description: Guides and best practices for working with Neon Serverless Postgres
 
 # Neon Serverless Postgres
 
+> **n-aible project notes**: see [PROJECT_NOTES.md](PROJECT_NOTES.md) for
+> project-specific identifiers (project id, branch names), the working
+> psycopg2 recipe, connection-string secret-handling rules, and the
+> `alembic_version` truncation gotcha that crashed experimental-v2
+> deploys on 2026-04-13. Read that first when touching the n-aible DB.
+
 Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
 
 ## Neon Documentation

--- a/.claude/skills/railway-deploy-check/SKILL.md
+++ b/.claude/skills/railway-deploy-check/SKILL.md
@@ -114,16 +114,22 @@ at least once before being documented:
 `railway logs` alone doesn't show deploy outcomes. Query the
 GraphQL API directly:
 
+Official Railway guidance is to authenticate GraphQL calls with the
+`RAILWAY_API_TOKEN` environment variable (account-scoped token,
+generated at <https://railway.com/account/tokens>). Do **not** parse
+`~/.railway/config.json` — the CLI login token there is brittle across
+CLI versions and auth modes, and Railway engineers explicitly
+discourage using it for automation.
+
 ```bash
-TOKEN=$(python3 -c "import json; \
-  print(json.load(open('$HOME/.railway/config.json'))['user']['accessToken'])")
+: "${RAILWAY_API_TOKEN:?Set RAILWAY_API_TOKEN before running this command}"
 curl -s -X POST 'https://backboard.railway.app/graphql/v2' \
-  -H "Authorization: Bearer $TOKEN" \
+  -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"query":"{ project(id:\"b5155e2f-af3c-49e9-9edc-664878402e01\") { services { edges { node { name deployments(first:5) { edges { node { id status createdAt } } } } } } } }"}'
 ```
 
-Do NOT print the `accessToken` into logs or commits. Treat the full
+Do NOT print `$RAILWAY_API_TOKEN` into logs or commits. Treat the full
 GraphQL response as potentially-sensitive; extract only what's needed.
 
 ### Per-deployment runtime logs
@@ -173,8 +179,8 @@ Verify a variable is set without echoing its value:
 ```bash
 railway variables --environment experimental --service Backend --json \
   | python3 -c "import json,sys; v=json.load(sys.stdin); \
-                print(f'{k}: {\"SET\" if v.get(k) else \"MISSING\"}') \
-                for k in ['GITHUB_TOKEN','RALPH_EVENT_TOKEN']"
+                [print(f'{k}: {\"SET\" if v.get(k) else \"MISSING\"}') \
+                 for k in ['GITHUB_TOKEN','RALPH_EVENT_TOKEN']]"
 ```
 
 ### The "stale deploy keeps serving" gotcha

--- a/.claude/skills/railway-deploy-check/SKILL.md
+++ b/.claude/skills/railway-deploy-check/SKILL.md
@@ -35,19 +35,30 @@ Auto-invoke after:
 Do **not** use this skill to diagnose `production-v3` or `staging-v2`
 deploys — it only reads from `experimental`.
 
-## Prerequisites
+## Prerequisites (in order — each one's failure is a distinct fix)
 
-Verify before invoking:
+1. **CLI present**: `command -v railway`
+2. **Session authed**: `railway whoami` exits 0 and names a user.
+   - Railway's OAuth tokens **expire silently** — a stale token looks
+     "logged in" in the config file but fails on any API call. Always
+     probe with `railway whoami`, never trust presence of the config.
+   - If expired: stop and tell the user "`railway login` required" —
+     only they can complete the browser flow.
+3. **Project + service linked**: needed so `railway logs` / `redeploy`
+   / `variables` know what to target. Two paths:
+   - Interactive: `railway link` then pick project + env + service
+     (prompts in terminal; not usable from automation)
+   - **Non-interactive (preferred for skills)**: known ids:
+     ```bash
+     railway link -p b5155e2f-af3c-49e9-9edc-664878402e01 \
+                  -e experimental -s Backend
+     ```
+     The project id is not a secret — it's a stable identifier safe
+     to hardcode. Secrets live in variables (see below), never in
+     links.
 
-- `railway` CLI is installed: `command -v railway`
-- Session is authed: `railway whoami` exits 0
-  (auth state lives in `~/.railway/config.json` — outside the repo;
-  never read or print its contents)
-- The Railway project is linked: from the repo root, `railway status`
-  should name the `n-aible_edtech_sims` project
-
-If any prerequisite fails, stop and report it to the user — do not try
-to re-authenticate or write to `~/.railway/`.
+If any prerequisite fails, stop and tell the user — do not try to
+re-authenticate, write to `~/.railway/`, or guess at project ids.
 
 ## Security
 
@@ -91,3 +102,89 @@ After the helper runs, summarize for the user:
 
 Keep the summary tight — the raw log block is already in the
 output; don't repeat it verbatim, just point at the salient line.
+
+## Operations beyond the helper (learned the hard way)
+
+The `check-deploy.sh` helper covers the common case. For things the
+helper doesn't do, here's what works reliably — each fell off a cliff
+at least once before being documented:
+
+### Listing recent deployments (build + deploy status)
+
+`railway logs` alone doesn't show deploy outcomes. Query the
+GraphQL API directly:
+
+```bash
+TOKEN=$(python3 -c "import json; \
+  print(json.load(open('$HOME/.railway/config.json'))['user']['accessToken'])")
+curl -s -X POST 'https://backboard.railway.app/graphql/v2' \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ project(id:\"b5155e2f-af3c-49e9-9edc-664878402e01\") { services { edges { node { name deployments(first:5) { edges { node { id status createdAt } } } } } } } }"}'
+```
+
+Do NOT print the `accessToken` into logs or commits. Treat the full
+GraphQL response as potentially-sensitive; extract only what's needed.
+
+### Per-deployment runtime logs
+
+Once you have a deployment id from the GraphQL call:
+
+```bash
+railway logs --environment experimental -s Backend <deploy-id-full-uuid>
+```
+
+If you get "Deployment not found", you're probably using a truncated
+id. The id in `deployments(first:N)` is a full UUID; use that.
+
+### Triggering a fresh deploy
+
+After fixing something (variable change, external state cleanup),
+force a redeploy:
+
+```bash
+railway redeploy -y   # requires --service linked
+```
+
+Setting env vars auto-triggers a redeploy, so use this only when
+you changed external state (DB, another service) and need to
+restart the backend.
+
+### Setting / updating variables
+
+```bash
+railway variables --environment experimental --service Backend \
+  --set "KEY=VALUE"
+```
+
+Triggers an automatic redeploy — usually desired. Two patterns we
+use:
+
+- `RALPH_EVENT_TOKEN` — shared secret for loop telemetry; generate
+  with `openssl rand -hex 32` and set on Railway + local `.env`
+  simultaneously.
+- `GITHUB_TOKEN` — from `gh auth token`; required for the admin
+  dashboard's "PRs merged / open issues" queries to avoid the 60
+  req/hr unauthenticated rate limit. Without it, the dashboard
+  silently shows 0 for GitHub-derived metrics.
+
+Verify a variable is set without echoing its value:
+
+```bash
+railway variables --environment experimental --service Backend --json \
+  | python3 -c "import json,sys; v=json.load(sys.stdin); \
+                print(f'{k}: {\"SET\" if v.get(k) else \"MISSING\"}') \
+                for k in ['GITHUB_TOKEN','RALPH_EVENT_TOKEN']"
+```
+
+### The "stale deploy keeps serving" gotcha
+
+Railway keeps the previous successful deploy running when a new one
+fails. So `/health` can return 200 while the actual code you pushed
+never made it live. Verification MUST include:
+
+1. `/openapi.json` has the routes you just added (curl + jq)
+2. Latest GraphQL deployment is `SUCCESS` not `FAILED`
+
+One of these passing is not enough — we lost multiple hours learning
+that `/health` on its own doesn't prove a deploy worked.


### PR DESCRIPTION
## Summary

Tonight's rewrite-track work exposed three infrastructure gaps that each cost real time. Embedding the learnings directly into the corresponding skills so they're free to recover from next time.

**railway-deploy-check** — silent OAuth expiry, non-interactive link command, GraphQL for deploy status, post-merge verification discipline (not just /health).

**neon-postgres** — new PROJECT_NOTES.md companion with n-aible identifiers, working psycopg2 recipe, `experimental-v2` vs `experimental` naming gotcha, and the alembic_version truncation bug + fix.

**daytona-sandbox** — two-auth-mode probe fix: `daytona sandbox list` works for both API-key and browser modes; `organization list` only works under browser auth.

## Security
- Diff scanned for `npg_` / `dtn_` / `ghp_` / 32-char hex patterns — zero matches
- Only non-secret identifiers committed (project ids, endpoint URLs, branch names)
- env var names referenced by name only; values never shown

## Test plan
- [x] Secret audit clean (grep over diff)
- [x] probe-sandboxes.sh syntax + live run — reports "no sandboxes" cleanly under current API-key auth (previously failed the auth probe with `organization list`)
- [ ] CodeRabbit passes
- [ ] Railway deploy green (docs-only, low risk, but verify per new policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Daytona Sandbox auth: two-mode model (Browser OAuth vs API key), updated sanity checks, probe guidance, and explicit user instructions for login or setting API key.
  * Added Neon Postgres project notes: authentication checks, connection-string secret handling, migration gotchas, execution recipes, and branch/operation guidance.
  * Expanded Railway Deploy Check: ordered prerequisites, auth/token handling, linking requirements, and deploy/variables troubleshooting.

* **Bug Fixes**
  * Probe now validates sandbox access via sandbox-list and shows actionable login/API-key instructions when unauthenticated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->