### PR TITLE
feat(skills): railway-deploy-check auth-recovery reference

### DIFF
--- a/.claude/skills/railway-deploy-check/SKILL.md
+++ b/.claude/skills/railway-deploy-check/SKILL.md
@@ -42,8 +42,12 @@ deploys — it only reads from `experimental`.
    - Railway's OAuth tokens **expire silently** — a stale token looks
      "logged in" in the config file but fails on any API call. Always
      probe with `railway whoami`, never trust presence of the config.
-   - If expired: stop and tell the user "`railway login` required" —
-     only they can complete the browser flow.
+   - **If expired or unauthenticated**, follow
+     [references/auth-recovery.md](references/auth-recovery.md) — do NOT
+     guess the command or ask the user "can you log in". The reference
+     gives the exact browserless (`railway login -b`) recovery flow, the
+     user-facing template for surfacing the auth code, and the edge cases
+     (token expired mid-session, wrong account, multiple accounts).
 3. **Project + service linked**: needed so `railway logs` / `redeploy`
    / `variables` know what to target. Two paths:
    - Interactive: `railway link` then pick project + env + service

--- a/.claude/skills/railway-deploy-check/references/auth-recovery.md
+++ b/.claude/skills/railway-deploy-check/references/auth-recovery.md
@@ -1,0 +1,71 @@
+# Railway CLI Auth Recovery
+
+Procedure for recovering from an unauthenticated Railway CLI session, driven
+from an agent context (no browser, no stdin).
+
+## When this applies
+
+Triggered by any of these signals:
+
+- `check-deploy.sh` exits 2 with stderr:
+  `ERROR: railway CLI not authed. See references/auth-recovery.md for recovery steps.`
+- `railway whoami` exits non-zero (often with `Unauthorized` or
+  `Not logged in. Please run \`railway login\``).
+- Any `railway <cmd>` — `logs`, `variables`, `link`, `redeploy`, `status` —
+  fails with `Unauthorized`, `401`, `Not logged in`, or a prompt to run
+  `railway login`. Tokens expire silently, so a previously-working session
+  can fail mid-task; the recovery is identical.
+
+## Recovery procedure
+
+1. Run **`railway login -b`** (browserless). Do NOT run plain `railway login` —
+   it opens a browser and blocks on stdin, which an agent cannot drive.
+2. Parse stdout for:
+   - **Auth code**: 8 chars, format `XXXX-XXXX` (uppercase alphanumeric), on
+     the line beginning `Your authentication code is:`.
+   - **Activation URL**: `https://railway.com/activate` (on the `Please visit:`
+     line).
+3. Surface both to the user verbatim, using this template so formatting stays
+   consistent across invocations:
+   ```
+   Railway CLI is not authenticated. To recover:
+     1. Visit: https://railway.com/activate
+     2. Enter code: HZXN-TCMF
+     3. Approve in your browser (requires existing Railway login)
+   Reply "done" once you've approved and I'll retry.
+   ```
+   (Replace `HZXN-TCMF` with the actual code from step 2.)
+4. Wait for the user's "done". Do NOT poll `railway whoami` in a tight loop —
+   trust the confirmation. Once received, run `railway whoami` once; if it
+   still reports unauthenticated, report that to the user and ask them to
+   redo step 3 (the approval click on `railway.com/activate`).
+5. Retry the command that originally failed (the `check-deploy.sh` invocation,
+   the `railway logs ...` call, whatever it was).
+
+## What NOT to do
+
+- Do NOT scrape Railway credentials from env vars, the macOS keychain,
+  `~/.railway/config.json`, or anywhere else on disk. The recovery is the
+  `login -b` flow above, period.
+- Do NOT run a headless browser, Selenium, or similar to automate
+  `railway.com/activate`. A Claude browser extension driving the user's
+  existing session is a separate path — not this reference.
+- Do NOT call plain `railway login` (without `-b`). It blocks on stdin and
+  opens a browser on the user's machine; an agent cannot complete it.
+- Do NOT attempt to "refresh" a token by writing to `~/.railway/config.json`.
+
+## Edge cases
+
+- **Token expired mid-session**: identical recovery — run `railway login -b`,
+  surface code + URL, wait for "done", retry.
+- **Wrong account** (user is logged into account A, needs to switch to B):
+  `railway login -b` does NOT switch accounts inline. Run
+  `railway logout && railway login -b` instead, then proceed from step 2.
+- **Multiple accounts**: same as above — logout first, then browserless login.
+
+## Future automation (out of scope)
+
+A Claude browser extension with access to the user's logged-in Railway session
+could click "Authorize" on `railway.com/activate` and collapse this into a
+single step. Out of scope for this CLI-only reference, but worth noting for a
+future author.

--- a/.claude/skills/railway-deploy-check/scripts/check-deploy.sh
+++ b/.claude/skills/railway-deploy-check/scripts/check-deploy.sh
@@ -27,7 +27,7 @@ if ! command -v railway >/dev/null 2>&1; then
   exit 2
 fi
 if ! railway whoami >/dev/null 2>&1; then
-  echo "ERROR: railway CLI not authed. Run: railway login" >&2
+  echo "ERROR: railway CLI not authed. See references/auth-recovery.md for recovery steps." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Motivation

When a Claude agent invokes the `railway-deploy-check` skill and the CLI isn't authenticated, the helper script bails with `ERROR: railway CLI not authed. Run: railway login` — which is useless to an agent: plain `railway login` opens a browser and blocks on stdin, so the agent can't drive it. Today, agents either give up or guess. This PR documents the actual recovery (browserless `railway login -b`, surface the auth code + activation URL to the user, wait for confirmation, retry) and wires the skill to cite it.

## Files changed

- **Added** `.claude/skills/railway-deploy-check/references/auth-recovery.md` — 71-line reference covering: the error strings that trigger it, the step-by-step browserless flow, the user-facing template for surfacing the code, what NOT to do (no credential scraping, no headless-browser automation, no plain `railway login`), edge cases (expired mid-session / wrong account / multiple accounts), and a note on a future Claude-browser-extension path.
- **Modified** `.claude/skills/railway-deploy-check/SKILL.md` — prerequisite #2 ("Session authed") now points at `references/auth-recovery.md` instead of the unhelpful "`railway login` required" line.
- **Modified** `.claude/skills/railway-deploy-check/scripts/check-deploy.sh` — the `railway whoami` bail-out error now reads `ERROR: railway CLI not authed. See references/auth-recovery.md for recovery steps.` so the pointer travels with the error.

## Test plan

- [ ] Next time Claude hits a Railway auth failure via this skill, it should cite `references/auth-recovery.md` and follow the browserless `railway login -b` flow rather than guessing a command or asking the user "can you log in".
- [ ] `grep -r "auth-recovery" .claude/skills/railway-deploy-check/` returns hits in both `SKILL.md` and `scripts/check-deploy.sh` (plus the reference itself). Verified locally.
- [ ] `bash -n scripts/check-deploy.sh` passes (no syntax regression from the error-string edit). Verified locally.
- [ ] Docs-only change; no runtime behavior changed beyond the error-message string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced authentication failure guidance to direct users to comprehensive recovery procedures.
  * Added new authentication recovery documentation with a streamlined, secure re-login process for Railway CLI session recovery.
  * Updated deployment check error messages to reference authentication recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->