### PR TITLE
feat(admin): clickable ticket-id + PR columns in Ralph Pipeline dashboard

### DIFF
--- a/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
+++ b/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
@@ -1,6 +1,6 @@
 """Add issue_number to ralph_pipeline_events
 
-Revision ID: add_issue_number_to_ralph_pipeline_events
+Revision ID: add_issue_num_to_ralph_events
 Revises: add_ralph_pipeline_events
 Create Date: 2026-04-14 10:00:00.000000
 
@@ -16,7 +16,8 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic.
-revision: str = "add_issue_number_to_ralph_pipeline_events"
+# Keep ≤32 chars — alembic_version.version_num is VARCHAR(32).
+revision: str = "add_issue_num_to_ralph_events"
 down_revision: Union[str, None] = "add_ralph_pipeline_events"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
+++ b/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
@@ -1,0 +1,47 @@
+"""Add issue_number to ralph_pipeline_events
+
+Revision ID: add_issue_number_to_ralph_pipeline_events
+Revises: add_ralph_pipeline_events
+Create Date: 2026-04-14 10:00:00.000000
+
+Adds a nullable ``issue_number`` column to ``ralph_pipeline_events`` so
+the admin dashboard can link each ticket row back to its GitHub plan
+issue. No backfill — rows predating this column render as plain text
+in the grid.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision: str = "add_issue_number_to_ralph_pipeline_events"
+down_revision: Union[str, None] = "add_ralph_pipeline_events"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == "postgresql":
+        existing = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'ralph_pipeline_events' "
+                "AND column_name = 'issue_number'"
+            )
+        ).fetchone()
+        if existing:
+            return
+
+    op.add_column(
+        "ralph_pipeline_events",
+        sa.Column("issue_number", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ralph_pipeline_events", "issue_number")

--- a/backend/common/db/models/admin/ralph_pipeline_event.py
+++ b/backend/common/db/models/admin/ralph_pipeline_event.py
@@ -30,6 +30,7 @@ class RalphPipelineEvent(Base):
     iteration: Mapped[int] = mapped_column(Integer, nullable=False)
     loop_run_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     pr_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     # What happened
     phase: Mapped[str] = mapped_column(String(32), nullable=False)

--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -68,6 +68,7 @@ class EventIn(BaseModel):
     iteration: int = Field(..., ge=1)
     loop_run_id: str = Field(..., min_length=1, max_length=64)
     pr_number: Optional[int] = None
+    issue_number: Optional[int] = None
     phase: str
     status: str
     detail: Optional[str] = None
@@ -85,6 +86,7 @@ class PhaseState(BaseModel):
 class TicketRow(BaseModel):
     ticket_id: str
     pr_number: Optional[int]
+    issue_number: Optional[int]
     state: str  # pending | running | merged | failed | blocked
     phases: Dict[str, Optional[PhaseState]]
     started_at: Optional[str]
@@ -135,6 +137,7 @@ async def ingest_event(
         iteration=event.iteration,
         loop_run_id=event.loop_run_id,
         pr_number=event.pr_number,
+        issue_number=event.issue_number,
         phase=event.phase,
         status=event.status,
         detail=event.detail,
@@ -158,6 +161,7 @@ async def ingest_event(
             "detail": row.detail,
             "duration_sec": row.duration_sec,
             "pr_number": row.pr_number,
+            "issue_number": row.issue_number,
             "created_at": row.created_at.isoformat(),
         }
     )
@@ -189,6 +193,7 @@ def list_tickets(
             e.ticket_id,
             {
                 "pr_number": None,
+                "issue_number": None,
                 "phases": {p: None for p in PHASES},
                 "started_at": e.created_at,
                 "completed_at": None,
@@ -198,6 +203,8 @@ def list_tickets(
         t["events"].append(e)
         if e.pr_number and not t["pr_number"]:
             t["pr_number"] = e.pr_number
+        if e.issue_number and not t["issue_number"]:
+            t["issue_number"] = e.issue_number
 
         # Collapse "started" + later terminal to show the terminal state
         # when present. If only "started" exists, show "running".
@@ -217,6 +224,7 @@ def list_tickets(
             TicketRow(
                 ticket_id=ticket_id,
                 pr_number=t["pr_number"],
+                issue_number=t["issue_number"],
                 state=_infer_state(t["phases"]),
                 phases=t["phases"],
                 started_at=t["started_at"].isoformat() if t["started_at"] else None,
@@ -269,6 +277,7 @@ def get_ticket_history(
                 "duration_sec": e.duration_sec,
                 "context": e.context,
                 "pr_number": e.pr_number,
+                "issue_number": e.issue_number,
                 "created_at": e.created_at.isoformat(),
             }
             for e in events

--- a/frontend/components/admin/RalphPipelineGrid.tsx
+++ b/frontend/components/admin/RalphPipelineGrid.tsx
@@ -35,6 +35,7 @@ interface PhaseState {
 interface TicketRow {
   ticket_id: string
   pr_number: number | null
+  issue_number: number | null
   state: "pending" | "running" | "merged" | "failed" | "blocked"
   phases: Record<string, PhaseState | null>
   started_at: string | null
@@ -84,6 +85,7 @@ interface StreamEvent {
 // ---------------------------------------------------------------------------
 // Constants — phase order + palette
 // ---------------------------------------------------------------------------
+const GH_REPO_URL = "https://github.com/Hendrik040/n-aible_edtech_sims"
 const PHASES = ["A-implement", "B-review", "C-testing", "D-merge", "E-canny"] as const
 const PHASE_SHORT: Record<string, string> = {
   "A-implement": "A",
@@ -361,7 +363,21 @@ export default function RalphPipelineGrid({ refreshKey = 0 }: RalphPipelineGridP
               {sortedTickets.map((t) => (
                 <div key={t.ticket_id} className="flex items-center gap-0 whitespace-pre">
                   <span className="text-stone-300">{"  "}</span>
-                  <span className="text-amber-100 w-[10ch] inline-block">{t.ticket_id}</span>
+                  <span className="w-[10ch] inline-block">
+                    {t.issue_number ? (
+                      <a
+                        href={`${GH_REPO_URL}/issues/${t.issue_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`GitHub issue #${t.issue_number} — plan for ${t.ticket_id}`}
+                        className="text-amber-100 hover:text-amber-300 hover:underline focus:outline-none focus:ring-1 focus:ring-amber-400 rounded-sm"
+                      >
+                        {t.ticket_id}
+                      </a>
+                    ) : (
+                      <span className="text-amber-100">{t.ticket_id}</span>
+                    )}
+                  </span>
                   {PHASES.map((p) => {
                     const phase = t.phases?.[p]
                     const label = phase
@@ -393,8 +409,20 @@ export default function RalphPipelineGrid({ refreshKey = 0 }: RalphPipelineGridP
                       </button>
                     )
                   })}
-                  <span className="text-stone-500 w-[8ch] inline-block text-right">
-                    {t.pr_number ? `#${t.pr_number}` : "—"}
+                  <span className="w-[8ch] inline-block text-right">
+                    {t.pr_number ? (
+                      <a
+                        href={`${GH_REPO_URL}/pull/${t.pr_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`GitHub PR #${t.pr_number}`}
+                        className="text-stone-400 hover:text-amber-200 hover:underline focus:outline-none focus:ring-1 focus:ring-amber-400 rounded-sm"
+                      >
+                        {`#${t.pr_number}`}
+                      </a>
+                    ) : (
+                      <span className="text-stone-500">—</span>
+                    )}
                   </span>
                   <span className="text-stone-500 mx-2">·</span>
                   <span className={`${stateColor(t.state)} w-[10ch] inline-block`}>

--- a/scripts/rewrite/backfill-events.py
+++ b/scripts/rewrite/backfill-events.py
@@ -106,6 +106,7 @@ class ParsedEvent:
     duration_sec: Optional[int] = None
     context: Optional[Dict[str, Any]] = None
     created_at: Optional[datetime] = None
+    issue_number: Optional[int] = None
 
     def to_payload(self) -> Dict[str, Any]:
         return {
@@ -113,6 +114,7 @@ class ParsedEvent:
             "iteration":    max(1, self.iteration),
             "loop_run_id":  self.loop_run_id,
             "pr_number":    self.pr_number,
+            "issue_number": self.issue_number,
             "phase":        self.phase,
             "status":       self.status,
             "detail":       self.detail,
@@ -134,6 +136,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
     current_ticket = "phase-0.0"
     current_iter = 0
     current_pr: Optional[int] = None
+    current_issue: Optional[int] = None
 
     for raw in path.read_text(errors="replace").splitlines():
         m = LINE_RE.match(raw)
@@ -157,6 +160,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
         if mp:
             # NOTE: the log prints ticket_id like "phase-0.01". Normalize to "phase-0.1".
             current_pr = None  # new ticket = new PR forthcoming
+            current_issue = int(mp.group(1))
             tid = mp.group(2)
             tid = re.sub(r"phase-(\d+)\.0(\d)", r"phase-\1.\2", tid)
             current_ticket = tid
@@ -185,6 +189,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
                 iteration=current_iter or 1,
                 loop_run_id=loop_run_id,
                 pr_number=current_pr,
+                issue_number=current_issue,
                 phase=phase,
                 status=status,
                 detail=detail,

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -31,7 +31,7 @@ emit_event() {
   payload=$(
     TICKET_ID="${TICKET_ID:-}" ITER="${ITER:-0}" \
     LOOP_RUN_ID="${LOOP_RUN_ID:-${TIMESTAMP:-unknown}}" \
-    PR_NUM="${PR_NUM:-}" \
+    PR_NUM="${PR_NUM:-}" ISSUE_NUM="${ISSUE_NUM:-}" \
     _P="$phase" _S="$status" _D="$detail" _DU="$duration" _C="$ctx" \
     python3 - <<'PY'
 import json, os
@@ -43,6 +43,7 @@ body = {
     "iteration":   max(1, _int(os.environ.get("ITER")) or 1),
     "loop_run_id": os.environ.get("LOOP_RUN_ID") or "unknown",
     "pr_number":   _int(os.environ.get("PR_NUM")),
+    "issue_number": _int(os.environ.get("ISSUE_NUM")),
     "phase":       os.environ["_P"],
     "status":      os.environ["_S"],
     "detail":      os.environ.get("_D") or None,


### PR DESCRIPTION
## Summary

Makes the **ticket-id** and **PR** columns in the Ralph Rewrite Pipeline admin dashboard clickable anchors that deep-link to the corresponding GitHub issue / PR in a new tab. Right now admins have to read the ticket row, copy the PR number, and paste it into the URL bar to get to the discussion — this removes that entire step for both the plan issue (the ticket-id column) and the merged/open PR (the PR column).

## Files changed

- `backend/common/db/models/admin/ralph_pipeline_event.py` — add nullable `issue_number: Mapped[Optional[int]]` column.
- `backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py` — Alembic migration adding `issue_number INTEGER NULL` (no backfill; idempotent if the column already exists on Postgres).
- `backend/modules/admin/ralph_pipeline_router.py` — `EventIn` + `TicketRow` schemas gain `issue_number`; `/event` persists + rebroadcasts it; `/tickets` aggregates first-non-null per ticket; `/tickets/{id}` returns it per event.
- `scripts/rewrite/resources/lib.sh` — `emit_event()` reads `ISSUE_NUM` from env (already exported at every call site in `ralph-rewrite-loop.sh`) and includes it in the POST payload.
- `scripts/rewrite/backfill-events.py` — parser captures the issue number from the `picked: #N phase-x.y` log line and threads it through every `ParsedEvent` for the ticket.
- `frontend/components/admin/RalphPipelineGrid.tsx` — `TicketRow` TS type gains `issue_number: number | null`; ticket-id cell renders `<a href="…/issues/<n>">` when set, PR cell renders `<a href="…/pull/<n>">`. Both anchors use `target="_blank" rel="noopener noreferrer"`, keyboard-focus ring, and the existing mono/amber palette. Fixed-width inline-block wrappers (`w-[10ch]` / `w-[8ch] text-right`) preserved so grid alignment doesn't shift. Null cases fall back to plain text.

## Migration note

Adds `issue_number` as a **nullable `INTEGER`** column to `ralph_pipeline_events`. **No backfill is required** — existing rows keep `issue_number = NULL` and render as plain text in the grid (unchanged from today). New events from the loop + the backfill script will populate it. Migration is idempotent (skips if the column already exists on Postgres).

Apply with `alembic upgrade head` in the backend dir — no downtime, purely additive.

## Test plan

- [ ] `alembic upgrade head` applies cleanly on Railway experimental; `\d+ ralph_pipeline_events` shows the new column.
- [ ] POST `/api/admin/ralph-pipeline/event` with `issue_number: 457` → row persisted; `/tickets` returns it in the aggregated row; SSE `/stream` includes it in the phase payload.
- [ ] POST an event without `issue_number` → still 202s; row gets NULL (backwards-compatible with the loop before this merges).
- [ ] Dashboard: ticket-id in the grid is underlined-on-hover amber link; clicking opens `…/issues/<n>` in a new tab. PR column `#N` is a link to `…/pull/<n>`. Tickets without an issue/PR show plain text / `—`.
- [ ] Keyboard: Tab through the grid — both anchors receive a visible amber focus ring; Enter activates.
- [ ] Loop run (dry-ish): trigger one iteration, confirm `issue_number` present in the ingested event via `/tickets` JSON.
- [ ] `scripts/rewrite/backfill-events.py --dry-run` — spot-check parsed events print non-null `issue_number` for tickets with a `picked: #N` line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue number tracking across the Ralph Pipeline admin UI and API.
  * Issue numbers shown in ticket rows and event history; ticket IDs link to GitHub when present.
  * API ingest and read endpoints accept and return issue numbers.
  * Backfill/log parsing and event emission now propagate issue numbers.

* **Chores**
  * Database schema updated to store nullable issue numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->