### PR TITLE
docs(rewrite): wire ralph-loop prompts to pr-review-workflow skill

### DIFF
--- a/scripts/rewrite/resources/prompts/address-pr-feedback.md
+++ b/scripts/rewrite/resources/prompts/address-pr-feedback.md
@@ -9,6 +9,19 @@ This is review round {{ROUND}} of {{MAX_ROUNDS}}.
 
 ---
 
+## Overarching discipline — follow the pr-review-workflow skill
+
+Follow the **pr-review-workflow** skill throughout this phase. It
+encodes the comment-closure rule (every CR comment gets either a
+code fix OR a reply-with-reason — never silent), the merge gates
+(Section 4), and the post-merge Railway verify (Section 5). The
+skill auto-invokes on "cr feedback" / "address pr" / "merge"
+phrasing, so you don't need to slash-command it explicitly — just
+let it shape your approach. If this phase ends with open CR comments
+that have neither a fix nor a reply, you have NOT finished the round.
+
+---
+
 ## Sources of feedback to check
 
 ### 1. CodeRabbit PR bot (always)

--- a/scripts/rewrite/resources/prompts/implement.md
+++ b/scripts/rewrite/resources/prompts/implement.md
@@ -32,9 +32,9 @@ based on description match. Relevant ones for this phase:
 - **pr-review-workflow** — PR lifecycle discipline: CLI health
   probes before anything, Test Plan shape, comment-closure rules,
   merge gates, post-merge Railway verify. Auto-invokes on PR / merge
-  / CR-related phrasing. Don't improvise PR handling — defer to the
-  skill for steps 6+ below (opening the PR, surviving the CR cycle,
-  and verifying the Railway deploy after merge).
+  / CR-related phrasing. Treat this skill as **authoritative** for
+  PR opening and every post-open step (review, merge, verify); do
+  not use ad-hoc PR body formats.
 
 ## Workflow (complete ALL steps — do not stop halfway)
 
@@ -73,21 +73,16 @@ test({{TICKET_ID}}): cover <cases>
 ```
 
 ### 6. Push and open the PR
-```
-git push -u origin {{FEATURE_BRANCH}}
-gh pr create --repo {{GH_REPO}} --base {{BASE_BRANCH}} \
-  --label {{LABEL}} \
-  --title '{{TICKET_ID}}: <summary>' \
-  --body 'Fixes #{{ISSUE_NUM}}
 
-Implements ticket {{TICKET_ID}}. See the issue for the full spec.
+Follow the **pr-review-workflow** skill for everything from here
+through merge — it's the authoritative source for the PR body shape
+(Test Plan with checkbox gates), the `gh pr create` invocation, the
+CR follow-up cadence, and the post-merge Railway verify.
 
-## Changes
-<bullet list>
-
-## Tests added
-<bullet list>'
-```
+The one ticket-specific addition on top of the skill's template:
+the PR body must include `Fixes #{{ISSUE_NUM}}` so the linked issue
+auto-closes on merge, and apply the `{{LABEL}}` label on `gh pr create`
+so the ralph-loop dashboard can find it.
 
 ### 7. Output the PR number (the loop reads this)
 

--- a/scripts/rewrite/resources/prompts/implement.md
+++ b/scripts/rewrite/resources/prompts/implement.md
@@ -29,6 +29,12 @@ based on description match. Relevant ones for this phase:
   and returns structured findings.
 - **neon-postgres** — guidance for querying the experimental Neon
   branch if you need to verify DB state during implementation.
+- **pr-review-workflow** — PR lifecycle discipline: CLI health
+  probes before anything, Test Plan shape, comment-closure rules,
+  merge gates, post-merge Railway verify. Auto-invokes on PR / merge
+  / CR-related phrasing. Don't improvise PR handling — defer to the
+  skill for steps 6+ below (opening the PR, surviving the CR cycle,
+  and verifying the Railway deploy after merge).
 
 ## Workflow (complete ALL steps — do not stop halfway)
 


### PR DESCRIPTION
## Summary

- Insert an "Overarching discipline" section at the top of
  `address-pr-feedback.md` that anchors the entire CR-feedback phase
  in the pr-review-workflow skill (merged in #472). Covers the
  comment-closure rule, merge gates, and post-merge Railway verify.
- Add a `pr-review-workflow` bullet to the "Skills available" list
  in `implement.md` so the loop knows about it when opening PRs and
  surviving CR cycles.

Both inserts match the existing bold-skill-name / invocation phrasing
pattern already used for autofix, railway-deploy-check, code-review,
neon-postgres.

Docs-only. No runtime change until the next loop iteration picks up
the updated prompts via `render_prompt`.

## Test plan
- [x] `bash -n scripts/rewrite/ralph-rewrite-loop.sh` passes
- [x] Visual diff — skill references phrased consistently with
      existing skill mentions in the same prompts
- [x] CodeRabbit passes or all comments closed per skill Section 3
- [ ] No Railway experimental verify needed (docs-only, no deploy
      impact) — but still confirm via the skill's Section 5 check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized PR review workflow: added a rule that every review comment must be closed by a code fix or a reply, and reinforced merge gates and post-merge verification.
  * Delegated PR creation and follow-up cadence to a centralized review skill; PRs must include a "Fixes #..." reference and apply the relevant label on creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->