### PR TITLE
feat(rewrite): --from-github mode for backfill-events.py

### DIFF
--- a/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
+++ b/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
@@ -1,6 +1,6 @@
 """Add issue_number to ralph_pipeline_events
 
-Revision ID: add_issue_number_to_ralph_pipeline_events
+Revision ID: add_issue_num_to_ralph_events
 Revises: add_ralph_pipeline_events
 Create Date: 2026-04-14 10:00:00.000000
 
@@ -16,7 +16,8 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic.
-revision: str = "add_issue_number_to_ralph_pipeline_events"
+# Keep ≤32 chars — alembic_version.version_num is VARCHAR(32).
+revision: str = "add_issue_num_to_ralph_events"
 down_revision: Union[str, None] = "add_ralph_pipeline_events"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
+++ b/backend/common/db/migrations/versions/2026_04_14_1000-add_issue_number_to_ralph_pipeline_events.py
@@ -1,0 +1,47 @@
+"""Add issue_number to ralph_pipeline_events
+
+Revision ID: add_issue_number_to_ralph_pipeline_events
+Revises: add_ralph_pipeline_events
+Create Date: 2026-04-14 10:00:00.000000
+
+Adds a nullable ``issue_number`` column to ``ralph_pipeline_events`` so
+the admin dashboard can link each ticket row back to its GitHub plan
+issue. No backfill — rows predating this column render as plain text
+in the grid.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision: str = "add_issue_number_to_ralph_pipeline_events"
+down_revision: Union[str, None] = "add_ralph_pipeline_events"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == "postgresql":
+        existing = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'ralph_pipeline_events' "
+                "AND column_name = 'issue_number'"
+            )
+        ).fetchone()
+        if existing:
+            return
+
+    op.add_column(
+        "ralph_pipeline_events",
+        sa.Column("issue_number", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ralph_pipeline_events", "issue_number")

--- a/backend/common/db/models/admin/ralph_pipeline_event.py
+++ b/backend/common/db/models/admin/ralph_pipeline_event.py
@@ -30,6 +30,7 @@ class RalphPipelineEvent(Base):
     iteration: Mapped[int] = mapped_column(Integer, nullable=False)
     loop_run_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     pr_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     # What happened
     phase: Mapped[str] = mapped_column(String(32), nullable=False)

--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -68,6 +68,7 @@ class EventIn(BaseModel):
     iteration: int = Field(..., ge=1)
     loop_run_id: str = Field(..., min_length=1, max_length=64)
     pr_number: Optional[int] = None
+    issue_number: Optional[int] = None
     phase: str
     status: str
     detail: Optional[str] = None
@@ -85,6 +86,7 @@ class PhaseState(BaseModel):
 class TicketRow(BaseModel):
     ticket_id: str
     pr_number: Optional[int]
+    issue_number: Optional[int]
     state: str  # pending | running | merged | failed | blocked
     phases: Dict[str, Optional[PhaseState]]
     started_at: Optional[str]
@@ -135,6 +137,7 @@ async def ingest_event(
         iteration=event.iteration,
         loop_run_id=event.loop_run_id,
         pr_number=event.pr_number,
+        issue_number=event.issue_number,
         phase=event.phase,
         status=event.status,
         detail=event.detail,
@@ -158,6 +161,7 @@ async def ingest_event(
             "detail": row.detail,
             "duration_sec": row.duration_sec,
             "pr_number": row.pr_number,
+            "issue_number": row.issue_number,
             "created_at": row.created_at.isoformat(),
         }
     )
@@ -189,6 +193,7 @@ def list_tickets(
             e.ticket_id,
             {
                 "pr_number": None,
+                "issue_number": None,
                 "phases": {p: None for p in PHASES},
                 "started_at": e.created_at,
                 "completed_at": None,
@@ -198,6 +203,8 @@ def list_tickets(
         t["events"].append(e)
         if e.pr_number and not t["pr_number"]:
             t["pr_number"] = e.pr_number
+        if e.issue_number and not t["issue_number"]:
+            t["issue_number"] = e.issue_number
 
         # Collapse "started" + later terminal to show the terminal state
         # when present. If only "started" exists, show "running".
@@ -217,6 +224,7 @@ def list_tickets(
             TicketRow(
                 ticket_id=ticket_id,
                 pr_number=t["pr_number"],
+                issue_number=t["issue_number"],
                 state=_infer_state(t["phases"]),
                 phases=t["phases"],
                 started_at=t["started_at"].isoformat() if t["started_at"] else None,
@@ -269,6 +277,7 @@ def get_ticket_history(
                 "duration_sec": e.duration_sec,
                 "context": e.context,
                 "pr_number": e.pr_number,
+                "issue_number": e.issue_number,
                 "created_at": e.created_at.isoformat(),
             }
             for e in events

--- a/frontend/components/admin/RalphPipelineGrid.tsx
+++ b/frontend/components/admin/RalphPipelineGrid.tsx
@@ -35,6 +35,7 @@ interface PhaseState {
 interface TicketRow {
   ticket_id: string
   pr_number: number | null
+  issue_number: number | null
   state: "pending" | "running" | "merged" | "failed" | "blocked"
   phases: Record<string, PhaseState | null>
   started_at: string | null
@@ -84,6 +85,7 @@ interface StreamEvent {
 // ---------------------------------------------------------------------------
 // Constants — phase order + palette
 // ---------------------------------------------------------------------------
+const GH_REPO_URL = "https://github.com/Hendrik040/n-aible_edtech_sims"
 const PHASES = ["A-implement", "B-review", "C-testing", "D-merge", "E-canny"] as const
 const PHASE_SHORT: Record<string, string> = {
   "A-implement": "A",
@@ -361,7 +363,21 @@ export default function RalphPipelineGrid({ refreshKey = 0 }: RalphPipelineGridP
               {sortedTickets.map((t) => (
                 <div key={t.ticket_id} className="flex items-center gap-0 whitespace-pre">
                   <span className="text-stone-300">{"  "}</span>
-                  <span className="text-amber-100 w-[10ch] inline-block">{t.ticket_id}</span>
+                  <span className="w-[10ch] inline-block">
+                    {t.issue_number ? (
+                      <a
+                        href={`${GH_REPO_URL}/issues/${t.issue_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`GitHub issue #${t.issue_number} — plan for ${t.ticket_id}`}
+                        className="text-amber-100 hover:text-amber-300 hover:underline focus:outline-none focus:ring-1 focus:ring-amber-400 rounded-sm"
+                      >
+                        {t.ticket_id}
+                      </a>
+                    ) : (
+                      <span className="text-amber-100">{t.ticket_id}</span>
+                    )}
+                  </span>
                   {PHASES.map((p) => {
                     const phase = t.phases?.[p]
                     const label = phase
@@ -393,8 +409,20 @@ export default function RalphPipelineGrid({ refreshKey = 0 }: RalphPipelineGridP
                       </button>
                     )
                   })}
-                  <span className="text-stone-500 w-[8ch] inline-block text-right">
-                    {t.pr_number ? `#${t.pr_number}` : "—"}
+                  <span className="w-[8ch] inline-block text-right">
+                    {t.pr_number ? (
+                      <a
+                        href={`${GH_REPO_URL}/pull/${t.pr_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`GitHub PR #${t.pr_number}`}
+                        className="text-stone-400 hover:text-amber-200 hover:underline focus:outline-none focus:ring-1 focus:ring-amber-400 rounded-sm"
+                      >
+                        {`#${t.pr_number}`}
+                      </a>
+                    ) : (
+                      <span className="text-stone-500">—</span>
+                    )}
                   </span>
                   <span className="text-stone-500 mx-2">·</span>
                   <span className={`${stateColor(t.state)} w-[10ch] inline-block`}>

--- a/scripts/rewrite/backfill-events.py
+++ b/scripts/rewrite/backfill-events.py
@@ -106,6 +106,7 @@ class ParsedEvent:
     duration_sec: Optional[int] = None
     context: Optional[Dict[str, Any]] = None
     created_at: Optional[datetime] = None
+    issue_number: Optional[int] = None
 
     def to_payload(self) -> Dict[str, Any]:
         return {
@@ -113,6 +114,7 @@ class ParsedEvent:
             "iteration":    max(1, self.iteration),
             "loop_run_id":  self.loop_run_id,
             "pr_number":    self.pr_number,
+            "issue_number": self.issue_number,
             "phase":        self.phase,
             "status":       self.status,
             "detail":       self.detail,
@@ -134,6 +136,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
     current_ticket = "phase-0.0"
     current_iter = 0
     current_pr: Optional[int] = None
+    current_issue: Optional[int] = None
 
     for raw in path.read_text(errors="replace").splitlines():
         m = LINE_RE.match(raw)
@@ -157,6 +160,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
         if mp:
             # NOTE: the log prints ticket_id like "phase-0.01". Normalize to "phase-0.1".
             current_pr = None  # new ticket = new PR forthcoming
+            current_issue = int(mp.group(1))
             tid = mp.group(2)
             tid = re.sub(r"phase-(\d+)\.0(\d)", r"phase-\1.\2", tid)
             current_ticket = tid
@@ -185,6 +189,7 @@ def parse_log(path: Path) -> List[ParsedEvent]:
                 iteration=current_iter or 1,
                 loop_run_id=loop_run_id,
                 pr_number=current_pr,
+                issue_number=current_issue,
                 phase=phase,
                 status=status,
                 detail=detail,

--- a/scripts/rewrite/backfill-events.py
+++ b/scripts/rewrite/backfill-events.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
-"""Backfill Ralph-pipeline events from historical log files.
+"""Backfill Ralph-pipeline events from historical log files or GitHub.
 
 The loop didn't emit events before PR-B landed, but it left behind
 rich master logs at `scripts/rewrite/logs/rewrite_*.log`. This script
 parses those logs for phase-transition signatures and POSTs synthetic
 events to the admin dashboard's ingest endpoint so the grid has data
 from the very first run the dashboard sees.
+
+For tickets merged on GitHub before the telemetry (PR #469) landed —
+phases 0.01, 1.01-1.04, 2.01, 2.02 — the log-based backfill can't
+recover them because the pre-telemetry loop's "PR opened" log lines
+got corrupted (two log lines concatenated, destroying the digits) and
+the pre-#478 loop never emitted a "CI green — merging" line because
+it didn't auto-merge. Those tickets show as "running" forever in the
+dashboard because the dashboard's `_infer_state` short-circuits on
+any phase with `status == "started"`. Use `--from-github` to query
+the GitHub PR list directly and emit synthetic `A-implement passed` +
+`D-merge passed` events so the dashboard can display them as merged.
 
 Idempotent enough for overnight use: the dashboard's /event endpoint
 accepts duplicates — if you run this twice you'll see double rows for
@@ -18,10 +29,12 @@ Usage:
     export RALPH_EVENT_URL=https://backend-experimental-246c.up.railway.app
     export RALPH_EVENT_TOKEN=<bearer>
 
-    python3 scripts/rewrite/backfill-events.py                    # all logs
-    python3 scripts/rewrite/backfill-events.py --dry-run          # parse + print, no POST
-    python3 scripts/rewrite/backfill-events.py --since 2026-04-13 # one day
-    python3 scripts/rewrite/backfill-events.py --file <one.log>   # just that log
+    python3 scripts/rewrite/backfill-events.py                         # all logs
+    python3 scripts/rewrite/backfill-events.py --dry-run               # parse + print, no POST
+    python3 scripts/rewrite/backfill-events.py --since 2026-04-13      # one day
+    python3 scripts/rewrite/backfill-events.py --file <one.log>        # just that log
+    python3 scripts/rewrite/backfill-events.py --from-github           # from GitHub merged PRs
+    python3 scripts/rewrite/backfill-events.py --from-github --dry-run # preview only
 
 Exit 0 on success; 2 on config error.
 """
@@ -31,12 +44,13 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = REPO_ROOT / "scripts" / "rewrite" / "logs"
@@ -221,13 +235,200 @@ def post_event(payload: Dict[str, Any]) -> bool:
         return False
 
 
+# ── GitHub backfill ───────────────────────────────────────────────────────
+# Match a phase ref anywhere in a string:
+#   "phase-2.01", "phase-2.1", "ralph-looped-rewrite/phase-0.01-..." etc.
+# Captures the major + minor digits so we can normalize to `phase-N.0M`
+# (two-digit minor) to match the loop's ticket_id normalization in
+# scripts/rewrite/resources/lib.sh:87-94.
+_PHASE_REF_RE = re.compile(r"phase-(\d+)\.(\d+)")
+
+# Extract the issue number the PR closes. Any of Fixes/Closes/Resolves,
+# case-insensitive, possibly wrapped in markdown/whitespace. We take the
+# FIRST match on the theory that a PR body sometimes references unrelated
+# issues further down (`See also #NNN`) but closes exactly one.
+_CLOSES_ISSUE_RE = re.compile(
+    r"(?:fixes|closes|resolves)\s+#(\d+)", re.IGNORECASE
+)
+
+
+def _normalize_phase(major: str, minor: str) -> str:
+    """Return `phase-N.0M` with two-digit minor, matching the loop's
+    ticket-id normalization at scripts/rewrite/resources/lib.sh:87-94.
+    """
+    return f"phase-{int(major)}.{int(minor):02d}"
+
+
+def _resolve_ticket(pr: Dict[str, Any]) -> Tuple[Optional[str], Optional[int]]:
+    """Resolve (ticket_id, issue_number) for a merged PR.
+
+    Order of preference:
+      1. `Fixes/Closes/Resolves #N` in the PR body → issue number, then use
+         the PR body or headRefName or title to derive ticket_id.
+      2. `phase-X.Y` in `headRefName`.
+      3. `phase-X.Y` in the PR title.
+
+    Returns `(None, None)` if we can't resolve — the caller logs a WARN
+    and skips. We never invent data.
+    """
+    body = pr.get("body") or ""
+    title = pr.get("title") or ""
+    head = pr.get("headRefName") or ""
+
+    issue: Optional[int] = None
+    m = _CLOSES_ISSUE_RE.search(body)
+    if m:
+        issue = int(m.group(1))
+
+    # Prefer a phase ref in the head branch (most reliable — it's the
+    # ticket_id the loop picked), then title (also loop-controlled), then
+    # body (can contain cross-refs to other phases).
+    ticket: Optional[str] = None
+    for source in (head, title, body):
+        pm = _PHASE_REF_RE.search(source)
+        if pm:
+            ticket = _normalize_phase(pm.group(1), pm.group(2))
+            break
+
+    return ticket, issue
+
+
+def fetch_merged_prs(repo: str, base_branch: str, label: str = "rewrite-agent-sdk",
+                     limit: int = 200) -> List[Dict[str, Any]]:
+    """Query GitHub for PRs merged into `base_branch` that carry `label`.
+
+    Uses the `gh` CLI as a subprocess — no extra deps. Raises RuntimeError
+    if gh is missing, unauthenticated, or returns invalid JSON.
+    """
+    cmd = [
+        "gh", "pr", "list",
+        "--repo", repo,
+        "--base", base_branch,
+        "--state", "merged",
+        "--search", f"label:{label}",
+        "--json", "number,title,body,mergedAt,headRefName,author,createdAt",
+        "--limit", str(limit),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "`gh` CLI not found on PATH — install it from https://cli.github.com/"
+        ) from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`gh pr list` failed (exit {result.returncode}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"`gh pr list` returned invalid JSON: {exc}") from exc
+    if not isinstance(data, list):
+        raise RuntimeError(f"`gh pr list` returned unexpected type: {type(data).__name__}")
+    return data
+
+
+def events_from_github(repo: str, base_branch: str) -> List[Tuple[ParsedEvent, Dict[str, Any]]]:
+    """Build synthetic events from GitHub's merged-PR list.
+
+    For each merged PR with a resolvable ticket_id, emit two events:
+      1. `A-implement passed` — clears the dashboard's `any_running`
+         short-circuit (backend/modules/admin/ralph_pipeline_router.py:239)
+         that pins these tickets to "running" because the old loop left
+         them with only an `A-implement started` event.
+      2. `D-merge passed` — the signal `_infer_state` counts as "merged".
+
+    Returns a list of `(event, source_pr)` tuples so the caller can print
+    them (dry-run) or POST them (live). PRs we can't resolve are logged
+    to stderr and skipped.
+    """
+    prs = fetch_merged_prs(repo, base_branch)
+    print(f"  GitHub: {len(prs)} merged PRs on base={base_branch} "
+          f"with label=rewrite-agent-sdk", file=sys.stderr)
+
+    out: List[Tuple[ParsedEvent, Dict[str, Any]]] = []
+    for pr in prs:
+        ticket_id, issue_number = _resolve_ticket(pr)
+        if not ticket_id:
+            print(
+                f"  WARN: PR #{pr.get('number')} — couldn't resolve ticket_id "
+                f"from body/branch/title (head={pr.get('headRefName')!r}, "
+                f"title={pr.get('title')!r}); skipping.",
+                file=sys.stderr,
+            )
+            continue
+
+        pr_number = int(pr["number"])
+        merged_at_raw = pr.get("mergedAt") or ""
+        # `mergedAt` is ISO 8601 in UTC (e.g. "2026-04-14T18:02:36Z"). Parse
+        # defensively so we can still tag the loop_run_id even if the field
+        # is missing or malformed.
+        merged_at: Optional[datetime] = None
+        try:
+            merged_at = datetime.strptime(merged_at_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            pass
+        date_tag = merged_at.strftime("%Y%m%d") if merged_at else "unknown"
+        loop_run_id = f"github-backfill-{date_tag}"
+
+        common = dict(
+            ticket_id=ticket_id,
+            iteration=1,
+            loop_run_id=loop_run_id,
+            pr_number=pr_number,
+            issue_number=issue_number,
+            created_at=merged_at,
+        )
+        out.append((
+            ParsedEvent(
+                phase="A-implement",
+                status="passed",
+                detail="github-backfill: inferred from merged PR",
+                **common,
+            ),
+            pr,
+        ))
+        out.append((
+            ParsedEvent(
+                phase="D-merge",
+                status="passed",
+                detail="github-backfill: inferred from merged PR",
+                **common,
+            ),
+            pr,
+        ))
+    return out
+
+
 # ── main ──────────────────────────────────────────────────────────────────
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--dry-run", action="store_true", help="parse + print, no POST")
     ap.add_argument("--since", help="YYYY-MM-DD — only logs modified on/after this date")
     ap.add_argument("--file", help="single log file (overrides --since + auto-discovery)")
+    ap.add_argument(
+        "--from-github",
+        action="store_true",
+        help=(
+            "Skip log parsing; query GitHub for merged PRs and synthesize "
+            "A-implement passed + D-merge passed events (recovers pre-telemetry "
+            "merges like phases 0.01, 1.01-1.04, 2.01, 2.02)."
+        ),
+    )
+    ap.add_argument(
+        "--base-branch",
+        default="ralph-looped",
+        help="Base branch to filter merged PRs by (default: ralph-looped).",
+    )
     args = ap.parse_args()
+
+    # --from-github and --file are mutually exclusive: the GitHub mode is a
+    # full replacement for log parsing on that invocation.
+    if args.from_github and args.file:
+        ap.error("--from-github and --file are mutually exclusive")
 
     if not args.dry_run:
         if not RALPH_EVENT_URL or not RALPH_EVENT_TOKEN:
@@ -235,6 +436,41 @@ def main() -> int:
                   "(env vars or .env / backend/.env)", file=sys.stderr)
             return 2
 
+    # ── GitHub-backfill mode ──────────────────────────────────────────────
+    if args.from_github:
+        repo = "Hendrik040/n-aible_edtech_sims"
+        try:
+            pairs = events_from_github(repo, args.base_branch)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+        if not pairs:
+            print("No resolvable merged PRs found on "
+                  f"{repo}@{args.base_branch}.", file=sys.stderr)
+            return 0
+
+        total_posted = 0
+        for event, pr in pairs:
+            if args.dry_run:
+                print(
+                    f"  would POST  ticket={event.ticket_id}  "
+                    f"issue=#{event.issue_number}  pr=#{event.pr_number}  "
+                    f"phase={event.phase}  status={event.status}  "
+                    f"mergedAt={pr.get('mergedAt')}"
+                )
+                continue
+            if post_event(event.to_payload()):
+                total_posted += 1
+
+        n = len(pairs)
+        mode = "prepared (dry-run)" if args.dry_run else "posted"
+        print(f"\nDone. {n} events {mode}; "
+              f"{total_posted} POST succeeded"
+              + (" (run without --dry-run to ingest)" if args.dry_run else ""))
+        return 0
+
+    # ── default log-scan mode ─────────────────────────────────────────────
     # Gather input logs.
     if args.file:
         logs = [Path(args.file)]

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -31,7 +31,7 @@ emit_event() {
   payload=$(
     TICKET_ID="${TICKET_ID:-}" ITER="${ITER:-0}" \
     LOOP_RUN_ID="${LOOP_RUN_ID:-${TIMESTAMP:-unknown}}" \
-    PR_NUM="${PR_NUM:-}" \
+    PR_NUM="${PR_NUM:-}" ISSUE_NUM="${ISSUE_NUM:-}" \
     _P="$phase" _S="$status" _D="$detail" _DU="$duration" _C="$ctx" \
     python3 - <<'PY'
 import json, os
@@ -43,6 +43,7 @@ body = {
     "iteration":   max(1, _int(os.environ.get("ITER")) or 1),
     "loop_run_id": os.environ.get("LOOP_RUN_ID") or "unknown",
     "pr_number":   _int(os.environ.get("PR_NUM")),
+    "issue_number": _int(os.environ.get("ISSUE_NUM")),
     "phase":       os.environ["_P"],
     "status":      os.environ["_S"],
     "detail":      os.environ.get("_D") or None,


### PR DESCRIPTION
## Summary
- Adds `--from-github` mode to `scripts/rewrite/backfill-events.py` so the Ralph Pipeline dashboard can display tickets as **merged** for PRs that landed before PR #469 added loop-event telemetry.
- Adds `--base-branch` (default `ralph-looped`) so the flag is reusable for future Ralph tracks.
- Preserves all existing behavior: `--dry-run`, `--since`, `--file`, and the default log-scan path are untouched.

## Why

Phases 0.01, 1.01, 1.02, 1.03, 1.04, 2.01, 2.02 (and 2.03) merged on GitHub before the loop emitted events. The log-based backfill can't recover them because:

1. The old loop's `"PR opened: #..."` log line was corrupted (two log lines concatenated, destroying the PR digits, so the `PR opened: #?(\d+)` regex never matched) → `A-implement passed` never got emitted.
2. The pre-#478 loop didn't auto-merge, so no `"CI green — merging"` log line was ever written → `D-merge passed` never got emitted.

Result: those tickets live in the DB with only `A-implement started`, which triggers the `any_running` short-circuit at `backend/modules/admin/ralph_pipeline_router.py:239` and pins the dashboard row to `"running"` forever. Dashboard header says `"0/22 merged · all-time"` even though ~7 tickets are clearly merged on `ralph-looped`.

## How

`--from-github` shells out to `gh pr list` (subprocess, no new runtime deps — stays within stdlib + `gh` CLI) for merged PRs on `--base-branch` with label `rewrite-agent-sdk`:

```
gh pr list --repo Hendrik040/n-aible_edtech_sims \
    --base ralph-looped --state merged \
    --search "label:rewrite-agent-sdk" \
    --json number,title,body,mergedAt,headRefName,author,createdAt \
    --limit 200
```

For each PR it resolves `(ticket_id, issue_number)` using:
1. `Fixes/Closes/Resolves #N` in the PR body (case-insensitive).
2. `phase-X.Y` in `headRefName` (normalized to `phase-N.0M`, matching `scripts/rewrite/resources/lib.sh:87-94`).
3. `phase-X.Y` in the PR title (same normalization).

PRs that can't be resolved are logged to stderr and skipped — no invented data. Then synthesizes two events per resolved PR:
- `A-implement passed` — clears the dashboard's `any_running` short-circuit.
- `D-merge passed` — the signal `_infer_state` counts as `"merged"`.

Both events carry `iteration=1`, `loop_run_id=f"github-backfill-{mergedAt date YYYYMMDD}"`, `pr_number`, `issue_number`, and a `detail` tagging them as github-backfilled. The POST payload is built by the existing `ParsedEvent.to_payload()` — no new dataclass. I did **not** add `created_at` to the payload because the backend's `EventIn` schema doesn't accept it; the backend timestamps on receipt, which is fine for a one-shot backfill.

`--from-github` and `--file` are mutually exclusive (argparse error).

## Dependencies

**Depends on #481 — do not merge until #481 lands.** This PR builds on the `issue_number` field that #481 added to `ParsedEvent` / `to_payload()` / the DB model / the `EventIn` schema.

Branched from `feat/dashboard-clickable-ticket-and-pr-links` (PR #481's head), based on the latest commit `61bab55` that includes the migration-revision-id fix.

## Dry-run output (live, read-only `gh pr list` call)

```
  GitHub: 8 merged PRs on base=ralph-looped with label=rewrite-agent-sdk
  would POST  ticket=phase-2.03  issue=#437  pr=#479  phase=A-implement  status=passed  mergedAt=2026-04-14T18:02:36Z
  would POST  ticket=phase-2.03  issue=#437  pr=#479  phase=D-merge      status=passed  mergedAt=2026-04-14T18:02:36Z
  would POST  ticket=phase-2.02  issue=#436  pr=#476  phase=A-implement  status=passed  mergedAt=2026-04-14T04:47:03Z
  would POST  ticket=phase-2.02  issue=#436  pr=#476  phase=D-merge      status=passed  mergedAt=2026-04-14T04:47:03Z
  would POST  ticket=phase-2.01  issue=#435  pr=#468  phase=A-implement  status=passed  mergedAt=2026-04-14T00:58:48Z
  would POST  ticket=phase-2.01  issue=#435  pr=#468  phase=D-merge      status=passed  mergedAt=2026-04-14T00:58:48Z
  would POST  ticket=phase-1.04  issue=#434  pr=#464  phase=A-implement  status=passed  mergedAt=2026-04-13T23:40:19Z
  would POST  ticket=phase-1.04  issue=#434  pr=#464  phase=D-merge      status=passed  mergedAt=2026-04-13T23:40:19Z
  ... (and phase-1.03, phase-1.02, phase-1.01, phase-0.01 — all 8 PRs resolved)

Done. 16 events prepared (dry-run); 0 POST succeeded (run without --dry-run to ingest)
```

All 8 target PRs resolved successfully (phases 0.01, 1.01-1.04, 2.01, 2.02, 2.03) — no skipped PRs.

## Test plan
- [x] `python -m py_compile scripts/rewrite/backfill-events.py` passes.
- [x] `python scripts/rewrite/backfill-events.py --help` shows `--from-github` and `--base-branch`.
- [x] `python scripts/rewrite/backfill-events.py --from-github --dry-run` lists the 8 expected PRs end-to-end.
- [x] `python scripts/rewrite/backfill-events.py --from-github --file x.log` errors out (mutual exclusion).
- [x] Default log-scan mode still returns `No logs to backfill.` / works unchanged (no edits to `parse_log`, `PARSE_MARKERS`, `LINE_RE`).
- [ ] After #481 merges: run `--from-github` against the experimental backend and confirm dashboard flips ~7 tickets from `running` to `merged`. (User will run this; this PR does NOT execute against the live backend.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub issue linking in the admin ticket grid, displaying clickable issue numbers when available
  * Enhanced PR column to render pull request links with proper formatting
  * Introduced support for tracking issue numbers in pipeline events
  * Added GitHub-based event backfill mode for easier data population

<!-- end of auto-generated comment: release notes by coderabbit.ai -->