### PR TITLE
fix(e2e-skill): kill silent fallbacks in Flow-1 draft resolution

### DIFF
--- a/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
+++ b/.claude/skills/e2e-simulation-flow/scripts/run-e2e.py
@@ -193,35 +193,22 @@ def run_flow_1() -> dict:
     simulation_id = parse_result.get("simulation_id") or parse_result.get("id")
     if not simulation_id:
         ai_result = parse_result.get("ai_result") or {}
-        if ai_result:
-            save_payload = {
-                "title": ai_result.get("title", f"E2E simulation {int(time.time())}"),
-                "description": ai_result.get("description", ""),
-                "personas": ai_result.get("personas", []),
-                "scenes": ai_result.get("scenes", []),
-                "learning_objectives": ai_result.get("learning_objectives", []),
-            }
-            sr = post(s, "/api/publishing/simulations/save", json=save_payload)
-            if sr.status_code in (200, 201):
-                simulation_id = sr.json().get("id") or sr.json().get("simulation_id")
-                if simulation_id:
-                    info(f"parse-pdf returned ai_result only; created draft via /save → id={simulation_id}")
-    if not simulation_id:
-        rr = get(s, "/api/publishing/simulations/drafts/")
-        if rr.status_code == 200 and rr.json():
-            simulation_id = rr.json()[0].get("id")
-            info(f"using existing draft simulation_id={simulation_id} (parse+save did not yield a new id)")
-    if not simulation_id:
-        # Final fallback: list any active simulation owned by anyone in the
-        # experimental DB. Tag the run as PARTIAL — the loop's Phase C still
-        # accepts ALL_TESTS_PASSED so we don't block the rewrite track on a
-        # known skill/endpoint mismatch.
-        rr = get(s, "/api/publishing/simulations/?status=active")
-        if rr.status_code == 200 and rr.json():
-            simulation_id = rr.json()[0].get("id")
-            info(f"PARTIAL — no draft created; reusing existing active sim id={simulation_id}")
-    if not simulation_id:
-        die("could not resolve any simulation_id (parse-pdf + save + drafts list + active list all empty)", r)
+        if not ai_result:
+            die("parse-pdf returned no simulation_id and no ai_result — cannot build a draft", r)
+        save_payload = {
+            "title": ai_result.get("title", f"E2E simulation {int(time.time())}"),
+            "description": ai_result.get("description", ""),
+            "personas": ai_result.get("personas", []),
+            "scenes": ai_result.get("scenes", []),
+            "learning_outcomes": ai_result.get("learning_outcomes", []),
+        }
+        sr = post(s, "/api/publishing/simulations/save", json=save_payload)
+        if sr.status_code not in (200, 201):
+            die("save draft failed — parse-pdf did not produce a usable draft", sr)
+        simulation_id = sr.json().get("simulation_id") or sr.json().get("id")
+        if not simulation_id:
+            die(f"/save returned {sr.status_code} but no simulation_id in body: {sr.text[:500]}")
+        info(f"created draft via /save → id={simulation_id}")
     ok(f"simulation_id={simulation_id}")
     db_verify("simulations.exists", "SELECT id FROM simulations WHERE id=%s", (simulation_id,))
 


### PR DESCRIPTION
## Summary
- **Bug 1 (dangerous silent fallbacks):** \`run-e2e.py\` had three cascading fallbacks if \`parse-pdf\` + \`/save\` didn't return a simulation_id: (1) pick the first draft from \`/drafts/\`, (2) pick the first **already-active** sim, (3) die. The active-sim fallback caused confusing cascading errors — the script would "succeed" at step 3 by reusing an already-published simulation from a prior run, then fail at step 4 \`/publish\` because that sim was already published. Every run also polluted experimental backend state. Removed both fallbacks; now if \`/save\` doesn't yield a fresh \`simulation_id\` we \`die()\` with the HTTP status + response body.
- **Bug 2 (silent data loss):** the save payload was sending \`learning_objectives\`, but the backend ([publishing/service.py:195](https://github.com/Hendrik040/n-aible_edtech_sims/blob/ralph-looped/backend/modules/publishing/service.py#L195) and [pdf_processing/pipeline.py:239](https://github.com/Hendrik040/n-aible_edtech_sims/blob/ralph-looped/backend/modules/pdf_processing/pipeline.py#L239)) uses the key \`learning_outcomes\`. Fixed on both the read (from \`ai_result\`) and the write (into \`save_payload\`).

Builds on #480.

## Test plan
- [ ] Run the e2e skill against a fresh experimental backend — confirm \`/save\` returns 200 with a fresh \`simulation_id\` and the run proceeds to step 4
- [ ] Run against a backend where \`/save\` is deliberately broken (e.g. malformed payload) — confirm it \`die()\`s immediately with a clear HTTP body, not a late failure at \`/publish\`
- [ ] Confirm the created draft actually persists \`learning_objectives\` (via DB check) — previously silently lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)