### PR TITLE
fix(rewrite-loop): picker filter + PR sweep (tier 1+2)

### DIFF
--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -61,10 +61,13 @@ log "═════════════════════════
 # --- Dry mode ---------------------------------------------------------------
 if [ "$ITERATIONS" -eq 0 ]; then
   log ""
+  log "DRY MODE — PR sweep preview (would sweep-merge APPROVED + CLEAN + green):"
+  sweep_ready_prs 1
+  log ""
   log "DRY MODE — ready tickets (earliest first):"
   rows=$(pick_ready_tickets)
   if [ -z "$rows" ]; then
-    log "  (none — either no open tickets, or all have unmet deps)"
+    log "  (none — either no open tickets, or all have unmet deps, or all have open/merged PRs)"
   else
     while IFS='|' read -r num tid title; do
       log "  #${num}  ${tid}  ${title}"
@@ -241,6 +244,12 @@ refresh_anchor
 for ITER in $(seq 1 "$ITERATIONS"); do
   log ""
   log "─── iteration ${ITER}/${ITERATIONS} ─────────────────────────────"
+
+  # --- Pre-iteration PR sweep ---------------------------------------------
+  # Merge any open PR that's already APPROVED + CLEAN + CI-green. Handles
+  # stranded PRs (Phase A opened one but C/D errored or loop was killed)
+  # and PRs whose CI went green mid-loop. Cost: one gh API call.
+  sweep_ready_prs
 
   # --- Pick next ticket (or the one the user pinned) -----------------------
   if [ -n "$ONLY_TICKET" ]; then

--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -79,11 +79,12 @@ gh_issue_list_open() {
 pick_ready_tickets() {
   local issues_json
   issues_json=$(gh_issue_list_open)
-  python3 - "$issues_json" "$BASE_BRANCH" "$GH_REPO" <<'PY'
+  python3 - "$issues_json" "$BASE_BRANCH" "$GH_REPO" "$LABEL" <<'PY'
 import json, re, subprocess, sys
 issues = json.loads(sys.argv[1])
 base   = sys.argv[2]
 repo   = sys.argv[3]
+label  = sys.argv[4]
 
 TICKET_RE = re.compile(r"phase-(\d+)(?:\.(\d+))?")
 DEP_RE    = re.compile(r"###\s*Depends on\s*\n(.*?)(?=\n###|\Z)", re.IGNORECASE | re.DOTALL)
@@ -99,11 +100,13 @@ def deps(body):
     m = DEP_RE.search(body)
     return [int(n) for n in NUM_RE.findall(m.group(1))] if m else []
 
-def _merged_pr_for(n):
-    """Return True iff a merged PR on `base` strictly closes issue #n."""
+def _pr_strictly_closes(n, state):
+    """Return True iff a PR (in `state`) on `base`, labeled `label`,
+    strictly closes issue #n via Fixes/Closes/Resolves."""
     p = subprocess.run(
         ["gh", "pr", "list", "--repo", repo,
-         "--state", "merged", "--base", base,
+         "--state", state, "--base", base,
+         "--label", label,
          "--search", f"Fixes #{n} OR Closes #{n} OR Resolves #{n}",
          "--json", "number,body,title"],
         capture_output=True, text=True
@@ -120,6 +123,19 @@ def _merged_pr_for(n):
             return True
     return False
 
+def _merged_pr_for(n):
+    """Return True iff a merged PR on `base`, labeled `label`, strictly
+    closes issue #n. Scoping to `label` avoids false-positives from
+    unrelated tooling PRs that happen to mention the ticket number."""
+    return _pr_strictly_closes(n, "merged")
+
+def _open_pr_for(n):
+    """Return True iff an open PR on `base`, labeled `label`, strictly
+    closes issue #n. Used to exclude tickets that already have work in
+    flight — otherwise the picker keeps returning them and the loop
+    wastes iterations logging "PR already open — skipping"."""
+    return _pr_strictly_closes(n, "open")
+
 def dep_met(n):
     # A dependency is satisfied once its closing PR is merged into
     # base. We do NOT require the issue itself to be CLOSED because
@@ -135,6 +151,12 @@ for i in issues:
     # branch), so a merged-but-still-OPEN issue would otherwise be
     # re-picked forever.
     if _merged_pr_for(i["number"]):
+        continue
+    # Skip tickets that already have an open PR. These are in-flight
+    # work — a new iteration shouldn't try to re-implement them; the
+    # pre-iteration sweep (sweep_ready_prs) will pick them up once
+    # they're APPROVED + CI-green.
+    if _open_pr_for(i["number"]):
         continue
     blocked = [d for d in deps(i.get("body","") or "") if not dep_met(d)]
     if not blocked:
@@ -155,6 +177,108 @@ pr_already_open_for() {
     --label "$LABEL" --limit 50 --json number,body \
     --jq ".[] | select(.body | test(\"(?i)(?:fixes|closes|resolves)\\\\s+#${issue}\\\\b\")) | .number" \
     2>/dev/null | head -1
+}
+
+# ===========================================================================
+# PR sweep — merge any APPROVED + CLEAN + CI-green PRs that are just sitting.
+# ===========================================================================
+# Called at the top of every iteration (and in --iterations 0 dry mode as a
+# preview). Fixes the "stranded PR" failure mode where Phase A opened a PR
+# but C/D errored or the loop got killed, leaving the PR approved + green
+# with nobody to merge it.
+#
+# Flags:
+#   dry_run=1  -> print "would merge" lines instead of actually merging.
+sweep_ready_prs() {
+  local dry_run=${1:-0}
+  local prs_json
+  prs_json=$(gh pr list --repo "$GH_REPO" --base "$BASE_BRANCH" \
+    --state open --label "$LABEL" --limit 50 \
+    --json number,body,title,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup \
+    2>/dev/null || echo "[]")
+
+  # Filter to mergeable PRs in a single python pass. Output one line per
+  # ready PR: "pr_num|issue_num_or_empty|ticket_id_or_unknown".
+  local ready
+  ready=$(python3 - "$prs_json" <<'PY'
+import json, re, sys
+prs = json.loads(sys.argv[1])
+
+TICKET_RE = re.compile(r"phase-(\d+)(?:\.(\d+))?")
+CLOSES_RE = re.compile(r"(?:[Ff]ixes|[Cc]loses|[Rr]esolves)\s+#(\d+)\b")
+
+def all_checks_green(rollup):
+    if not rollup:
+        # No required checks configured → treat as green.
+        return True
+    for c in rollup:
+        state = (c.get("state") or c.get("conclusion") or "").upper()
+        if state != "SUCCESS":
+            return False
+    return True
+
+def issue_num_from_body(body):
+    if not body:
+        return None
+    m = CLOSES_RE.search(body)
+    return int(m.group(1)) if m else None
+
+for pr in prs:
+    if (pr.get("mergeable") or "").upper() != "MERGEABLE":          continue
+    if (pr.get("mergeStateStatus") or "").upper() != "CLEAN":        continue
+    if (pr.get("reviewDecision") or "").upper() != "APPROVED":       continue
+    if not all_checks_green(pr.get("statusCheckRollup") or []):      continue
+    num   = pr.get("number")
+    issue = issue_num_from_body(pr.get("body",""))
+    issue_s = str(issue) if issue else ""
+    print(f"{num}|{issue_s}|")
+PY
+)
+
+  if [ -z "$ready" ]; then
+    log "  sweep: 0 PRs ready to merge"
+    return 0
+  fi
+
+  # For each ready PR, resolve ticket_id from the linked issue's title
+  # (same TICKET_RE as the picker). Then merge (or preview) and emit
+  # telemetry. ticket_id resolution failure does NOT block the merge.
+  while IFS='|' read -r pr_num issue_num _; do
+    [ -z "$pr_num" ] && continue
+    local ticket_id="unknown"
+    local detail=""
+    if [ -n "$issue_num" ]; then
+      local issue_title
+      issue_title=$(gh issue view "$issue_num" --repo "$GH_REPO" \
+        --json title --jq .title 2>/dev/null || echo "")
+      if [ -n "$issue_title" ]; then
+        ticket_id=$(python3 - "$issue_title" <<'PY'
+import re, sys
+m = re.search(r"phase-(\d+)(?:\.(\d+))?", sys.argv[1])
+print(f"phase-{int(m.group(1))}.{int(m.group(2) or 0):02d}" if m else "unknown")
+PY
+        )
+      fi
+    fi
+    if [ "$ticket_id" = "unknown" ]; then
+      detail="ticket_id unresolved"
+    fi
+
+    if [ "$dry_run" = "1" ]; then
+      log "  sweep: would sweep-merge PR #${pr_num} (ticket=${ticket_id}, all checks green)"
+      continue
+    fi
+
+    log "  sweep: merging PR #${pr_num} (ticket=${ticket_id}, all checks green)"
+    if gh pr merge "$pr_num" --repo "$GH_REPO" --squash --delete-branch >/dev/null 2>&1; then
+      PR_NUM="$pr_num" ISSUE_NUM="${issue_num:-}" TICKET_ID="$ticket_id" \
+        emit_event "D-merge" "passed" "${detail:-swept by sweep_ready_prs}"
+    else
+      log "  sweep: merge FAILED for PR #${pr_num} — leaving for manual attention"
+      PR_NUM="$pr_num" ISSUE_NUM="${issue_num:-}" TICKET_ID="$ticket_id" \
+        emit_event "D-merge" "failed" "sweep_ready_prs merge failed"
+    fi
+  done <<< "$ready"
 }
 
 get_cr_plan() {


### PR DESCRIPTION
## Summary

Fixes the Ralph loop's 96%-skip failure mode (50 iterations → 48 "PR already open" skips, 0 merges) with two compounding changes.

### Tier 1 — picker filter (`pick_ready_tickets` in `resources/lib.sh`)
- New `_open_pr_for(n)` helper — mirrors `_merged_pr_for` but with `--state open`. Both share a `_pr_strictly_closes(n, state)` worker that uses strict `Fixes/Closes/Resolves #N` regex on body+title.
- Picker now excludes issues whose PR is either merged OR open (labeled `rewrite-agent-sdk`, base `ralph-looped`). Returns only actionable tickets.
- Added `--label rewrite-agent-sdk` to the existing `_merged_pr_for` gh call (was missing) — prevents unrelated tooling PRs from false-positiving.
- The existing bash helper `pr_already_open_for` at `lib.sh:148-158` is untouched (still used at `ralph-rewrite-loop.sh:259`).

### Tier 2 — pre-iteration PR sweep (`sweep_ready_prs`)
- Lists open PRs on `$BASE_BRANCH` labeled `$LABEL` with `mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`.
- Merges any PR where `mergeable == MERGEABLE` && `mergeStateStatus == CLEAN` && `reviewDecision == APPROVED` && all `statusCheckRollup[].state // .conclusion == SUCCESS` — via `gh pr merge --squash --delete-branch`.
- Resolves `ticket_id` from the linked issue's title via the same `TICKET_RE` the picker uses. Unresolved → `ticket_id="unknown"` with `detail="ticket_id unresolved"`, merge still proceeds, telemetry still fires.
- Emits `D-merge passed` telemetry with `PR_NUM`/`ISSUE_NUM`/`TICKET_ID` set per-merge.
- Logs `sweep: merging PR #N (ticket=…, all checks green)` per merge, or `sweep: 0 PRs ready to merge` when nothing matches — so the log always confirms the sweep ran.

### Wiring
- `ralph-rewrite-loop.sh` calls `sweep_ready_prs` at the top of every iteration, immediately after the iteration header and before the picker. Cost: 1 extra gh API call per iteration.
- `--iterations 0` dry mode previews both the sweep (`sweep_ready_prs 1`) and the ready-ticket list.

### Explicitly NOT in this PR
- No "resume open PR to Phase B/C/D" (Tier 3, out of scope).
- CR-review and tests phases untouched.
- No new runtime deps — still bash + gh + python3.
- Only PRs labeled `rewrite-agent-sdk` are auto-merged.

## Before / After

> Before: 50 iterations → 48 "PR already open" skips, 0 merges.
> After: picker returns only actionable tickets; pre-iteration sweep auto-merges APPROVED + CLEAN + green PRs.
> Would have cleared #479 and #474 automatically.

Live `--iterations 0` against the repo confirms: PR #474 (stranded since 01:22 UTC, ~18h old) is reported as "would sweep-merge" and 5 ready tickets surface (none with open PRs).

## Test plan
- [x] `bash -n scripts/rewrite/ralph-rewrite-loop.sh` — syntax OK
- [x] `bash -n scripts/rewrite/resources/lib.sh` — syntax OK
- [x] All 6 embedded python heredocs compile clean via `compile(block, ..., 'exec')`
- [x] `bash scripts/rewrite/ralph-rewrite-loop.sh --iterations 0` against live GitHub — prints sweep preview (finds PR #474) and ready-tickets list (5 actionable tickets) cleanly in ~30s
- [ ] Next live loop iteration verifies PR #474 is swept automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automation workflow with improved PR-to-ticket coordination during ticket selection.
  * Added automatic merging of qualified pull requests before processing new tickets.
  * Improved dry-run preview mode to better reflect system state.
  * Refined ticket selection logic to prevent duplicate work assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->