### PR TITLE
fix(e2e-skill): wait for images + correct invite endpoint

### DIFF
--- a/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
+++ b/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
@@ -117,6 +117,35 @@ def post(s: requests.Session, path: str, **kw) -> requests.Response:
 def get(s: requests.Session, path: str, **kw) -> requests.Response:
     return s.get(f"{BASE_URL}{path}", timeout=30, **kw)
 
+def wait_for_images_ready(
+    s: requests.Session, sim_id: int, *, timeout_s: int = 300, interval_s: int = 5
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    # /upload-status returns total=0 when Redis keys haven't been populated yet
+    # (worker hasn't enqueued), so we need a short grace period before trusting it.
+    grace_deadline = time.monotonic() + 15
+    while True:
+        r = get(s, f"/api/publishing/simulations/{sim_id}/upload-status")
+        if r.status_code != 200:
+            die(f"upload-status fetch failed for sim_id={sim_id}", r)
+        body = r.json()
+        total     = body.get("total", 0)
+        pending   = body.get("pending", 0)
+        completed = body.get("completed", 0)
+        if total > 0 and pending == 0:
+            ok(f"images ready ({completed}/{total})")
+            return
+        if total == 0 and time.monotonic() >= grace_deadline:
+            info("upload-status reports total=0 after grace period; proceeding")
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"timeout after {timeout_s}s waiting for images on sim_id={sim_id} "
+                f"(total={total} pending={pending} completed={completed})"
+            )
+        info(f"waiting on {pending}/{total} image(s)")
+        time.sleep(interval_s)
+
 # ---------------------------------------------------------------------------
 # Flow 1 — Professor
 # ---------------------------------------------------------------------------
@@ -198,6 +227,7 @@ def run_flow_1() -> dict:
 
     # --- 4. publish
     step("FLOW-1", 4, f"publish simulation_id={simulation_id}")
+    wait_for_images_ready(s, simulation_id)
     r = post(s, f"/api/publishing/simulations/publish/{simulation_id}", json={})
     if r.status_code not in (200, 201):
         die("publish failed", r)
@@ -272,11 +302,12 @@ def run_flow_2(ctx: dict) -> None:
 
     # --- 3. accept invite
     step("FLOW-2", 3, "accept cohort invite")
-    r = post(s, f"/student/invitations/{ctx['invite_token']}/respond",
-             json={"action": "accept"})
+    r = post(s, f"/invites/{ctx['invite_token']}/accept")
     if r.status_code not in (200, 201):
         die("accept invite failed", r)
-    ok("joined cohort")
+    accept_body = r.json()
+    ok(f"joined cohort (cohort_id={accept_body.get('cohort_id')} "
+       f"already_enrolled={accept_body.get('already_enrolled')})")
 
     # --- 4. start simulation
     step("FLOW-2", 4, f"start simulation (id={ctx['simulation_id']})")


### PR DESCRIPTION
## Summary
- **Bug 1 (primary, blocked every run):** Flow-1 step 4 always failed with \`"Cannot publish simulation: N images still uploading"\` because \`run-e2e.py\` called \`/publish\` immediately after \`/parse-pdf\` with no wait. Added \`wait_for_images_ready()\` that polls \`GET /api/publishing/simulations/{id}/upload-status\` every 5s (300s timeout, 15s grace for the \`total=0 pending=0\` false-positive from [tasks.py:127-128](https://github.com/Hendrik040/n-aible_edtech_sims/blob/ralph-looped/backend/modules/publishing/tasks.py#L127-L128)).
- **Bug 2 (secondary, masked by #1):** Flow-2 step 3 posted link-tokens to \`POST /student/invitations/{invite_token}/respond\`, which expects an integer \`invitation_id\` from the email-driven \`CohortInvitation\` table — not a link-invite token. Swapped to \`POST /invites/{token}/accept\` ([invites.py:120](https://github.com/Hendrik040/n-aible_edtech_sims/blob/ralph-looped/backend/app/routers/invites.py#L120)), which is the correct route for token invites and uses the existing student auth cookie.

Diagnosis from today's run log \`scripts/rewrite/logs/tests_phase-2.03_iter1.log\` and yesterday's \`tests_phase-2.00_iter8.log\`.

## Test plan
- [ ] Run the e2e skill against the experimental backend once images queue is known to be slow (>15s) — confirm \`waiting on N/M images\` progress log + publish succeeds
- [ ] Run with a simulation that has 0 scene images — confirm the 15s grace falls through and publish still works
- [ ] Confirm student invite acceptance via link token succeeds end-to-end (was previously unreachable due to Bug 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing simulations now waits for image uploads to complete before proceeding.
  * Updated invite acceptance process to use the current API endpoint.

* **Improvements**
  * Enhanced acceptance confirmation messaging to include cohort ID and enrollment status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->