### PR TITLE
phase-2.00: push persona/scene filter into pgvector SQL

### DIFF
--- a/backend_v2/common/services/pgvector_store.py
+++ b/backend_v2/common/services/pgvector_store.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from typing import Any, Callable
 
 from sqlalchemy import text
@@ -45,9 +46,15 @@ DEFAULT_K = 5
 
 SessionFactory = Callable[[], Session]
 
+_METADATA_FILTER_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 class UnsupportedNamespaceError(ValueError):
     """Raised when a namespace does not map to a known table."""
+
+
+class UnsupportedFilterError(ValueError):
+    """Raised when a metadata filter is invalid or unsupported for the namespace."""
 
 
 def _validate_namespace(namespace: str) -> None:
@@ -62,11 +69,39 @@ def _format_vector_literal(vec: list[float]) -> str:
     return "[" + ",".join(format(float(x), ".17g") for x in vec) + "]"
 
 
+def _build_metadata_filter_sql(
+    metadata_filter: dict[str, Any] | None,
+) -> tuple[str, dict[str, str]]:
+    """Compile a metadata filter dict into ``AND``-joined SQL + bind params.
+
+    Values are compared via ``embedding_metadata ->> 'key' = :param`` so that
+    metadata stored as JSON numbers *or* JSON strings both match when the
+    caller passes the equivalent Python value (``->>`` always returns text).
+    Keys are validated to be simple identifiers — they are interpolated into
+    the SQL string because JSON key accessors cannot be bound parameters.
+    """
+    if not metadata_filter:
+        return "", {}
+    clauses: list[str] = []
+    params: dict[str, str] = {}
+    for idx, (key, value) in enumerate(metadata_filter.items()):
+        if not isinstance(key, str) or not _METADATA_FILTER_KEY_RE.match(key):
+            raise UnsupportedFilterError(
+                f"metadata_filter key {key!r} must match "
+                f"{_METADATA_FILTER_KEY_RE.pattern}"
+            )
+        param_name = f"_mf_{idx}"
+        clauses.append(f"embedding_metadata ->> '{key}' = :{param_name}")
+        params[param_name] = str(value)
+    return " AND " + " AND ".join(clauses), params
+
+
 async def similarity_search(
     query_embedding: list[float],
     namespace: str,
     k: int = DEFAULT_K,
     *,
+    metadata_filter: dict[str, Any] | None = None,
     session_factory: SessionFactory | None = None,
 ) -> list[dict]:
     """Return the ``k`` nearest rows for ``namespace``, ordered closest first.
@@ -74,16 +109,30 @@ async def similarity_search(
     Each result dict contains ``id``, identifier/content columns for the
     backing table, and ``similarity_score`` = ``1 - cosine_distance``.
     Returns ``[]`` when ``k <= 0``.
+
+    ``metadata_filter`` is an optional mapping of ``embedding_metadata``
+    field→value equality constraints applied in SQL. Supported only for
+    vector-embedding namespaces (``memory`` / ``conversation`` / ``scene``),
+    since the grading table has no metadata column.
     """
     _validate_namespace(namespace)
     if not query_embedding:
         raise ValueError("query_embedding must be a non-empty list of floats")
     if k <= 0:
         return []
+    if metadata_filter and namespace == _GRADING_NAMESPACE:
+        raise UnsupportedFilterError(
+            "metadata_filter is not supported for the 'grading' namespace"
+        )
 
     factory = session_factory or SessionLocal
     return await asyncio.to_thread(
-        _similarity_search_sync, factory, query_embedding, namespace, k
+        _similarity_search_sync,
+        factory,
+        query_embedding,
+        namespace,
+        k,
+        metadata_filter,
     )
 
 
@@ -120,6 +169,7 @@ def _similarity_search_sync(
     query_embedding: list[float],
     namespace: str,
     k: int,
+    metadata_filter: dict[str, Any] | None,
 ) -> list[dict]:
     vec = _format_vector_literal(query_embedding)
     session = factory()
@@ -143,8 +193,9 @@ def _similarity_search_sync(
             )
             params: dict[str, Any] = {"vec": vec, "k": k}
         else:
+            meta_sql, meta_params = _build_metadata_filter_sql(metadata_filter)
             sql = text(
-                """
+                f"""
                 SELECT id,
                        entity_type,
                        entity_id,
@@ -153,13 +204,13 @@ def _similarity_search_sync(
                              <=> CAST(:vec AS vector)) AS similarity_score
                 FROM vector_embeddings
                 WHERE entity_type = :ns
-                  AND embedding_vector IS NOT NULL
+                  AND embedding_vector IS NOT NULL{meta_sql}
                 ORDER BY (embedding_vector::text)::vector
                          <=> CAST(:vec AS vector)
                 LIMIT :k
                 """
             )
-            params = {"vec": vec, "ns": namespace, "k": k}
+            params = {"vec": vec, "ns": namespace, "k": k, **meta_params}
 
         rows = session.execute(sql, params).mappings().all()
         return [dict(row) for row in rows]
@@ -282,6 +333,7 @@ def _upsert_grading_chunk(
 __all__ = [
     "DEFAULT_K",
     "SUPPORTED_NAMESPACES",
+    "UnsupportedFilterError",
     "UnsupportedNamespaceError",
     "similarity_search",
     "upsert",

--- a/backend_v2/common/services/pgvector_store.py
+++ b/backend_v2/common/services/pgvector_store.py
@@ -79,6 +79,11 @@ def _build_metadata_filter_sql(
     caller passes the equivalent Python value (``->>`` always returns text).
     Keys are validated to be simple identifiers — they are interpolated into
     the SQL string because JSON key accessors cannot be bound parameters.
+
+    Booleans serialize to lowercase ``'true'``/``'false'`` to match the text
+    ``->>`` returns for JSON booleans, and ``None`` emits ``IS NULL`` since
+    ``->>`` yields SQL ``NULL`` for JSON null (an ``=`` comparison never
+    matches).
     """
     if not metadata_filter:
         return "", {}
@@ -90,9 +95,21 @@ def _build_metadata_filter_sql(
                 f"metadata_filter key {key!r} must match "
                 f"{_METADATA_FILTER_KEY_RE.pattern}"
             )
+        if value is None:
+            clauses.append(f"embedding_metadata ->> '{key}' IS NULL")
+            continue
+        if isinstance(value, bool):
+            serialized = "true" if value else "false"
+        elif isinstance(value, (str, int, float)):
+            serialized = str(value)
+        else:
+            raise UnsupportedFilterError(
+                f"metadata_filter value for {key!r} must be a JSON scalar "
+                f"(str, int, float, bool, or None); got {type(value).__name__}"
+            )
         param_name = f"_mf_{idx}"
         clauses.append(f"embedding_metadata ->> '{key}' = :{param_name}")
-        params[param_name] = str(value)
+        params[param_name] = serialized
     return " AND " + " AND ".join(clauses), params
 
 

--- a/backend_v2/modules/simulation/mcp/memory_tools.py
+++ b/backend_v2/modules/simulation/mcp/memory_tools.py
@@ -3,10 +3,11 @@
 Ports the hybrid ranking behaviour of
 ``backend/common/services/simulation_helper/memory_service.retrieve_memories_hybrid``
 to an ``@tool``-decorated async function that plugs into an MCP server
-(assembled in phase-2.7). Memory rows are read through the phase-1.2
-``pgvector_store`` and filtered client-side by ``persona_id`` / ``scene_id``
-metadata, since the low-level store intentionally exposes only an
-``entity_type`` namespace filter.
+(assembled in phase-2.7). Persona / scene scoping is pushed down into the
+``pgvector_store`` SQL query via ``metadata_filter``, so only in-scope rows
+ever reach the ranker. The small constant overfetch on top of ``k`` exists
+purely to give the hybrid re-ranker enough candidates to promote high-
+importance memories past high-similarity ones.
 
 Contract:
 
@@ -37,7 +38,6 @@ logger = logging.getLogger(__name__)
 
 _MEMORY_NAMESPACE = "memory"
 _OVERFETCH_MULTIPLIER = 3
-_MAX_OVERFETCH_MULTIPLIER = 24
 _SEMANTIC_WEIGHT = 0.7
 _IMPORTANCE_WEIGHT = 0.3
 _DEFAULT_K = 5
@@ -89,21 +89,18 @@ def _extract_content(metadata: dict[str, Any]) -> str | None:
 
 def _rank_candidates(
     rows: list[dict[str, Any]],
-    persona_id: int,
-    scene_id: int,
 ) -> list[tuple[float, str]]:
-    """Filter ``rows`` by persona+scene and hybrid-rank the survivors."""
-    persona_key = str(persona_id)
-    scene_key = str(scene_id)
+    """Hybrid-rank ``rows`` by weighted semantic + importance score.
+
+    Persona / scene scoping has already been applied by the SQL query via
+    ``metadata_filter``, so this function only needs to extract content,
+    compute hybrid scores, and sort.
+    """
     ranked: list[tuple[float, str]] = []
 
     for row in rows:
         metadata = row.get("embedding_metadata")
         if not isinstance(metadata, dict):
-            continue
-        if str(metadata.get("persona_id")) != persona_key:
-            continue
-        if str(metadata.get("scene_id")) != scene_key:
             continue
         content = _extract_content(metadata)
         if content is None:
@@ -167,20 +164,16 @@ async def recall_memory(args: dict[str, Any]) -> dict[str, Any]:
         query_vector = embed_result[0]
 
         fetch_k = max(k * _OVERFETCH_MULTIPLIER, k)
-        max_fetch_k = max(k * _MAX_OVERFETCH_MULTIPLIER, k)
-        ranked: list[tuple[float, str]] = []
-        while True:
-            candidates = await pgvector_store.similarity_search(
-                query_vector, _MEMORY_NAMESPACE, k=fetch_k
-            )
-            ranked = _rank_candidates(candidates, persona_id, scene_id)
-            if (
-                len(ranked) >= k
-                or len(candidates) < fetch_k
-                or fetch_k >= max_fetch_k
-            ):
-                break
-            fetch_k = min(fetch_k * 2, max_fetch_k)
+        candidates = await pgvector_store.similarity_search(
+            query_vector,
+            _MEMORY_NAMESPACE,
+            k=fetch_k,
+            metadata_filter={
+                "persona_id": persona_id,
+                "scene_id": scene_id,
+            },
+        )
+        ranked = _rank_candidates(candidates)
 
         blocks = [{"type": "text", "text": text} for _, text in ranked[:k]]
         return _success(blocks)

--- a/backend_v2/tests/common/services/test_pgvector_store.py
+++ b/backend_v2/tests/common/services/test_pgvector_store.py
@@ -594,6 +594,41 @@ def test_build_metadata_filter_sql_rejects_unsafe_key() -> None:
             _build_metadata_filter_sql({bad_key: "1"})  # type: ignore[dict-item]
 
 
+def test_build_metadata_filter_sql_booleans_use_json_text() -> None:
+    """Booleans serialize to lowercase ``'true'``/``'false'`` to match ``->>``."""
+    sql_true, params_true = _build_metadata_filter_sql({"is_active": True})
+    assert sql_true == " AND embedding_metadata ->> 'is_active' = :_mf_0"
+    assert params_true == {"_mf_0": "true"}
+
+    sql_false, params_false = _build_metadata_filter_sql({"is_active": False})
+    assert sql_false == " AND embedding_metadata ->> 'is_active' = :_mf_0"
+    assert params_false == {"_mf_0": "false"}
+
+
+def test_build_metadata_filter_sql_none_uses_is_null() -> None:
+    """``None`` emits ``IS NULL`` (``->>`` returns SQL NULL for JSON null)."""
+    sql, params = _build_metadata_filter_sql({"scene_id": None})
+    assert sql == " AND embedding_metadata ->> 'scene_id' IS NULL"
+    assert params == {}
+
+    # Mixed with other values: IS NULL clause coexists with bound params.
+    sql_mix, params_mix = _build_metadata_filter_sql(
+        {"scene_id": None, "persona_id": 7}
+    )
+    assert sql_mix == (
+        " AND embedding_metadata ->> 'scene_id' IS NULL"
+        " AND embedding_metadata ->> 'persona_id' = :_mf_1"
+    )
+    assert params_mix == {"_mf_1": "7"}
+
+
+def test_build_metadata_filter_sql_rejects_non_scalar_value() -> None:
+    """Non-JSON-scalar values (list/dict/etc.) are refused."""
+    for bad_value in ([1, 2], {"nested": 1}, object()):
+        with pytest.raises(UnsupportedFilterError):
+            _build_metadata_filter_sql({"persona_id": bad_value})  # type: ignore[dict-item]
+
+
 def test_similarity_search_rejects_metadata_filter_on_grading() -> None:
     """The grading table has no metadata column, so filters are refused."""
     import asyncio
@@ -701,3 +736,64 @@ async def test_similarity_search_metadata_filter_matches_numeric_and_string(
         session_factory=session_factory,
     )
     assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_metadata_filter_matches_bool_and_null(
+    session_factory,
+) -> None:
+    """Bool and None filter values match PostgreSQL's JSON text semantics.
+
+    ``->>`` returns ``'true'``/``'false'`` for JSON booleans and SQL ``NULL``
+    for JSON null, so Python ``True``/``False``/``None`` must be handled
+    explicitly rather than stringified as ``'True'``/``'False'``/``'None'``.
+    """
+    await upsert(
+        embedding=_unit_vector(4, 0),
+        metadata={
+            "entity_id": 1,
+            "is_active": True,
+            "scene_id": 10,
+            "content": "active-with-scene",
+        },
+        namespace="memory",
+        session_factory=session_factory,
+    )
+    await upsert(
+        embedding=_unit_vector(4, 0),
+        metadata={
+            "entity_id": 2,
+            "is_active": False,
+            "scene_id": None,
+            "content": "inactive-no-scene",
+        },
+        namespace="memory",
+        session_factory=session_factory,
+    )
+
+    active = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"is_active": True},
+        session_factory=session_factory,
+    )
+    assert [row["entity_id"] for row in active] == [1]
+
+    inactive = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"is_active": False},
+        session_factory=session_factory,
+    )
+    assert [row["entity_id"] for row in inactive] == [2]
+
+    no_scene = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"scene_id": None},
+        session_factory=session_factory,
+    )
+    assert [row["entity_id"] for row in no_scene] == [2]

--- a/backend_v2/tests/common/services/test_pgvector_store.py
+++ b/backend_v2/tests/common/services/test_pgvector_store.py
@@ -25,7 +25,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from common.services.pgvector_store import (
     DEFAULT_K,
     SUPPORTED_NAMESPACES,
+    UnsupportedFilterError,
     UnsupportedNamespaceError,
+    _build_metadata_filter_sql,
     _format_vector_literal,
     similarity_search,
     upsert,
@@ -558,3 +560,144 @@ def test_upsert_requires_material_id_and_hash_for_grading(session_factory) -> No
                 session_factory=session_factory,
             )
         )
+
+
+# ---- metadata_filter — pure unit + DB-backed tests ---------------------
+
+
+def test_build_metadata_filter_sql_empty() -> None:
+    """No filter yields an empty SQL fragment and no params."""
+    assert _build_metadata_filter_sql(None) == ("", {})
+    assert _build_metadata_filter_sql({}) == ("", {})
+
+
+def test_build_metadata_filter_sql_single_and_multi_key() -> None:
+    """Filter compiles to ``AND``-joined ``->>`` equality clauses."""
+    sql_one, params_one = _build_metadata_filter_sql({"persona_id": 7})
+    assert sql_one == " AND embedding_metadata ->> 'persona_id' = :_mf_0"
+    assert params_one == {"_mf_0": "7"}
+
+    sql_two, params_two = _build_metadata_filter_sql(
+        {"persona_id": 7, "scene_id": 42}
+    )
+    assert sql_two == (
+        " AND embedding_metadata ->> 'persona_id' = :_mf_0"
+        " AND embedding_metadata ->> 'scene_id' = :_mf_1"
+    )
+    assert params_two == {"_mf_0": "7", "_mf_1": "42"}
+
+
+def test_build_metadata_filter_sql_rejects_unsafe_key() -> None:
+    """Non-identifier keys are refused so the dynamic SQL stays safe."""
+    for bad_key in ("persona id", "persona-id", "'; DROP--", "", 123):
+        with pytest.raises(UnsupportedFilterError):
+            _build_metadata_filter_sql({bad_key: "1"})  # type: ignore[dict-item]
+
+
+def test_similarity_search_rejects_metadata_filter_on_grading() -> None:
+    """The grading table has no metadata column, so filters are refused."""
+    import asyncio
+
+    with pytest.raises(UnsupportedFilterError):
+        asyncio.run(
+            similarity_search(
+                [0.1, 0.2],
+                "grading",
+                k=1,
+                metadata_filter={"persona_id": 1},
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_metadata_filter_scopes_by_key(
+    session_factory,
+) -> None:
+    """SQL-level ``metadata_filter`` narrows results to matching rows only."""
+    # Seed three memories with identical vectors but different persona_ids.
+    for idx, persona_id in enumerate((1, 2, 1)):
+        await upsert(
+            embedding=_unit_vector(4, 0),
+            metadata={
+                "entity_id": 100 + idx,
+                "persona_id": persona_id,
+                "scene_id": 10,
+                "content": f"memory-{idx}-p{persona_id}",
+            },
+            namespace="memory",
+            session_factory=session_factory,
+        )
+
+    # No filter → all three rows come back.
+    unfiltered = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        session_factory=session_factory,
+    )
+    assert len(unfiltered) == 3
+
+    # Filter persona_id=1 → only the two persona-1 rows.
+    filtered = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"persona_id": 1},
+        session_factory=session_factory,
+    )
+    assert len(filtered) == 2
+    for row in filtered:
+        meta = row["embedding_metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        assert str(meta["persona_id"]) == "1"
+
+    # Combined persona_id + scene_id filter also works.
+    combo = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"persona_id": 2, "scene_id": 10},
+        session_factory=session_factory,
+    )
+    assert len(combo) == 1
+    assert combo[0]["entity_id"] == 101
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_metadata_filter_matches_numeric_and_string(
+    session_factory,
+) -> None:
+    """``->>`` returns text, so JSON numbers and JSON strings both match.
+
+    This keeps the filter tolerant of writers that serialize ids differently.
+    """
+    await upsert(
+        embedding=_unit_vector(4, 0),
+        metadata={
+            "entity_id": 1,
+            "persona_id": 5,  # JSON number
+            "content": "numeric-key",
+        },
+        namespace="memory",
+        session_factory=session_factory,
+    )
+    await upsert(
+        embedding=_unit_vector(4, 0),
+        metadata={
+            "entity_id": 2,
+            "persona_id": "5",  # JSON string
+            "content": "string-key",
+        },
+        namespace="memory",
+        session_factory=session_factory,
+    )
+
+    results = await similarity_search(
+        query_embedding=_unit_vector(4, 0),
+        namespace="memory",
+        k=10,
+        metadata_filter={"persona_id": 5},
+        session_factory=session_factory,
+    )
+    assert len(results) == 2

--- a/backend_v2/tests/modules/simulation/mcp/test_memory_tools.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_memory_tools.py
@@ -104,6 +104,12 @@ async def test_recall_memory_returns_topk_chunks(
     assert call_args.args[1] == "memory"
     # Over-fetch to allow hybrid re-ranking; callers still get at most k blocks.
     assert call_args.kwargs["k"] >= 5
+    # Persona / scene scoping is pushed into the SQL query, not filtered
+    # client-side, so the store sees the filter as a metadata constraint.
+    assert call_args.kwargs["metadata_filter"] == {
+        "persona_id": 1,
+        "scene_id": 10,
+    }
 
 
 @pytest.mark.asyncio
@@ -179,22 +185,58 @@ async def test_recall_memory_missing_persona_returns_error_envelope(
 
 
 @pytest.mark.asyncio
-async def test_recall_memory_filters_by_persona_and_scene_metadata(
+async def test_recall_memory_pushes_persona_scene_filter_to_vector_store(
     mock_validator, mock_embeddings, mock_similarity_search
 ) -> None:
+    """The tool delegates persona / scene scoping to the vector store.
+
+    Since filtering happens in SQL, the ranker trusts every row it receives.
+    We verify (a) the filter is forwarded to ``similarity_search`` and
+    (b) every row the mock returns is surfaced (no client-side discard) —
+    this is the behaviour that guarantees ``k`` scoped matches return fully.
+    """
     mock_similarity_search.return_value = [
-        _row(persona_id=1, scene_id=10, content="keep-1", similarity=0.9),
-        _row(persona_id=2, scene_id=10, content="drop-wrong-persona", similarity=0.85),
-        _row(persona_id=1, scene_id=11, content="drop-wrong-scene", similarity=0.8),
-        _row(persona_id=1, scene_id=10, content="keep-2", similarity=0.7),
+        _row(persona_id=1, scene_id=10, content="hit-1", similarity=0.9),
+        _row(persona_id=1, scene_id=10, content="hit-2", similarity=0.7),
     ]
+
+    result = await recall_memory.handler(
+        {"persona_id": 7, "scene_id": 42, "query": "q", "k": 5}
+    )
+
+    call_args = mock_similarity_search.await_args
+    assert call_args.kwargs["metadata_filter"] == {
+        "persona_id": 7,
+        "scene_id": 42,
+    }
+    texts = [block["text"] for block in result["content"]]
+    assert texts == ["hit-1", "hit-2"]
+
+
+@pytest.mark.asyncio
+async def test_recall_memory_uses_constant_overfetch_no_retry_loop(
+    mock_validator, mock_embeddings, mock_similarity_search, sample_rows
+) -> None:
+    """SQL-side filtering makes the adaptive fetch loop unnecessary.
+
+    Because the store already scopes by persona / scene, one fetch at
+    ``k * _OVERFETCH_MULTIPLIER`` is enough to feed the hybrid re-ranker.
+    """
+    from modules.simulation.mcp.memory_tools import _OVERFETCH_MULTIPLIER
+
+    mock_similarity_search.return_value = sample_rows[:2]  # fewer than k
 
     result = await recall_memory.handler(
         {"persona_id": 1, "scene_id": 10, "query": "q", "k": 5}
     )
 
-    texts = [block["text"] for block in result["content"]]
-    assert texts == ["keep-1", "keep-2"]
+    # Only one fetch — no widening retry when matches are scarce, since the
+    # SQL filter has already returned every in-scope candidate.
+    assert mock_similarity_search.await_count == 1
+    call_args = mock_similarity_search.await_args
+    assert call_args.kwargs["k"] == 5 * _OVERFETCH_MULTIPLIER
+    assert result["is_error"] is False
+    assert len(result["content"]) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #473

Implements ticket phase-2.00. See the issue for the full spec.

Closes out the three non-blocking CR findings that were raised on PR
#468 (phase-2.1 recall_memory). Findings #1 (drop `k` from
`input_schema`) and #2 (`asyncio.to_thread` around the sync persona
lookup) had already been picked up in the final round of PR #468; this
polish pass delivers finding #3 by choosing **option 1 — push the
persona/scene filter into the vector-query SQL** (rather than keep
widening the overfetch window client-side).

## Changes

- `common/services/pgvector_store.py`
  - `similarity_search` gains `metadata_filter: dict[str, Any] | None`.
  - `_build_metadata_filter_sql` compiles the dict to `AND`-joined
    `embedding_metadata ->> 'key' = :param` clauses. Keys are validated
    against `[A-Za-z_][A-Za-z0-9_]*` and rejected via a new
    `UnsupportedFilterError` otherwise, so the dynamic fragment stays
    safe.
  - `->>` returns text, so JSON-number and JSON-string metadata both
    match — keeping the filter tolerant of legacy writers.
  - Filters on the `grading` namespace raise `UnsupportedFilterError`
    (that table has no metadata column).
- `modules/simulation/mcp/memory_tools.py`
  - `recall_memory` drops the adaptive `k*3 → k*24` fetch loop. A
    single fetch at `k * _OVERFETCH_MULTIPLIER` is now enough; overfetch
    exists purely to feed the hybrid re-ranker.
  - Persona / scene equality flows through `metadata_filter=...` to the
    store instead of being enforced in `_rank_candidates`.
  - `_rank_candidates` loses its persona/scene guard — every row it
    sees is already scoped — and its signature shrinks accordingly.

## Tests added

- `tests/common/services/test_pgvector_store.py`
  - `_build_metadata_filter_sql`: empty / single / multi-key
    compilation.
  - `_build_metadata_filter_sql`: rejection of unsafe keys (whitespace,
    dashes, SQL-injection-looking strings, empty, non-string).
  - `similarity_search`: grading namespace refuses a metadata_filter.
  - `similarity_search`: DB-backed — single-key filter scopes results,
    multi-key filter ANDs correctly, JSON numbers and strings both
    match via `->>`.
- `tests/modules/simulation/mcp/test_memory_tools.py`
  - Existing `test_recall_memory_returns_topk_chunks` extended to
    assert `metadata_filter` is forwarded.
  - New `test_recall_memory_pushes_persona_scene_filter_to_vector_store`
    replaces the old client-side-filter test.
  - New `test_recall_memory_uses_constant_overfetch_no_retry_loop`
    pins the removal of the adaptive fetch loop (single fetch, even
    when matches are scarce).

Local `coderabbit review --prompt-only --base origin/ralph-looped`:
no findings. Full memory_tools + pgvector_store suite (34 tests)
passes against a local pgvector instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metadata filter parameter to similarity search queries for fine-grained result filtering.

* **Improvements**
  * Memory retrieval now applies persona and scene filtering at the vector store level.
  * Simplified memory recall overfetch to a single, consistent fetch amount.
  * Validation added to prevent metadata filters in grading contexts.

* **Tests**
  * Added unit and integration tests covering metadata filter behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->