### PR TITLE
fix(e2e-skill): send empty body to publish endpoint

### DIFF
--- a/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
+++ b/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
@@ -198,7 +198,7 @@ def run_flow_1() -> dict:
 
     # --- 4. publish
     step("FLOW-1", 4, f"publish simulation_id={simulation_id}")
-    r = post(s, f"/api/publishing/simulations/publish/{simulation_id}")
+    r = post(s, f"/api/publishing/simulations/publish/{simulation_id}", json={})
     if r.status_code not in (200, 201):
         die("publish failed", r)
     ok("published")


### PR DESCRIPTION
## Summary

- `run-e2e.py` was POSTing to `/api/publishing/simulations/publish/{simulation_id}` with no body, but the backend requires a `SimulationPublishRequest` body (Pydantic model with zero fields — but the body itself is mandatory). Result: `422 Field required`, which tripped the ralph-loop Phase C gate on PR #476 despite that PR's diff being wholly internal to `grading_tools.py` and unable to regress the publish flow.
- One-line fix: pass `json={}` — satisfies the Pydantic contract without changing server semantics.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('.claude/skills/e2e-simulation-flow/scripts/run-e2e.py').read())"` → syntax ok
- [x] Visual confirmation: `backend_v2/modules/publishing/schemas/dto.py:12-14` — `SimulationPublishRequest` has no fields, so `{}` is the minimal valid body
- [x] `bash -n` style: no other callsite of `/api/publishing/simulations/publish/` in the repo besides `run-e2e.py`
- [ ] CodeRabbit passes (or all comments addressed / replied)
- [ ] CI green on `ralph-looped`
- [ ] Railway experimental deploy unaffected (skill file, no runtime change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal test script improvements to ensure proper API communication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->