### PR TITLE
phase-2.02: lookup_rubric MCP tool

### DIFF
--- a/backend_v2/modules/simulation/mcp/grading_tools.py
+++ b/backend_v2/modules/simulation/mcp/grading_tools.py
@@ -1,0 +1,213 @@
+"""``lookup_rubric`` MCP tool — scenario-scoped grading-material retrieval.
+
+Ports the retrieval behaviour of
+``backend/common/services/simulation_helper/grading_vector_store.GradingVectorStore.search_grading_materials``
+to an ``@tool``-decorated async function that plugs into an MCP server
+(assembled in phase-2.7). Grading chunks live in the ``"grading"`` namespace
+of the phase-1.2 ``pgvector_store``; the rows it returns include
+``material_id`` but not the owning ``simulation_id``, so we resolve the set
+of materials belonging to ``scenario_id`` via a focused read against the
+``grading_materials`` table and filter the candidates client-side.
+
+Contract:
+
+* Input schema:  ``scenario_id: int``, ``query: str``, ``k: int = 3``.
+* Success return:  ``{"content": [{"type": "text", "text": ...}, ...],
+  "structuredContent": {"results": [...]}, "is_error": False}`` with up to
+  ``k`` chunks ordered best-first. Each ``results`` entry has ``content``,
+  ``material_id``, ``chunk_index``, and ``relevance_score``.
+* Unknown scenario (no completed grading materials for ``scenario_id``):
+  ``{"content": [{"type": "text", "text": "<message naming scenario_id>"}],
+  "is_error": True}``. The tool never raises to the MCP runtime.
+* Empty / whitespace ``query`` or non-positive ``k`` short-circuits to
+  ``{"content": [], "structuredContent": {"results": []}, "is_error": False}``
+  without touching the DB.
+* Any unexpected exception is logged and surfaces as a generic error
+  envelope.
+
+``scenario_id`` maps directly to ``simulation_id`` in the underlying schema
+— the rewrite uses the ``scenario`` vocabulary at the MCP boundary while
+the DB still stores the row on ``simulations``/``grading_materials``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable
+
+from claude_agent_sdk import tool
+from openai import AsyncOpenAI
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from common.db.connection import SessionLocal
+from common.db.models import GradingMaterial
+from common.services import pgvector_store
+from common.services.embeddings_service import EmbeddingsService
+
+logger = logging.getLogger(__name__)
+
+_GRADING_NAMESPACE = "grading"
+_OVERFETCH_MULTIPLIER = 3
+_MAX_OVERFETCH_MULTIPLIER = 24
+_DEFAULT_K = 3
+_COMPLETED_STATUS = "completed"
+
+_UNKNOWN_SCENARIO_TEMPLATE = (
+    "No grading materials found for scenario_id={scenario_id}"
+)
+_GENERIC_ERROR_MESSAGE = "Failed to look up rubric"
+
+SessionFactory = Callable[[], Session]
+
+_embeddings_service_singleton: EmbeddingsService | None = None
+
+
+def _get_embeddings_service() -> EmbeddingsService:
+    """Return a lazily-constructed shared embeddings service.
+
+    Kept module-scoped so the OpenAI client is created once per process and
+    so tests can monkeypatch this function to inject a mock.
+    """
+    global _embeddings_service_singleton
+    if _embeddings_service_singleton is None:
+        _embeddings_service_singleton = EmbeddingsService(client=AsyncOpenAI())
+    return _embeddings_service_singleton
+
+
+def _success(
+    blocks: list[dict[str, Any]], structured: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "content": blocks,
+        "structuredContent": {"results": structured},
+        "is_error": False,
+    }
+
+
+def _error(message: str) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": message}],
+        "is_error": True,
+    }
+
+
+def _load_scenario_material_ids(
+    scenario_id: int,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> set[int]:
+    """Return the set of ``grading_materials.id`` rows for ``scenario_id``.
+
+    Only materials whose ``processing_status`` is ``"completed"`` are
+    returned — a scenario whose materials are still being embedded is
+    indistinguishable from an unknown scenario for the purposes of this
+    tool. Tests inject ``session_factory`` to avoid touching the real DB.
+    """
+    factory = session_factory or SessionLocal
+    session = factory()
+    try:
+        stmt = select(GradingMaterial.id).where(
+            GradingMaterial.simulation_id == scenario_id,
+            GradingMaterial.processing_status == _COMPLETED_STATUS,
+        )
+        return set(session.execute(stmt).scalars().all())
+    finally:
+        session.close()
+
+
+def _as_score(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@tool(
+    name="lookup_rubric",
+    description=(
+        "Retrieve up to k most-relevant grading-rubric chunks for a scenario "
+        "using cosine similarity over that scenario's uploaded grading "
+        "materials. Returns MCP text content blocks ordered best-first plus "
+        "a structured 'results' list with material_id, chunk_index, and "
+        "relevance_score. Optional integer argument 'k' (default 3) caps "
+        "the number of chunks returned."
+    ),
+    input_schema={
+        "scenario_id": int,
+        "query": str,
+    },
+)
+async def lookup_rubric(args: dict[str, Any]) -> dict[str, Any]:
+    """MCP tool entry point — see module docstring for the contract."""
+    try:
+        scenario_id = args["scenario_id"]
+        query = args.get("query", "")
+        k = args.get("k", _DEFAULT_K)
+
+        if not isinstance(k, int) or k <= 0:
+            return _success([], [])
+        if not isinstance(query, str) or not query.strip():
+            return _success([], [])
+
+        material_ids = await asyncio.to_thread(
+            _load_scenario_material_ids, scenario_id
+        )
+        if not material_ids:
+            return _error(
+                _UNKNOWN_SCENARIO_TEMPLATE.format(scenario_id=scenario_id)
+            )
+
+        service = _get_embeddings_service()
+        embed_result = await service.embed([query])
+        if not embed_result or not embed_result[0]:
+            return _success([], [])
+        query_vector = embed_result[0]
+
+        fetch_k = max(k * _OVERFETCH_MULTIPLIER, k)
+        max_fetch_k = max(k * _MAX_OVERFETCH_MULTIPLIER, k)
+        filtered: list[dict[str, Any]] = []
+        while True:
+            candidates = await pgvector_store.similarity_search(
+                query_vector, _GRADING_NAMESPACE, k=fetch_k
+            )
+            filtered = [
+                row for row in candidates
+                if row.get("material_id") in material_ids
+            ]
+            if (
+                len(filtered) >= k
+                or len(candidates) < fetch_k
+                or fetch_k >= max_fetch_k
+            ):
+                break
+            fetch_k = min(fetch_k * 2, max_fetch_k)
+
+        filtered.sort(
+            key=lambda row: _as_score(row.get("similarity_score")),
+            reverse=True,
+        )
+        top = filtered[:k]
+
+        structured = [
+            {
+                "content": row.get("content", ""),
+                "material_id": row.get("material_id"),
+                "chunk_index": row.get("chunk_index"),
+                "relevance_score": _as_score(row.get("similarity_score")),
+            }
+            for row in top
+        ]
+        blocks = [
+            {"type": "text", "text": row.get("content", "")} for row in top
+        ]
+        return _success(blocks, structured)
+    except Exception:
+        logger.exception(
+            "lookup_rubric failed for scenario_id=%s",
+            args.get("scenario_id"),
+        )
+        return _error(_GENERIC_ERROR_MESSAGE)
+
+
+__all__ = ["lookup_rubric"]

--- a/backend_v2/modules/simulation/mcp/grading_tools.py
+++ b/backend_v2/modules/simulation/mcp/grading_tools.py
@@ -136,6 +136,7 @@ def _as_score(value: Any) -> float:
     input_schema={
         "scenario_id": int,
         "query": str,
+        "k": int,
     },
 )
 async def lookup_rubric(args: dict[str, Any]) -> dict[str, Any]:

--- a/backend_v2/modules/simulation/mcp/grading_tools.py
+++ b/backend_v2/modules/simulation/mcp/grading_tools.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from typing import Any, Callable
 
 from claude_agent_sdk import tool
@@ -51,6 +52,7 @@ _GRADING_NAMESPACE = "grading"
 _OVERFETCH_MULTIPLIER = 3
 _MAX_OVERFETCH_MULTIPLIER = 24
 _DEFAULT_K = 3
+_MAX_K = 50
 _COMPLETED_STATUS = "completed"
 
 _UNKNOWN_SCENARIO_TEMPLATE = (
@@ -118,9 +120,10 @@ def _load_scenario_material_ids(
 
 def _as_score(value: Any) -> float:
     try:
-        return float(value)
+        score = float(value)
     except (TypeError, ValueError):
         return 0.0
+    return score if math.isfinite(score) else 0.0
 
 
 @tool(
@@ -148,6 +151,7 @@ async def lookup_rubric(args: dict[str, Any]) -> dict[str, Any]:
 
         if not isinstance(k, int) or k <= 0:
             return _success([], [])
+        k = min(k, _MAX_K)
         if not isinstance(query, str) or not query.strip():
             return _success([], [])
 

--- a/backend_v2/tests/modules/simulation/mcp/test_grading_tools_lookup.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_grading_tools_lookup.py
@@ -344,6 +344,52 @@ async def test_lookup_rubric_overfetches_when_scenario_hits_are_sparse(
     assert async_mock.await_count >= 2
 
 
+@pytest.mark.asyncio
+async def test_lookup_rubric_non_finite_similarity_falls_back_to_zero(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """NaN / inf / -inf similarity scores collapse to 0.0 (valid JSON)."""
+    mock_material_ids.return_value = {1}
+    mock_similarity_search.return_value = [
+        {"material_id": 1, "chunk_index": 0, "content": "a", "similarity_score": "nan"},
+        {"material_id": 1, "chunk_index": 1, "content": "b", "similarity_score": "inf"},
+        {"material_id": 1, "chunk_index": 2, "content": "c", "similarity_score": "-inf"},
+    ]
+
+    result = await lookup_rubric.handler(
+        {"scenario_id": 1, "query": "q", "k": 3}
+    )
+
+    assert result["is_error"] is False
+    for row in result["structuredContent"]["results"]:
+        assert row["relevance_score"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_clamps_oversized_k(
+    mock_material_ids, mock_embeddings
+) -> None:
+    """``k`` > ``_MAX_K`` clamps so a single call can't balloon the pgvector query."""
+    mock_material_ids.return_value = {1}
+    captured_ks: list[int] = []
+
+    async def side_effect(_vec, _ns, k: int):
+        captured_ks.append(k)
+        return []
+
+    async_mock = AsyncMock(side_effect=side_effect)
+    with patch.object(
+        grading_tools.pgvector_store, "similarity_search", async_mock
+    ):
+        await lookup_rubric.handler(
+            {"scenario_id": 1, "query": "q", "k": 10_000}
+        )
+
+    # Every similarity_search must stay within the clamped bound.
+    assert captured_ks, "similarity_search was never called"
+    assert max(captured_ks) <= grading_tools._MAX_K * grading_tools._MAX_OVERFETCH_MULTIPLIER
+
+
 def test_get_embeddings_service_is_cached() -> None:
     """The embeddings singleton is constructed lazily and reused."""
     grading_tools._embeddings_service_singleton = None

--- a/backend_v2/tests/modules/simulation/mcp/test_grading_tools_lookup.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_grading_tools_lookup.py
@@ -1,0 +1,358 @@
+"""Unit tests for the ``lookup_rubric`` MCP tool (phase-2.2).
+
+Every external collaborator (embeddings service, pgvector store, scenario
+material-id loader) is replaced with an in-memory fake. The only thing
+under test is the tool's envelope contract, scenario scoping, top-k
+ordering, and error-envelope behaviour on unknown scenarios.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from modules.simulation.mcp import grading_tools
+from modules.simulation.mcp.grading_tools import lookup_rubric
+
+
+def _row(
+    *,
+    material_id: int,
+    chunk_index: int,
+    content: str,
+    similarity: float,
+) -> dict[str, Any]:
+    """Build a ``pgvector_store.similarity_search`` result row for grading."""
+    return {
+        "id": material_id * 100 + chunk_index,
+        "material_id": material_id,
+        "chunk_index": chunk_index,
+        "content": content,
+        "content_hash": f"hash-{material_id}-{chunk_index}",
+        "similarity_score": similarity,
+    }
+
+
+@pytest.fixture
+def mock_material_ids():
+    """Patch ``_load_scenario_material_ids`` with a ``MagicMock``."""
+    with patch.object(
+        grading_tools, "_load_scenario_material_ids"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_embeddings():
+    """Patch the embeddings singleton factory with a mock service."""
+    service = MagicMock()
+    service.embed = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    with patch.object(
+        grading_tools, "_get_embeddings_service", return_value=service
+    ):
+        yield service
+
+
+@pytest.fixture
+def mock_similarity_search():
+    """Patch ``pgvector_store.similarity_search`` with an ``AsyncMock``."""
+    async_mock = AsyncMock()
+    with patch.object(
+        grading_tools.pgvector_store, "similarity_search", async_mock
+    ):
+        yield async_mock
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_returns_topk(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """More than ``k`` candidates → the top ``k`` by similarity are returned."""
+    mock_material_ids.return_value = {1, 2}
+    # Five chunks belonging to the scenario's materials, interleaved similarity.
+    mock_similarity_search.return_value = [
+        _row(material_id=1, chunk_index=0, content="rubric-A", similarity=0.95),
+        _row(material_id=2, chunk_index=0, content="rubric-B", similarity=0.80),
+        _row(material_id=1, chunk_index=1, content="rubric-C", similarity=0.70),
+        _row(material_id=2, chunk_index=1, content="rubric-D", similarity=0.60),
+        _row(material_id=1, chunk_index=2, content="rubric-E", similarity=0.50),
+    ]
+
+    result = await lookup_rubric.handler(
+        {"scenario_id": 42, "query": "evaluate analysis quality", "k": 3}
+    )
+
+    assert result["is_error"] is False
+    assert result["content"] == [
+        {"type": "text", "text": "rubric-A"},
+        {"type": "text", "text": "rubric-B"},
+        {"type": "text", "text": "rubric-C"},
+    ]
+    structured = result["structuredContent"]["results"]
+    assert len(structured) == 3
+    assert [item["content"] for item in structured] == [
+        "rubric-A",
+        "rubric-B",
+        "rubric-C",
+    ]
+    # Ordered by relevance_score, descending.
+    scores = [item["relevance_score"] for item in structured]
+    assert scores == sorted(scores, reverse=True)
+    assert structured[0]["material_id"] == 1
+    assert structured[0]["chunk_index"] == 0
+    assert structured[0]["relevance_score"] == pytest.approx(0.95)
+
+    mock_material_ids.assert_called_once_with(42)
+    mock_embeddings.embed.assert_awaited_once_with(["evaluate analysis quality"])
+    mock_similarity_search.assert_awaited()
+    call_args = mock_similarity_search.await_args
+    assert call_args.args[0] == [0.1, 0.2, 0.3]
+    assert call_args.args[1] == "grading"
+    # Over-fetch to allow scenario filtering; callers still get at most k blocks.
+    assert call_args.kwargs["k"] >= 3
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_default_k_is_three(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """Omitted ``k`` defaults to 3."""
+    mock_material_ids.return_value = {1}
+    mock_similarity_search.return_value = [
+        _row(material_id=1, chunk_index=i, content=f"chunk-{i}", similarity=0.9 - i * 0.1)
+        for i in range(5)
+    ]
+
+    result = await lookup_rubric.handler(
+        {"scenario_id": 7, "query": "anything"}
+    )
+
+    assert result["is_error"] is False
+    assert len(result["content"]) == 3
+    assert len(result["structuredContent"]["results"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_scoped_to_scenario(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """Chunks whose ``material_id`` is not owned by the scenario are filtered out."""
+    # Scenario 42 owns materials {1, 2}. Candidates include material 99 from
+    # another scenario — it must NOT appear in the result.
+    mock_material_ids.return_value = {1, 2}
+    mock_similarity_search.return_value = [
+        _row(material_id=99, chunk_index=0, content="other-scenario-1",
+             similarity=0.99),
+        _row(material_id=1, chunk_index=0, content="keep-A", similarity=0.90),
+        _row(material_id=99, chunk_index=1, content="other-scenario-2",
+             similarity=0.85),
+        _row(material_id=2, chunk_index=0, content="keep-B", similarity=0.80),
+        _row(material_id=1, chunk_index=1, content="keep-C", similarity=0.70),
+    ]
+
+    result = await lookup_rubric.handler(
+        {"scenario_id": 42, "query": "q", "k": 5}
+    )
+
+    assert result["is_error"] is False
+    texts = [block["text"] for block in result["content"]]
+    assert texts == ["keep-A", "keep-B", "keep-C"]
+    # No cross-contamination from scenario 99.
+    assert all("other-scenario" not in text for text in texts)
+    structured_material_ids = {
+        item["material_id"] for item in result["structuredContent"]["results"]
+    }
+    assert structured_material_ids <= {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_unknown_scenario_returns_error_envelope(
+    mock_embeddings, mock_similarity_search
+) -> None:
+    """A scenario with no completed grading materials → error envelope."""
+    with patch.object(
+        grading_tools, "_load_scenario_material_ids", return_value=set()
+    ):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 999, "query": "q", "k": 3}
+        )
+
+    assert result["is_error"] is True
+    assert len(result["content"]) == 1
+    assert result["content"][0]["type"] == "text"
+    # Error message mentions the scenario_id that was not found.
+    assert "999" in result["content"][0]["text"]
+    # A missing scenario short-circuits before we hit embeddings / pgvector.
+    mock_embeddings.embed.assert_not_called()
+    mock_similarity_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_empty_query_returns_empty(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """Empty / whitespace query short-circuits without DB work."""
+    for query in ("", "   ", "\n\t"):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 1, "query": query, "k": 3}
+        )
+        assert result == {
+            "content": [],
+            "structuredContent": {"results": []},
+            "is_error": False,
+        }
+
+    mock_material_ids.assert_not_called()
+    mock_embeddings.embed.assert_not_called()
+    mock_similarity_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_non_positive_k_returns_empty(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """``k <= 0`` short-circuits without DB work."""
+    for k in (0, -1):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 1, "query": "q", "k": k}
+        )
+        assert result == {
+            "content": [],
+            "structuredContent": {"results": []},
+            "is_error": False,
+        }
+
+    mock_material_ids.assert_not_called()
+    mock_embeddings.embed.assert_not_called()
+    mock_similarity_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_empty_embedding_returns_empty(
+    mock_material_ids, mock_similarity_search
+) -> None:
+    """An embedding service that returns an empty vector → empty success."""
+    mock_material_ids.return_value = {1}
+    service = MagicMock()
+    service.embed = AsyncMock(return_value=[])
+    with patch.object(
+        grading_tools, "_get_embeddings_service", return_value=service
+    ):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 1, "query": "q", "k": 3}
+        )
+
+    assert result == {
+        "content": [],
+        "structuredContent": {"results": []},
+        "is_error": False,
+    }
+    mock_similarity_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_similarity_search_exception_returns_error_envelope(
+    mock_material_ids, mock_embeddings
+) -> None:
+    """Unexpected exceptions from pgvector surface as a generic error envelope."""
+    mock_material_ids.return_value = {1}
+    async_mock = AsyncMock(side_effect=RuntimeError("pgvector exploded"))
+    with patch.object(
+        grading_tools.pgvector_store, "similarity_search", async_mock
+    ):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 1, "query": "q", "k": 3}
+        )
+
+    assert result["is_error"] is True
+    assert result["content"] == [
+        {"type": "text", "text": "Failed to look up rubric"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_missing_required_field_returns_error_envelope(
+    mock_embeddings, mock_similarity_search
+) -> None:
+    """A missing ``scenario_id`` key falls through to the generic error envelope."""
+    result = await lookup_rubric.handler({"query": "q", "k": 3})
+
+    assert result == {
+        "content": [{"type": "text", "text": "Failed to look up rubric"}],
+        "is_error": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_non_numeric_similarity_falls_back_to_zero(
+    mock_material_ids, mock_embeddings, mock_similarity_search
+) -> None:
+    """Malformed similarity scores default to 0.0 without crashing."""
+    mock_material_ids.return_value = {1}
+    mock_similarity_search.return_value = [
+        {
+            "material_id": 1,
+            "chunk_index": 0,
+            "content": "good",
+            "similarity_score": "not-a-number",
+        },
+    ]
+
+    result = await lookup_rubric.handler(
+        {"scenario_id": 1, "query": "q", "k": 3}
+    )
+
+    assert result["is_error"] is False
+    assert result["structuredContent"]["results"][0]["relevance_score"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_lookup_rubric_overfetches_when_scenario_hits_are_sparse(
+    mock_material_ids, mock_embeddings
+) -> None:
+    """If the first fetch under-serves, the tool over-fetches until k are found."""
+    mock_material_ids.return_value = {1}
+
+    # First batch contains mostly foreign chunks; second batch has the hits.
+    batch_first = [
+        _row(material_id=99, chunk_index=i, content=f"foreign-{i}",
+             similarity=0.9 - i * 0.01)
+        for i in range(9)
+    ]
+    batch_second = batch_first + [
+        _row(material_id=1, chunk_index=0, content="hit-A", similarity=0.50),
+        _row(material_id=1, chunk_index=1, content="hit-B", similarity=0.40),
+        _row(material_id=1, chunk_index=2, content="hit-C", similarity=0.30),
+    ]
+
+    async def side_effect(_vec, _ns, k: int):
+        return batch_second if k > 9 else batch_first
+
+    async_mock = AsyncMock(side_effect=side_effect)
+    with patch.object(
+        grading_tools.pgvector_store, "similarity_search", async_mock
+    ):
+        result = await lookup_rubric.handler(
+            {"scenario_id": 1, "query": "q", "k": 3}
+        )
+
+    assert result["is_error"] is False
+    texts = [block["text"] for block in result["content"]]
+    assert texts == ["hit-A", "hit-B", "hit-C"]
+    # Over-fetch triggered at least one extra round-trip.
+    assert async_mock.await_count >= 2
+
+
+def test_get_embeddings_service_is_cached() -> None:
+    """The embeddings singleton is constructed lazily and reused."""
+    grading_tools._embeddings_service_singleton = None
+    try:
+        with patch.object(grading_tools, "AsyncOpenAI") as openai_cls:
+            openai_cls.return_value = MagicMock()
+            first = grading_tools._get_embeddings_service()
+            second = grading_tools._get_embeddings_service()
+        assert first is second
+        openai_cls.assert_called_once()
+    finally:
+        grading_tools._embeddings_service_singleton = None


### PR DESCRIPTION
Fixes #436

Implements ticket phase-2.2 — ports `backend/common/services/simulation_helper/grading_vector_store.py` behind an `@tool`-decorated async `lookup_rubric(scenario_id, query, k=3)` so the grading agent (phase-2.7) can retrieve scenario-scoped rubric chunks via MCP.

## Summary
- `backend_v2/modules/simulation/mcp/grading_tools.py` — new module; same MCP envelope as phase-2.1 (`content` + `is_error`, plus `structuredContent.results` with `content`, `material_id`, `chunk_index`, `relevance_score`).
  - `scenario_id` maps directly to `grading_materials.simulation_id` (no new schema).
  - Loads the set of **completed** materials for the scenario; unknown scenario → error envelope that names the `scenario_id`. Tool never raises to the MCP runtime.
  - Embeds the query via `EmbeddingsService` (lazy singleton; tests patch the factory) and calls `pgvector_store.similarity_search("grading", k=k*3)`, then filters candidates to the scenario's material_ids.
  - Over-fetches up to `24k` when foreign-scenario chunks crowd out hits, before settling for fewer than `k`.
  - Empty / whitespace query or non-positive `k` short-circuits to empty success without touching the DB.
  - Malformed similarity scores default to `0.0` via `_as_score`.
- `backend_v2/tests/modules/simulation/mcp/test_grading_tools_lookup.py` — 12 tests, in-memory fakes for embeddings / pgvector / material-id loader. Covers the three tests the ticket names (`test_lookup_rubric_returns_topk`, `test_lookup_rubric_scoped_to_scenario`, `test_lookup_rubric_unknown_scenario_returns_error_envelope`) plus default `k`, empty query, non-positive `k`, empty embedding, pgvector exception path, missing `scenario_id`, non-numeric similarity, over-fetch, and the singleton factory.

No other files are touched (scope discipline: `__init__.py` re-export is left to phase-2.7 per the ticket's files allowlist). No new dependencies — all imports are already in `backend_v2/pyproject.toml`.

## Test plan
- [x] `cd backend_v2 && uv run pytest tests/modules/simulation/mcp/test_grading_tools_lookup.py -q --cov=modules.simulation.mcp.grading_tools --cov-fail-under=80` → **12 passed, coverage 92%** (≥ 80 gate).
- [x] `cd backend_v2 && uv run pytest tests/modules/simulation/mcp/ -q` → **26 passed** (phase-2.1 suite unaffected).
- [x] Local `coderabbit review --prompt-only -t uncommitted` → **No findings**.
- [ ] CodeRabbit PR review passes (or all comments addressed / replied).
- [ ] CI green on `ralph-looped`.

### Note on the ticket's verbatim verification command
The ticket spec says:

```
cd backend_v2 && uv run pytest tests/modules/simulation/mcp/test_grading_tools_lookup.py -q --cov=modules/simulation/mcp/grading_tools --cov-fail-under=80
```

`coverage.py` 7.x rejects the slash form `--cov=modules/simulation/mcp/grading_tools` as an invalid module path (0% collected, fail-under trips). The dotted form — `--cov=modules.simulation.mcp.grading_tools` — passes cleanly and is the form phase-2.01 adopted (PR #468). Both variants target the same single file; the dotted form is what the Test Plan above uses.

## Non-goals
Does not implement `submit_grade` — that's phase-2.3, which will append to the same `grading_tools.py` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rubric lookup: search grading materials by query and return top-k relevant text chunks with relevance scores filtered to the requested scenario; defaults to k=3. Returns empty success for empty/invalid queries or non-positive k; returns an error when no completed materials exist for the scenario.

* **Tests**
  * End-to-end tests cover relevance ordering, scenario filtering, over-fetch behavior, error mappings, score normalization (non-numeric/NaN → 0.0), and singleton embeddings usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->