### PR TITLE
fix(rewrite-loop): skip tickets whose PR already merged

### DIFF
--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -98,19 +98,8 @@ def deps(body):
     m = DEP_RE.search(body)
     return [int(n) for n in NUM_RE.findall(m.group(1))] if m else []
 
-def dep_met(n):
-    # issue closed AND its PR merged into base.
-    r = subprocess.run(
-        ["gh", "issue", "view", str(n), "--repo", repo, "--json", "state"],
-        capture_output=True, text=True
-    )
-    if r.returncode != 0:
-        return False
-    try:
-        if json.loads(r.stdout).get("state") != "CLOSED":
-            return False
-    except json.JSONDecodeError:
-        return False
+def _merged_pr_for(n):
+    """Return True iff a merged PR on `base` strictly closes issue #n."""
     p = subprocess.run(
         ["gh", "pr", "list", "--repo", repo,
          "--state", "merged", "--base", base,
@@ -130,8 +119,29 @@ def dep_met(n):
             return True
     return False
 
+def dep_met(n):
+    # issue closed AND its PR merged into base.
+    r = subprocess.run(
+        ["gh", "issue", "view", str(n), "--repo", repo, "--json", "state"],
+        capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        return False
+    try:
+        if json.loads(r.stdout).get("state") != "CLOSED":
+            return False
+    except json.JSONDecodeError:
+        return False
+    return _merged_pr_for(n)
+
 rows = []
 for i in issues:
+    # Skip tickets whose PR is already merged. Issues on `ralph-looped`
+    # don't auto-close on merge (Fixes # only fires for the default
+    # branch), so a merged-but-still-OPEN issue would otherwise be
+    # re-picked forever.
+    if _merged_pr_for(i["number"]):
+        continue
     blocked = [d for d in deps(i.get("body","") or "") if not dep_met(d)]
     if not blocked:
         rows.append((ticket_id(i["title"]), i["number"], i["title"]))

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -103,7 +103,7 @@ def _merged_pr_for(n):
     p = subprocess.run(
         ["gh", "pr", "list", "--repo", repo,
          "--state", "merged", "--base", base,
-         "--search", f"Fixes #{n} OR Closes #{n}",
+         "--search", f"Fixes #{n} OR Closes #{n} OR Resolves #{n}",
          "--json", "number,body,title"],
         capture_output=True, text=True
     )
@@ -120,18 +120,11 @@ def _merged_pr_for(n):
     return False
 
 def dep_met(n):
-    # issue closed AND its PR merged into base.
-    r = subprocess.run(
-        ["gh", "issue", "view", str(n), "--repo", repo, "--json", "state"],
-        capture_output=True, text=True
-    )
-    if r.returncode != 0:
-        return False
-    try:
-        if json.loads(r.stdout).get("state") != "CLOSED":
-            return False
-    except json.JSONDecodeError:
-        return False
+    # A dependency is satisfied once its closing PR is merged into
+    # base. We do NOT require the issue itself to be CLOSED because
+    # `Fixes #N` only auto-closes on default-branch merges, not on
+    # merges into `ralph-looped` — so a merged-but-still-OPEN issue
+    # must count as met, otherwise downstream tickets stall.
     return _merged_pr_for(n)
 
 rows = []


### PR DESCRIPTION
## Summary

- Ralph loop was getting stuck re-picking `#436` (phase-2.02) even after PR #476 merged, because issues don't auto-close on `ralph-looped` merges (GitHub only honours `Fixes #N` on the default branch).
- Patch `pick_ready_tickets()` in `scripts/rewrite/resources/lib.sh` with a new `_merged_pr_for(n)` helper that runs the same strict close-keyword regex already used by `dep_met` — but at the row level — so any ticket with a merged PR is excluded before readiness evaluation.
- Same 1.5h of wasted polling last night won't recur.

## Test plan

- [x] `bash -n scripts/rewrite/ralph-rewrite-loop.sh` exits 0
- [x] `scripts/rewrite/ralph-rewrite-loop.sh --iterations 0` dry-run: `#436` no longer appears; `#437 phase-2.03` is now first
- [ ] CodeRabbit passes (or all comments addressed / replied)
- [ ] CI green on `ralph-looped`
- [ ] Railway experimental deploy unaffected (script-only change; no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ticket selection to treat dependencies as satisfied when a matching merged pull request explicitly closes the issue (Fixes/Closes/Resolves), reducing false re-selection.
  * Now skips already-merged work to prevent re-processing completed items.
  * Broadened closing-keyword detection to include "Resolves", further reducing duplicate effort and processing overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->