### PR TITLE
feat(rewrite): phase-2.04 MCP tools — advance_scene + complete_scene

### DIFF
--- a/backend_v2/modules/simulation/mcp/__init__.py
+++ b/backend_v2/modules/simulation/mcp/__init__.py
@@ -1,4 +1,5 @@
 """MCP tools exposed by the simulation module."""
 from modules.simulation.mcp.memory_tools import recall_memory
+from modules.simulation.mcp.scene_tools import advance_scene, complete_scene
 
-__all__ = ["recall_memory"]
+__all__ = ["recall_memory", "advance_scene", "complete_scene"]

--- a/backend_v2/modules/simulation/mcp/scene_tools.py
+++ b/backend_v2/modules/simulation/mcp/scene_tools.py
@@ -1,0 +1,233 @@
+"""Scene-progression MCP tools — ``advance_scene`` and ``complete_scene``.
+
+``advance_scene`` moves a learner to the next scene in order.
+``complete_scene`` marks the current scene as completed with a summary.
+
+Both tools validate preconditions and return ``is_error=True`` with a
+descriptive message on violation.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from claude_agent_sdk import tool
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from common.db.connection import SessionLocal
+from common.db.models import (
+    SceneProgress,
+    SimulationScene,
+    UserProgress,
+)
+
+logger = logging.getLogger(__name__)
+
+SessionFactory = Callable[[], Session]
+
+
+def _error(message: str) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": message}],
+        "is_error": True,
+    }
+
+
+def _ok(message: str) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": message}],
+        "is_error": False,
+    }
+
+
+def _advance_scene_sync(
+    user_progress_id: int,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> dict[str, Any]:
+    factory = session_factory or SessionLocal
+    session = factory()
+    try:
+        user_progress = session.get(UserProgress, user_progress_id)
+        if user_progress is None:
+            return _error(
+                f"No user_progress found for user_progress_id={user_progress_id}"
+            )
+
+        if user_progress.simulation_status == "completed":
+            return _error("Simulation is already completed")
+
+        scenes = (
+            session.execute(
+                select(SimulationScene)
+                .where(SimulationScene.simulation_id == user_progress.simulation_id)
+                .where(SimulationScene.deleted_at.is_(None))
+                .order_by(SimulationScene.scene_order)
+            )
+            .scalars()
+            .all()
+        )
+
+        current_idx = None
+        for i, scene in enumerate(scenes):
+            if scene.id == user_progress.current_scene_id:
+                current_idx = i
+                break
+
+        if current_idx is None:
+            return _error(
+                f"Current scene {user_progress.current_scene_id} not found in simulation"
+            )
+
+        if current_idx >= len(scenes) - 1:
+            return _ok(
+                f"Already at final scene (scene_id={scenes[current_idx].id}, "
+                f"title={scenes[current_idx].title!r}). No advancement possible."
+            )
+
+        next_scene = scenes[current_idx + 1]
+
+        completed = list(user_progress.scenes_completed or [])
+        completed.append(user_progress.current_scene_id)
+        user_progress.scenes_completed = completed
+        user_progress.current_scene_id = next_scene.id
+
+        existing_progress = session.execute(
+            select(SceneProgress)
+            .where(SceneProgress.user_progress_id == user_progress_id)
+            .where(SceneProgress.scene_id == next_scene.id)
+        ).scalar_one_or_none()
+
+        if existing_progress is None:
+            session.add(
+                SceneProgress(
+                    user_progress_id=user_progress_id,
+                    scene_id=next_scene.id,
+                    status="in_progress",
+                )
+            )
+        else:
+            existing_progress.status = "in_progress"
+
+        session.commit()
+        return _ok(
+            f"Advanced to scene_id={next_scene.id}, title={next_scene.title!r}"
+        )
+    except Exception:
+        logger.exception(
+            "advance_scene failed for user_progress_id=%s", user_progress_id
+        )
+        session.rollback()
+        return _error("Failed to advance scene")
+    finally:
+        session.close()
+
+
+@tool(
+    name="advance_scene",
+    description=(
+        "Move the learner to the next scene in order. "
+        "Returns the new scene ID and title on success, "
+        "or a no-op message if already at the final scene."
+    ),
+    input_schema={
+        "user_progress_id": int,
+    },
+)
+async def advance_scene(args: dict[str, Any]) -> dict[str, Any]:
+    return await asyncio.to_thread(
+        _advance_scene_sync, args["user_progress_id"]
+    )
+
+
+def _complete_scene_sync(
+    user_progress_id: int,
+    scene_id: int,
+    summary: str,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> dict[str, Any]:
+    factory = session_factory or SessionLocal
+    session = factory()
+    try:
+        user_progress = session.get(UserProgress, user_progress_id)
+        if user_progress is None:
+            return _error(
+                f"No user_progress found for user_progress_id={user_progress_id}"
+            )
+
+        if user_progress.current_scene_id != scene_id:
+            return _error(
+                f"cannot complete scene {scene_id} when current scene is "
+                f"{user_progress.current_scene_id}"
+            )
+
+        completed = list(user_progress.scenes_completed or [])
+        if scene_id in completed:
+            return _error(f"Scene {scene_id} is already completed")
+
+        scene_progress = session.execute(
+            select(SceneProgress)
+            .where(SceneProgress.user_progress_id == user_progress_id)
+            .where(SceneProgress.scene_id == scene_id)
+        ).scalar_one_or_none()
+
+        now = datetime.now(timezone.utc)
+        if scene_progress is None:
+            scene_progress = SceneProgress(
+                user_progress_id=user_progress_id,
+                scene_id=scene_id,
+                status="completed",
+                completed_at=now,
+                progress_data={"summary": summary},
+            )
+            session.add(scene_progress)
+        else:
+            scene_progress.status = "completed"
+            scene_progress.completed_at = now
+            progress_data = dict(scene_progress.progress_data or {})
+            progress_data["summary"] = summary
+            scene_progress.progress_data = progress_data
+
+        completed.append(scene_id)
+        user_progress.scenes_completed = completed
+
+        session.commit()
+        return _ok(f"Scene {scene_id} marked as completed")
+    except Exception:
+        logger.exception(
+            "complete_scene failed for user_progress_id=%s scene_id=%s",
+            user_progress_id,
+            scene_id,
+        )
+        session.rollback()
+        return _error("Failed to complete scene")
+    finally:
+        session.close()
+
+
+@tool(
+    name="complete_scene",
+    description=(
+        "Mark the current scene as completed and store a summary. "
+        "The scene_id must match the learner's current scene."
+    ),
+    input_schema={
+        "user_progress_id": int,
+        "scene_id": int,
+        "summary": str,
+    },
+)
+async def complete_scene(args: dict[str, Any]) -> dict[str, Any]:
+    return await asyncio.to_thread(
+        _complete_scene_sync,
+        args["user_progress_id"],
+        args["scene_id"],
+        args["summary"],
+    )
+
+
+__all__ = ["advance_scene", "complete_scene"]

--- a/backend_v2/modules/simulation/mcp/scene_tools.py
+++ b/backend_v2/modules/simulation/mcp/scene_tools.py
@@ -51,7 +51,9 @@ def _advance_scene_sync(
     factory = session_factory or SessionLocal
     session = factory()
     try:
-        user_progress = session.get(UserProgress, user_progress_id)
+        user_progress = session.get(
+            UserProgress, user_progress_id, with_for_update=True
+        )
         if user_progress is None:
             return _error(
                 f"No user_progress found for user_progress_id={user_progress_id}"
@@ -91,7 +93,8 @@ def _advance_scene_sync(
         next_scene = scenes[current_idx + 1]
 
         completed = list(user_progress.scenes_completed or [])
-        completed.append(user_progress.current_scene_id)
+        if user_progress.current_scene_id not in completed:
+            completed.append(user_progress.current_scene_id)
         user_progress.scenes_completed = completed
         user_progress.current_scene_id = next_scene.id
 
@@ -153,7 +156,9 @@ def _complete_scene_sync(
     factory = session_factory or SessionLocal
     session = factory()
     try:
-        user_progress = session.get(UserProgress, user_progress_id)
+        user_progress = session.get(
+            UserProgress, user_progress_id, with_for_update=True
+        )
         if user_progress is None:
             return _error(
                 f"No user_progress found for user_progress_id={user_progress_id}"

--- a/backend_v2/tests/modules/simulation/mcp/test_scene_tools.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_scene_tools.py
@@ -1,0 +1,423 @@
+"""Unit tests for ``advance_scene`` and ``complete_scene`` MCP tools.
+
+All tests run against the in-memory SQLite session from ``tests/conftest.py``.
+A ``patched_session_factory`` fixture routes the tool's DB work through the
+test session so commits land in the same transaction the test observes.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from common.db.models import (
+    SceneProgress,
+    SimulationScene,
+    Simulation,
+    UserProgress,
+    User,
+)
+from modules.simulation.mcp import scene_tools
+from modules.simulation.mcp.scene_tools import (
+    _advance_scene_sync,
+    _complete_scene_sync,
+)
+
+
+@pytest.fixture
+def patched_session_factory(db_session: Session):
+    """Route tool DB work through the test session."""
+
+    class _NoCloseSession:
+        def __init__(self, inner: Session) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str):
+            return getattr(self._inner, name)
+
+        def close(self) -> None:
+            pass
+
+        def commit(self) -> None:
+            self._inner.flush()
+
+        def rollback(self) -> None:
+            self._inner.rollback()
+
+    def factory() -> Session:  # type: ignore[return-value]
+        return _NoCloseSession(db_session)  # type: ignore[return-value]
+
+    with patch.object(scene_tools, "SessionLocal", factory):
+        yield factory
+
+
+@pytest.fixture
+def simulation(db_session: Session) -> Simulation:
+    user = User(
+        user_id="prof-scene",
+        email="prof-scene@example.com",
+        full_name="Scene Professor",
+        username="prof-scene",
+        role="professor",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    sim = Simulation(
+        unique_id="sim-scene-tools",
+        title="Scene Tools Sim",
+        description="Fixture simulation for scene tool tests",
+        created_by=user.id,
+    )
+    db_session.add(sim)
+    db_session.flush()
+    return sim
+
+
+@pytest.fixture
+def three_scenes(db_session: Session, simulation: Simulation) -> list[SimulationScene]:
+    scenes = []
+    for i in range(1, 4):
+        scene = SimulationScene(
+            simulation_id=simulation.id,
+            title=f"Scene {i}",
+            description=f"Description for scene {i}",
+            scene_order=i,
+        )
+        db_session.add(scene)
+        scenes.append(scene)
+    db_session.flush()
+    return scenes
+
+
+@pytest.fixture
+def user_progress_at_scene1(
+    db_session: Session,
+    simulation: Simulation,
+    three_scenes: list[SimulationScene],
+) -> UserProgress:
+    user = User(
+        user_id="student-1",
+        email="student-1@example.com",
+        full_name="Student One",
+        username="student-1",
+        role="student",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    up = UserProgress(
+        user_id=user.id,
+        simulation_id=simulation.id,
+        current_scene_id=three_scenes[0].id,
+        simulation_status="in_progress",
+        scenes_completed=[],
+    )
+    db_session.add(up)
+    db_session.flush()
+    return up
+
+
+@pytest.fixture
+def user_progress_at_final_scene(
+    db_session: Session,
+    simulation: Simulation,
+    three_scenes: list[SimulationScene],
+) -> UserProgress:
+    user = User(
+        user_id="student-final",
+        email="student-final@example.com",
+        full_name="Student Final",
+        username="student-final",
+        role="student",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    up = UserProgress(
+        user_id=user.id,
+        simulation_id=simulation.id,
+        current_scene_id=three_scenes[2].id,
+        simulation_status="in_progress",
+        scenes_completed=[three_scenes[0].id, three_scenes[1].id],
+    )
+    db_session.add(up)
+    db_session.flush()
+    return up
+
+
+@pytest.fixture
+def user_progress_at_scene2(
+    db_session: Session,
+    simulation: Simulation,
+    three_scenes: list[SimulationScene],
+) -> UserProgress:
+    user = User(
+        user_id="student-2",
+        email="student-2@example.com",
+        full_name="Student Two",
+        username="student-2",
+        role="student",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    up = UserProgress(
+        user_id=user.id,
+        simulation_id=simulation.id,
+        current_scene_id=three_scenes[1].id,
+        simulation_status="in_progress",
+        scenes_completed=[three_scenes[0].id],
+    )
+    db_session.add(up)
+    db_session.flush()
+
+    db_session.add(
+        SceneProgress(
+            user_progress_id=up.id,
+            scene_id=three_scenes[1].id,
+            status="in_progress",
+        )
+    )
+    db_session.flush()
+    return up
+
+
+# ---------- advance_scene tests ----------
+
+
+def test_advance_scene_moves_to_next_in_order(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_scene1: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    result = _advance_scene_sync(
+        user_progress_at_scene1.id,
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is False
+    assert str(three_scenes[1].id) in result["content"][0]["text"]
+
+    db_session.refresh(user_progress_at_scene1)
+    assert user_progress_at_scene1.current_scene_id == three_scenes[1].id
+    assert three_scenes[0].id in user_progress_at_scene1.scenes_completed
+
+    new_progress = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress_at_scene1.id)
+        .where(SceneProgress.scene_id == three_scenes[1].id)
+    ).scalar_one_or_none()
+    assert new_progress is not None
+    assert new_progress.status == "in_progress"
+
+
+def test_advance_scene_noop_on_final_scene(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_final_scene: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    result = _advance_scene_sync(
+        user_progress_at_final_scene.id,
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is False
+    assert "final scene" in result["content"][0]["text"].lower()
+
+    db_session.refresh(user_progress_at_final_scene)
+    assert user_progress_at_final_scene.current_scene_id == three_scenes[2].id
+
+
+def test_advance_scene_error_user_progress_not_found(patched_session_factory):
+    result = _advance_scene_sync(
+        999999,
+        session_factory=patched_session_factory,
+    )
+    assert result["is_error"] is True
+    assert "999999" in result["content"][0]["text"]
+
+
+def test_advance_scene_error_simulation_completed(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_scene1: UserProgress,
+):
+    user_progress_at_scene1.simulation_status = "completed"
+    db_session.flush()
+
+    result = _advance_scene_sync(
+        user_progress_at_scene1.id,
+        session_factory=patched_session_factory,
+    )
+    assert result["is_error"] is True
+    assert "completed" in result["content"][0]["text"].lower()
+
+
+# ---------- complete_scene tests ----------
+
+
+def test_complete_scene_marks_completed(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_scene2: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    scene_id = three_scenes[1].id
+    summary = "Student demonstrated strong analytical skills."
+
+    result = _complete_scene_sync(
+        user_progress_at_scene2.id,
+        scene_id,
+        summary,
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is False
+
+    db_session.refresh(user_progress_at_scene2)
+    assert scene_id in user_progress_at_scene2.scenes_completed
+
+    sp = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress_at_scene2.id)
+        .where(SceneProgress.scene_id == scene_id)
+    ).scalar_one()
+    assert sp.status == "completed"
+    assert sp.completed_at is not None
+    assert sp.progress_data["summary"] == summary
+
+
+def test_complete_scene_rejects_wrong_current_scene(
+    patched_session_factory,
+    user_progress_at_scene2: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    wrong_scene_id = three_scenes[2].id
+
+    result = _complete_scene_sync(
+        user_progress_at_scene2.id,
+        wrong_scene_id,
+        "some summary",
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert f"cannot complete scene {wrong_scene_id}" in text
+    assert str(three_scenes[1].id) in text
+
+
+def test_complete_scene_rejects_already_completed(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_scene2: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    scene_id = three_scenes[0].id
+    user_progress_at_scene2.current_scene_id = scene_id
+    db_session.flush()
+
+    result = _complete_scene_sync(
+        user_progress_at_scene2.id,
+        scene_id,
+        "re-completing",
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is True
+    assert "already completed" in result["content"][0]["text"].lower()
+
+
+def test_complete_scene_error_user_progress_not_found(patched_session_factory):
+    result = _complete_scene_sync(
+        999999,
+        1,
+        "summary",
+        session_factory=patched_session_factory,
+    )
+    assert result["is_error"] is True
+    assert "999999" in result["content"][0]["text"]
+
+
+def test_advance_scene_reuses_existing_scene_progress(
+    patched_session_factory,
+    db_session: Session,
+    user_progress_at_scene1: UserProgress,
+    three_scenes: list[SimulationScene],
+):
+    """When a SceneProgress row already exists for the next scene, advance_scene
+    should update it to in_progress rather than creating a duplicate."""
+    db_session.add(
+        SceneProgress(
+            user_progress_id=user_progress_at_scene1.id,
+            scene_id=three_scenes[1].id,
+            status="not_started",
+        )
+    )
+    db_session.flush()
+
+    result = _advance_scene_sync(
+        user_progress_at_scene1.id,
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is False
+
+    sp = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == user_progress_at_scene1.id)
+        .where(SceneProgress.scene_id == three_scenes[1].id)
+    ).scalar_one()
+    assert sp.status == "in_progress"
+
+
+def test_complete_scene_creates_progress_when_missing(
+    patched_session_factory,
+    db_session: Session,
+    simulation: Simulation,
+    three_scenes: list[SimulationScene],
+):
+    """When no SceneProgress row exists, complete_scene should create one."""
+    user = User(
+        user_id="student-no-sp",
+        email="no-sp@example.com",
+        full_name="No SP",
+        username="student-no-sp",
+        role="student",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    up = UserProgress(
+        user_id=user.id,
+        simulation_id=simulation.id,
+        current_scene_id=three_scenes[0].id,
+        simulation_status="in_progress",
+        scenes_completed=[],
+    )
+    db_session.add(up)
+    db_session.flush()
+
+    result = _complete_scene_sync(
+        up.id,
+        three_scenes[0].id,
+        "created fresh",
+        session_factory=patched_session_factory,
+    )
+
+    assert result["is_error"] is False
+
+    sp = db_session.execute(
+        select(SceneProgress)
+        .where(SceneProgress.user_progress_id == up.id)
+        .where(SceneProgress.scene_id == three_scenes[0].id)
+    ).scalar_one()
+    assert sp.status == "completed"
+    assert sp.progress_data["summary"] == "created fresh"
+
+


### PR DESCRIPTION
## Summary
- Port scene-progression state-machine into two MCP tools: `advance_scene` (moves learner to next scene in order) and `complete_scene` (marks current scene completed with summary)
- Both tools validate preconditions and return `is_error=True` with descriptive messages on violation
- Follows established `@tool` + `asyncio.to_thread` + injectable session_factory pattern from `grading_tools.py`

Fixes #438

## Test plan
- [x] `uv run pytest tests/modules/simulation/mcp/test_scene_tools.py -q --cov=modules.simulation.mcp.scene_tools --cov-fail-under=85` passes at 88% coverage (10 tests)
- [x] Local CodeRabbit review passes with no findings
- [ ] CodeRabbit PR review passes (or all comments addressed / replied)
- [ ] Railway experimental deploy green (verify with `railway logs --environment experimental -s Backend --lines 30` AFTER merge, before claiming done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two tools to advance learners through simulation scenes and to mark scenes as completed.

* **Tests**
  * Added comprehensive unit tests covering scene progression, completion tracking, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->