### PR TITLE
phase-2.03: submit_grade MCP tool

### DIFF
--- a/backend_v2/modules/simulation/mcp/grading_tools.py
+++ b/backend_v2/modules/simulation/mcp/grading_tools.py
@@ -56,6 +56,7 @@ from common.db.models import (
     GradingMaterial,
     SceneProgress,
     Simulation,
+    SimulationScene,
     UserProgress,
 )
 from common.services import pgvector_store
@@ -238,8 +239,18 @@ _GENERIC_SUBMIT_ERROR_MESSAGE = "Failed to submit grade"
 _UNKNOWN_USER_PROGRESS_TEMPLATE = (
     "No user_progress found for user_progress_id={user_progress_id}"
 )
+_UNKNOWN_SCENE_TEMPLATE = "No scene found for scene_id={scene_id}"
+_SCENE_SIMULATION_MISMATCH_TEMPLATE = (
+    "scene_id={scene_id} does not belong to simulation_id={simulation_id}"
+)
 _NO_RUBRIC_TEMPLATE = (
     "Simulation {simulation_id} has no grading rubric configured"
+)
+_REQUIRED_SUBMIT_GRADE_KEYS = (
+    "user_progress_id",
+    "scene_id",
+    "rubric_scores",
+    "strictness",
 )
 
 
@@ -288,7 +299,16 @@ def _submit_grade_sync(
     factory = session_factory or SessionLocal
     session = factory()
     try:
-        user_progress = session.get(UserProgress, user_progress_id)
+        # Lock the user_progress row so concurrent submit_grade calls for
+        # the same learner serialise on Postgres; SQLite ignores FOR UPDATE
+        # and is single-writer anyway, so tests are unaffected. A proper
+        # DB-side upsert would require unique constraints on
+        # scene_progress(user_progress_id, scene_id) and
+        # grading_materials(simulation_id, filename) — schema changes that
+        # are out of scope for this ticket.
+        user_progress = session.get(
+            UserProgress, user_progress_id, with_for_update=True
+        )
         if user_progress is None:
             return _error(
                 _UNKNOWN_USER_PROGRESS_TEMPLATE.format(
@@ -296,6 +316,17 @@ def _submit_grade_sync(
                 )
             )
         simulation_id = user_progress.simulation_id
+
+        scene = session.get(SimulationScene, scene_id)
+        if scene is None:
+            return _error(_UNKNOWN_SCENE_TEMPLATE.format(scene_id=scene_id))
+        if scene.simulation_id != simulation_id:
+            return _error(
+                _SCENE_SIMULATION_MISMATCH_TEMPLATE.format(
+                    scene_id=scene_id, simulation_id=simulation_id
+                )
+            )
+
         simulation = session.get(Simulation, simulation_id)
         rubric_keys = _extract_rubric_keys(
             simulation.grading_config if simulation is not None else None
@@ -398,14 +429,26 @@ def _submit_grade_sync(
 )
 async def submit_grade(args: dict[str, Any]) -> dict[str, Any]:
     """MCP tool entry point for ``submit_grade`` — see module docstring."""
-    try:
-        user_progress_id = args["user_progress_id"]
-        scene_id = args["scene_id"]
-        rubric_scores = args["rubric_scores"]
-        strictness = args["strictness"]
-    except KeyError:
-        logger.exception("submit_grade missing required argument: args=%s", args)
+    if not isinstance(args, dict):
+        logger.warning(
+            "submit_grade called with non-dict args: type=%s", type(args).__name__
+        )
         return _error(_GENERIC_SUBMIT_ERROR_MESSAGE)
+
+    missing = [key for key in _REQUIRED_SUBMIT_GRADE_KEYS if key not in args]
+    if missing:
+        # Log only field names so per-criterion scores and identifiers from
+        # the incoming payload never leak into stdout/log aggregators.
+        logger.warning(
+            "submit_grade missing required arguments: %s",
+            ", ".join(sorted(missing)),
+        )
+        return _error(_GENERIC_SUBMIT_ERROR_MESSAGE)
+
+    user_progress_id = args["user_progress_id"]
+    scene_id = args["scene_id"]
+    rubric_scores = args["rubric_scores"]
+    strictness = args["strictness"]
 
     if not isinstance(rubric_scores, dict):
         return _error(

--- a/backend_v2/modules/simulation/mcp/grading_tools.py
+++ b/backend_v2/modules/simulation/mcp/grading_tools.py
@@ -1,6 +1,6 @@
-"""``lookup_rubric`` MCP tool — scenario-scoped grading-material retrieval.
+"""Grading MCP tools — ``lookup_rubric`` retrieval and ``submit_grade`` write.
 
-Ports the retrieval behaviour of
+``lookup_rubric`` ports the retrieval behaviour of
 ``backend/common/services/simulation_helper/grading_vector_store.GradingVectorStore.search_grading_materials``
 to an ``@tool``-decorated async function that plugs into an MCP server
 (assembled in phase-2.7). Grading chunks live in the ``"grading"`` namespace
@@ -8,6 +8,15 @@ of the phase-1.2 ``pgvector_store``; the rows it returns include
 ``material_id`` but not the owning ``simulation_id``, so we resolve the set
 of materials belonging to ``scenario_id`` via a focused read against the
 ``grading_materials`` table and filter the candidates client-side.
+
+``submit_grade`` is the write-side companion: the grading agent calls it
+with a per-criterion score map once it has finished evaluating a scene. The
+tool validates that every submitted rubric key corresponds to a criterion
+on the scenario's ``grading_config``, persists the result into the scene's
+``scene_progress.progress_data["grading_result"]`` slot, and records one
+``grading_materials`` row whose ``content`` is the JSON-serialised payload.
+Both the scene-progress update and the grading-material insert are
+idempotent on ``(user_progress_id, scene_id)``.
 
 Contract:
 
@@ -32,6 +41,7 @@ the DB still stores the row on ``simulations``/``grading_materials``.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import math
 from typing import Any, Callable
@@ -42,7 +52,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from common.db.connection import SessionLocal
-from common.db.models import GradingMaterial
+from common.db.models import (
+    GradingMaterial,
+    SceneProgress,
+    Simulation,
+    UserProgress,
+)
 from common.services import pgvector_store
 from common.services.embeddings_service import EmbeddingsService
 
@@ -215,4 +230,195 @@ async def lookup_rubric(args: dict[str, Any]) -> dict[str, Any]:
         return _error(_GENERIC_ERROR_MESSAGE)
 
 
-__all__ = ["lookup_rubric"]
+_GRADE_RESULT_KEY = "grading_result"
+_GRADE_MATERIAL_FILENAME_TEMPLATE = "grade_{user_progress_id}_{scene_id}.json"
+_GRADE_MATERIAL_SUCCESS_STATUS = "completed"
+_CRITERION_KEY_FIELDS = ("description", "name", "criterion_name")
+_GENERIC_SUBMIT_ERROR_MESSAGE = "Failed to submit grade"
+_UNKNOWN_USER_PROGRESS_TEMPLATE = (
+    "No user_progress found for user_progress_id={user_progress_id}"
+)
+_NO_RUBRIC_TEMPLATE = (
+    "Simulation {simulation_id} has no grading rubric configured"
+)
+
+
+def _extract_rubric_keys(grading_config: dict[str, Any] | None) -> list[str]:
+    """Return the ordered list of rubric-criterion keys for a simulation.
+
+    Criteria are stored as a list under ``grading_config["criteria"]``. Each
+    criterion dict is expected to expose one of ``description`` /
+    ``name`` / ``criterion_name`` as its human-facing label; the first
+    non-empty match wins. Any criterion missing all three fields is skipped
+    silently rather than failing validation — the rubric author owns that
+    structural gap.
+    """
+    if not isinstance(grading_config, dict):
+        return []
+    criteria = grading_config.get("criteria")
+    if not isinstance(criteria, list):
+        return []
+    keys: list[str] = []
+    for item in criteria:
+        if not isinstance(item, dict):
+            continue
+        for field in _CRITERION_KEY_FIELDS:
+            value = item.get(field)
+            if isinstance(value, str) and value.strip():
+                keys.append(value)
+                break
+    return keys
+
+
+def _submit_grade_sync(
+    user_progress_id: int,
+    scene_id: int,
+    rubric_scores: dict[str, Any],
+    strictness: str,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> dict[str, Any]:
+    """Blocking implementation of ``submit_grade`` — kept out of the event loop.
+
+    The async ``submit_grade`` wrapper runs this via ``asyncio.to_thread`` so
+    the write does not stall the MCP server. Tests can also call it directly
+    (passing a fixture ``session_factory``) to avoid spinning up an asyncio
+    runner.
+    """
+    factory = session_factory or SessionLocal
+    session = factory()
+    try:
+        user_progress = session.get(UserProgress, user_progress_id)
+        if user_progress is None:
+            return _error(
+                _UNKNOWN_USER_PROGRESS_TEMPLATE.format(
+                    user_progress_id=user_progress_id
+                )
+            )
+        simulation_id = user_progress.simulation_id
+        simulation = session.get(Simulation, simulation_id)
+        rubric_keys = _extract_rubric_keys(
+            simulation.grading_config if simulation is not None else None
+        )
+        if not rubric_keys:
+            return _error(
+                _NO_RUBRIC_TEMPLATE.format(simulation_id=simulation_id)
+            )
+
+        submitted_keys = set(rubric_scores.keys())
+        valid_keys = set(rubric_keys)
+        invalid_keys = sorted(submitted_keys - valid_keys)
+        if invalid_keys:
+            return _error(
+                "rubric_scores contains keys not in the simulation's rubric: "
+                + ", ".join(invalid_keys)
+            )
+
+        payload = {
+            "user_progress_id": user_progress_id,
+            "scene_id": scene_id,
+            "simulation_id": simulation_id,
+            "rubric_scores": dict(rubric_scores),
+            "strictness": strictness,
+        }
+
+        scene_progress = session.execute(
+            select(SceneProgress)
+            .where(SceneProgress.user_progress_id == user_progress_id)
+            .where(SceneProgress.scene_id == scene_id)
+        ).scalar_one_or_none()
+        if scene_progress is None:
+            scene_progress = SceneProgress(
+                user_progress_id=user_progress_id,
+                scene_id=scene_id,
+                progress_data={_GRADE_RESULT_KEY: payload},
+            )
+            session.add(scene_progress)
+        else:
+            progress_data = dict(scene_progress.progress_data or {})
+            progress_data[_GRADE_RESULT_KEY] = payload
+            scene_progress.progress_data = progress_data
+
+        filename = _GRADE_MATERIAL_FILENAME_TEMPLATE.format(
+            user_progress_id=user_progress_id, scene_id=scene_id
+        )
+        content = json.dumps(payload, sort_keys=True)
+        material = session.execute(
+            select(GradingMaterial)
+            .where(GradingMaterial.simulation_id == simulation_id)
+            .where(GradingMaterial.filename == filename)
+        ).scalar_one_or_none()
+        if material is None:
+            material = GradingMaterial(
+                simulation_id=simulation_id,
+                filename=filename,
+                content=content,
+                processing_status=_GRADE_MATERIAL_SUCCESS_STATUS,
+            )
+            session.add(material)
+        else:
+            material.content = content
+            material.processing_status = _GRADE_MATERIAL_SUCCESS_STATUS
+
+        session.commit()
+        return {
+            "content": [{"type": "text", "text": "grade recorded"}],
+            "structuredContent": payload,
+            "is_error": False,
+        }
+    except Exception:
+        session.rollback()
+        logger.exception(
+            "submit_grade failed for user_progress_id=%s scene_id=%s",
+            user_progress_id,
+            scene_id,
+        )
+        return _error(_GENERIC_SUBMIT_ERROR_MESSAGE)
+    finally:
+        session.close()
+
+
+@tool(
+    name="submit_grade",
+    description=(
+        "Persist a per-criterion grade for one scene of a student's "
+        "simulation run. Writes the result into that scene_progress row "
+        "and records the payload as a grading_materials entry. Validates "
+        "that rubric_scores keys match the simulation's configured rubric "
+        "criteria; unknown keys surface as is_error=True without touching "
+        "the database. Idempotent on (user_progress_id, scene_id): "
+        "re-submitting updates the existing rows."
+    ),
+    input_schema={
+        "user_progress_id": int,
+        "scene_id": int,
+        "rubric_scores": dict,
+        "strictness": str,
+    },
+)
+async def submit_grade(args: dict[str, Any]) -> dict[str, Any]:
+    """MCP tool entry point for ``submit_grade`` — see module docstring."""
+    try:
+        user_progress_id = args["user_progress_id"]
+        scene_id = args["scene_id"]
+        rubric_scores = args["rubric_scores"]
+        strictness = args["strictness"]
+    except KeyError:
+        logger.exception("submit_grade missing required argument: args=%s", args)
+        return _error(_GENERIC_SUBMIT_ERROR_MESSAGE)
+
+    if not isinstance(rubric_scores, dict):
+        return _error(
+            "rubric_scores must be a dict of criterion_key -> score"
+        )
+
+    return await asyncio.to_thread(
+        _submit_grade_sync,
+        user_progress_id,
+        scene_id,
+        rubric_scores,
+        strictness,
+    )
+
+
+__all__ = ["lookup_rubric", "submit_grade"]

--- a/backend_v2/tests/modules/simulation/mcp/test_grading_tools_submit.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_grading_tools_submit.py
@@ -1,0 +1,515 @@
+"""Unit tests for the ``submit_grade`` MCP tool (phase-2.3).
+
+The tool has three moving parts we care about:
+
+* rubric-key validation against ``Simulation.grading_config``,
+* writing the grading payload into the scene's ``progress_data`` column
+  under the ``"grading_result"`` key, and
+* inserting / updating a single ``grading_materials`` row per
+  ``(user_progress_id, scene_id)``.
+
+All tests run against the in-memory SQLite session from
+``tests/conftest.py``. A ``patched_session_factory`` fixture makes the
+tool reuse that session so commits land in the same transaction the test
+observes before teardown.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from common.db.models import (
+    GradingMaterial,
+    SceneProgress,
+    Simulation,
+    SimulationScene,
+    UserProgress,
+    User,
+)
+from modules.simulation.mcp import grading_tools
+from modules.simulation.mcp.grading_tools import submit_grade
+
+
+@pytest.fixture
+def patched_session_factory(db_session: Session):
+    """Route ``submit_grade``'s DB work through the test's session.
+
+    The tool builds its own session via ``SessionLocal()`` by default;
+    patching the module-level ``SessionLocal`` to a factory that returns
+    a wrapper session — with ``close()`` / ``commit()`` neutralised so the
+    fixture's rollback-on-teardown still wins — makes all writes visible
+    to assertions without escaping the transaction.
+    """
+    class _NoCloseSession:
+        def __init__(self, inner: Session) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str):
+            return getattr(self._inner, name)
+
+        def close(self) -> None:  # tests own the session lifecycle
+            pass
+
+        def commit(self) -> None:
+            # Flush so follow-up selects see pending inserts/updates,
+            # but defer the real commit to the test's teardown rollback.
+            self._inner.flush()
+
+        def rollback(self) -> None:
+            self._inner.rollback()
+
+    def factory() -> Session:  # type: ignore[return-value]
+        return _NoCloseSession(db_session)  # type: ignore[return-value]
+
+    with patch.object(grading_tools, "SessionLocal", factory):
+        yield factory
+
+
+@pytest.fixture
+def simulation(db_session: Session) -> Simulation:
+    """Simulation with a two-criterion rubric keyed by ``description``."""
+    user = User(
+        user_id="prof-1",
+        email="prof@example.com",
+        full_name="Phase 2.3 Professor",
+        username="prof-phase-2-3",
+        role="professor",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    sim = Simulation(
+        unique_id="sim-phase-2-3",
+        title="Phase 2.3 Sim",
+        description="Fixture simulation",
+        created_by=user.id,
+        grading_config={
+            "title": "Rubric",
+            "criteria": [
+                {"description": "Analysis"},
+                {"description": "Communication"},
+            ],
+            "performance_levels": [],
+            "strictness_level": 3,
+        },
+    )
+    db_session.add(sim)
+    db_session.flush()
+    return sim
+
+
+@pytest.fixture
+def scene(db_session: Session, simulation: Simulation) -> SimulationScene:
+    scene_row = SimulationScene(
+        simulation_id=simulation.id,
+        title="Scene 1",
+        description="",
+        scene_order=1,
+    )
+    db_session.add(scene_row)
+    db_session.flush()
+    return scene_row
+
+
+@pytest.fixture
+def user_progress(
+    db_session: Session, simulation: Simulation, scene: SimulationScene
+) -> UserProgress:
+    student = User(
+        user_id="stud-1",
+        email="stud@example.com",
+        full_name="Phase 2.3 Student",
+        username="stud-phase-2-3",
+        role="student",
+    )
+    db_session.add(student)
+    db_session.flush()
+
+    progress = UserProgress(
+        user_id=student.id,
+        simulation_id=simulation.id,
+        current_scene_id=scene.id,
+    )
+    db_session.add(progress)
+    db_session.flush()
+    return progress
+
+
+def _valid_scores() -> dict[str, int]:
+    return {"Analysis": 8, "Communication": 7}
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_writes_scene_progress_row(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A valid submission persists the payload to ``scene_progress.progress_data``."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is False
+    assert result["structuredContent"]["rubric_scores"] == _valid_scores()
+    assert result["structuredContent"]["strictness"] == "balanced"
+
+    row = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress.id)
+        .where(SceneProgress.scene_id == scene.id)
+    ).scalar_one()
+    assert row.progress_data is not None
+    grading = row.progress_data["grading_result"]
+    assert grading["rubric_scores"] == _valid_scores()
+    assert grading["strictness"] == "balanced"
+    assert grading["simulation_id"] == simulation.id
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_inserts_grading_materials_row(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A valid submission inserts exactly one ``grading_materials`` row."""
+    await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    materials = db_session.execute(
+        select(GradingMaterial).where(
+            GradingMaterial.simulation_id == simulation.id
+        )
+    ).scalars().all()
+    assert len(materials) == 1
+    material = materials[0]
+    assert material.filename == f"grade_{user_progress.id}_{scene.id}.json"
+    assert material.processing_status == "completed"
+    payload = json.loads(material.content)
+    assert payload["rubric_scores"] == _valid_scores()
+    assert payload["strictness"] == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_rejects_unknown_rubric_keys(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """Unknown rubric keys short-circuit to ``is_error=True`` with no DB writes."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": {
+                "Analysis": 8,
+                "NotARealCriterion": 5,
+                "AlsoFake": 3,
+            },
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert "NotARealCriterion" in text
+    assert "AlsoFake" in text
+
+    # Nothing was persisted — validation runs before writes.
+    assert (
+        db_session.execute(
+            select(SceneProgress).where(
+                SceneProgress.user_progress_id == user_progress.id
+            )
+        ).scalar_one_or_none()
+        is None
+    )
+    assert (
+        db_session.execute(
+            select(GradingMaterial).where(
+                GradingMaterial.simulation_id == simulation.id
+            )
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_idempotent_on_same_user_progress(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """Resubmitting for the same (user_progress, scene) updates in place."""
+    first = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": {"Analysis": 5, "Communication": 5},
+            "strictness": "balanced",
+        }
+    )
+    assert first["is_error"] is False
+
+    second = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": {"Analysis": 9, "Communication": 9},
+            "strictness": "strict",
+        }
+    )
+    assert second["is_error"] is False
+
+    scene_progress_rows = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress.id)
+        .where(SceneProgress.scene_id == scene.id)
+    ).scalars().all()
+    assert len(scene_progress_rows) == 1
+    latest = scene_progress_rows[0].progress_data["grading_result"]
+    assert latest["rubric_scores"] == {"Analysis": 9, "Communication": 9}
+    assert latest["strictness"] == "strict"
+
+    materials = db_session.execute(
+        select(GradingMaterial).where(
+            GradingMaterial.simulation_id == simulation.id
+        )
+    ).scalars().all()
+    assert len(materials) == 1
+    assert json.loads(materials[0].content)["strictness"] == "strict"
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_missing_user_progress_returns_error(
+    db_session: Session, patched_session_factory
+) -> None:
+    """An unknown ``user_progress_id`` produces an error envelope, not an exception."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": 999_999,
+            "scene_id": 1,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    assert "999999" in result["content"][0]["text"]
+    assert (
+        db_session.execute(select(GradingMaterial)).scalar_one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_simulation_without_rubric_returns_error(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A simulation whose ``grading_config`` has no criteria is rejected."""
+    simulation.grading_config = {"title": "Empty", "criteria": []}
+    db_session.flush()
+
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": {"Analysis": 8},
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    assert f"Simulation {simulation.id}" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_missing_required_field_returns_error(
+    patched_session_factory,
+) -> None:
+    """Dropping a required arg falls through to the generic error envelope."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": 1,
+            "scene_id": 1,
+            "rubric_scores": _valid_scores(),
+            # no strictness
+        }
+    )
+
+    assert result == {
+        "content": [{"type": "text", "text": "Failed to submit grade"}],
+        "is_error": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_non_dict_rubric_scores_returns_error(
+    patched_session_factory,
+) -> None:
+    """A list / string in ``rubric_scores`` is rejected before touching the DB."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": 1,
+            "scene_id": 1,
+            "rubric_scores": ["not", "a", "dict"],
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    assert "dict" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strictness", ["lenient", "balanced", "strict"])
+async def test_submit_grade_accepts_various_strictness_values(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+    strictness: str,
+) -> None:
+    """Every declared strictness value round-trips into the stored payload."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": _valid_scores(),
+            "strictness": strictness,
+        }
+    )
+    assert result["is_error"] is False
+    assert result["structuredContent"]["strictness"] == strictness
+
+    row = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress.id)
+        .where(SceneProgress.scene_id == scene.id)
+    ).scalar_one()
+    assert row.progress_data["grading_result"]["strictness"] == strictness
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_updates_existing_scene_progress(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """Pre-existing ``progress_data`` keys survive; only ``grading_result`` changes."""
+    existing = SceneProgress(
+        user_progress_id=user_progress.id,
+        scene_id=scene.id,
+        progress_data={"turn_count": 7, "some_other_key": "preserved"},
+    )
+    db_session.add(existing)
+    db_session.flush()
+
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is False
+    row = db_session.execute(
+        select(SceneProgress).where(SceneProgress.id == existing.id)
+    ).scalar_one()
+    assert row.progress_data["turn_count"] == 7
+    assert row.progress_data["some_other_key"] == "preserved"
+    assert row.progress_data["grading_result"]["rubric_scores"] == _valid_scores()
+
+
+def test_extract_rubric_keys_handles_malformed_configs() -> None:
+    """Non-dict configs, non-list criteria, and structurally broken criteria all yield ``[]``."""
+    assert grading_tools._extract_rubric_keys(None) == []
+    assert grading_tools._extract_rubric_keys("not a dict") == []  # type: ignore[arg-type]
+    assert grading_tools._extract_rubric_keys({}) == []
+    assert grading_tools._extract_rubric_keys({"criteria": "not-a-list"}) == []
+    # Items without any known key field are skipped, not errored on.
+    assert grading_tools._extract_rubric_keys(
+        {"criteria": [{"foo": "bar"}, {"description": "   "}, {"description": "ok"}]}
+    ) == ["ok"]
+    # Non-dict entries inside the criteria list are skipped without error.
+    assert grading_tools._extract_rubric_keys(
+        {"criteria": ["just a string", 42, None, {"description": "kept"}]}
+    ) == ["kept"]
+    # Prefers ``description`` when multiple fields are present.
+    assert grading_tools._extract_rubric_keys(
+        {"criteria": [{"description": "A", "name": "B", "criterion_name": "C"}]}
+    ) == ["A"]
+    # Falls back to ``name`` and then ``criterion_name``.
+    assert grading_tools._extract_rubric_keys(
+        {"criteria": [{"name": "just-name"}, {"criterion_name": "just-cn"}]}
+    ) == ["just-name", "just-cn"]
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_database_error_returns_error_envelope() -> None:
+    """An unexpected DB exception collapses to a generic error envelope.
+
+    We patch the session factory so ``_submit_grade_sync`` gets a session
+    whose ``get`` explodes. The tool must catch, log, rollback, and return
+    the generic error envelope — not propagate the exception to the MCP
+    runtime.
+    """
+    class _ExplodingSession:
+        def get(self, *_a, **_kw):
+            raise RuntimeError("synthetic db failure")
+
+        def execute(self, *_a, **_kw):
+            raise RuntimeError("synthetic db failure")
+
+        def rollback(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    with patch.object(grading_tools, "SessionLocal", lambda: _ExplodingSession()):
+        result = await submit_grade.handler(
+            {
+                "user_progress_id": 1,
+                "scene_id": 1,
+                "rubric_scores": _valid_scores(),
+                "strictness": "balanced",
+            }
+        )
+
+    assert result == {
+        "content": [{"type": "text", "text": "Failed to submit grade"}],
+        "is_error": True,
+    }

--- a/backend_v2/tests/modules/simulation/mcp/test_grading_tools_submit.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_grading_tools_submit.py
@@ -389,6 +389,142 @@ async def test_submit_grade_non_dict_rubric_scores_returns_error(
 
 
 @pytest.mark.asyncio
+async def test_submit_grade_rejects_non_dict_args(
+    patched_session_factory,
+) -> None:
+    """A non-mapping ``args`` collapses to the generic error envelope."""
+    result = await submit_grade.handler(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    assert result == {
+        "content": [{"type": "text", "text": "Failed to submit grade"}],
+        "is_error": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_missing_field_does_not_log_full_args(
+    patched_session_factory, caplog: pytest.LogCaptureFixture
+) -> None:
+    """On missing required fields we log only field names, not the payload.
+
+    This guards the finding that logger.exception previously echoed the
+    entire request — including per-criterion grade data and identifiers
+    — into structured logs.
+    """
+    import logging
+
+    sensitive_score = 0xBADC0FFEE
+    with caplog.at_level(logging.WARNING, logger="modules.simulation.mcp.grading_tools"):
+        result = await submit_grade.handler(
+            {
+                "user_progress_id": 42,
+                "scene_id": 7,
+                "rubric_scores": {"Analysis": sensitive_score},
+                # strictness intentionally omitted
+            }
+        )
+
+    assert result["is_error"] is True
+    combined = " ".join(record.getMessage() for record in caplog.records)
+    assert "strictness" in combined
+    assert str(sensitive_score) not in combined
+    assert "'rubric_scores'" not in combined
+    assert "Analysis" not in combined
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_unknown_scene_returns_error(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A ``scene_id`` that doesn't map to any scene surfaces as is_error."""
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": 999_999,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    assert "999999" in result["content"][0]["text"]
+    assert (
+        db_session.execute(select(GradingMaterial)).scalar_one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_grade_rejects_scene_from_other_simulation(
+    db_session: Session,
+    patched_session_factory,
+    simulation: Simulation,
+    user_progress: UserProgress,
+) -> None:
+    """A scene belonging to a different simulation is rejected without writes.
+
+    Guards against a caller passing a scene_id from an unrelated simulation
+    and silently corrupting the wrong simulation's scene_progress.
+    """
+    other_prof = User(
+        user_id="prof-other",
+        email="other@example.com",
+        full_name="Other Professor",
+        username="prof-other",
+        role="professor",
+    )
+    db_session.add(other_prof)
+    db_session.flush()
+    other_sim = Simulation(
+        unique_id="sim-other",
+        title="Other Sim",
+        description="Different simulation",
+        created_by=other_prof.id,
+        grading_config={
+            "title": "Rubric",
+            "criteria": [{"description": "Analysis"}],
+            "performance_levels": [],
+            "strictness_level": 3,
+        },
+    )
+    db_session.add(other_sim)
+    db_session.flush()
+    foreign_scene = SimulationScene(
+        simulation_id=other_sim.id,
+        title="Foreign",
+        description="",
+        scene_order=1,
+    )
+    db_session.add(foreign_scene)
+    db_session.flush()
+
+    result = await submit_grade.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": foreign_scene.id,
+            "rubric_scores": _valid_scores(),
+            "strictness": "balanced",
+        }
+    )
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert str(foreign_scene.id) in text
+    assert str(simulation.id) in text
+    # No scene_progress written for the foreign scene.
+    assert (
+        db_session.execute(
+            select(SceneProgress).where(SceneProgress.scene_id == foreign_scene.id)
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("strictness", ["lenient", "balanced", "strict"])
 async def test_submit_grade_accepts_various_strictness_values(
     db_session: Session,


### PR DESCRIPTION
Fixes #437

Implements ticket phase-2.3 — appends an `@tool`-decorated `submit_grade` to `backend_v2/modules/simulation/mcp/grading_tools.py` so the grading agent (phase-2.7) can persist a per-criterion grade via MCP.

## Summary
- `backend_v2/modules/simulation/mcp/grading_tools.py` — appends `submit_grade(args)` and its sync worker `_submit_grade_sync`.
  - Same MCP envelope as phase-2.2's `lookup_rubric` (`content` blocks + `is_error`, plus `structuredContent` on success carrying the stored payload).
  - Validates `rubric_scores` keys against `Simulation.grading_config["criteria"]` using the first non-empty of `description` / `name` / `criterion_name` per criterion. Unknown keys → `is_error=True` with the bad keys named, **no DB writes**.
  - Writes the payload into `scene_progress.progress_data["grading_result"]`, merging with existing `progress_data` keys so scene-turn bookkeeping is preserved. Creates the `scene_progress` row if it doesn't yet exist.
  - Inserts one `grading_materials` row per `(user_progress_id, scene_id)`, keyed on filename `grade_{user_progress_id}_{scene_id}.json` with `processing_status="completed"`. Resubmitting updates the row in place — exactly one row regardless of call count.
  - Sync worker runs via `asyncio.to_thread` so the MCP server never stalls on the write. Any unexpected DB error is caught, rolled back, logged, and surfaces as the generic `Failed to submit grade` error envelope — the tool never raises to the MCP runtime.
  - Missing required args or non-dict `rubric_scores` short-circuit to error envelopes without opening a session.
- `backend_v2/tests/modules/simulation/mcp/test_grading_tools_submit.py` — 14 tests covering the four ticket-required cases plus edge / coverage-boosting cases (missing user_progress_id, simulation without rubric, missing strictness, non-dict scores, strictness round-trip for lenient/balanced/strict, existing progress_data merging, malformed grading_config, synthetic DB exception).

Strict scope discipline: only the two files listed in the ticket's `files` allowlist are touched. No `__init__.py` re-export (that's phase-2.7's job per the ticket). No new dependencies.

## Test plan
- [x] `cd backend_v2 && uv run pytest tests/modules/simulation/mcp/test_grading_tools_submit.py tests/modules/simulation/mcp/test_grading_tools_lookup.py -q --cov=modules.simulation.mcp.grading_tools --cov-fail-under=85` → **28 passed, coverage 96.23%** (≥ 85 gate).
- [x] `cd backend_v2 && uv run pytest tests/modules/simulation/mcp/ -q` → **42 passed** (phase-2.1 + 2.2 suites unaffected).
- [x] Local `coderabbit review --prompt-only -t uncommitted` → **No findings**.
- [ ] CodeRabbit PR review passes (or all comments addressed / replied).
- [ ] CI green on `ralph-looped`.
- [ ] Railway experimental deploy green post-merge (verify via `railway logs --environment experimental -s Backend --lines 30`).

### Note on the ticket's verbatim verification command
The ticket's merge gate is:

```
cd backend_v2 && uv run pytest tests/modules/simulation/mcp/test_grading_tools_submit.py -q --cov=modules/simulation/mcp/grading_tools --cov-fail-under=85
```

Two structural issues, same as phase-2.02's PR #476 called out:

1. `coverage.py` 7.x rejects the slash form `--cov=modules/simulation/mcp/grading_tools` (module-not-imported warning, 0% collected). The dotted form `--cov=modules.simulation.mcp.grading_tools` is the one phase-2.01 / phase-2.02 adopted.
2. `grading_tools.py` now contains BOTH `lookup_rubric` (phase-2.02) and `submit_grade` (this ticket). Running only `test_grading_tools_submit.py` excludes the lookup_rubric body from coverage (~70 lines), capping measured coverage at 69%. The right command is to run both `_submit.py` and `_lookup.py` together — which yields **96.23%** on the file.

`submit_grade`'s own branches are covered by the 14 tests in this PR (every happy-path branch, every early-return validation branch, the DB-exception rollback branch).

## Non-goals
- No grading prompt (phase-4.1).
- No notification dispatch (future phase).
- No MCP server wiring / `__init__.py` re-export (phase-2.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a grade submission tool that validates rubric scores against simulation criteria and persists grading results.
  * Submissions return structured success data including the saved grading payload.

* **Bug Fixes**
  * Rejects submissions containing unknown rubric keys and avoids any database writes on invalid input.
  * Repeated submissions for the same scene update existing records idempotently.

* **Tests**
  * Comprehensive tests cover success, validation failures, idempotency, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->