### PR TITLE
fix(rewrite-loop): watchdog — stop killing user's Claude Code sessions

### DIFF
--- a/scripts/rewrite/resources/lib.sh
+++ b/scripts/rewrite/resources/lib.sh
@@ -404,15 +404,18 @@ run_claude_in() {
 }
 
 # ===========================================================================
-# Watchdog — kills any claude process older than CLAUDE_TIMEOUT_SEC
+# Watchdog — kills the loop's own claude subprocesses if they hang past
+# CLAUDE_TIMEOUT_SEC. Must NOT match the user's interactive Claude Code
+# sessions (which also have "claude" in their cmdline) — we key on the
+# exact argv run_claude_in invokes: `claude --print --dangerously-skip-permissions`.
 # ===========================================================================
 start_watchdog() {
   (
     while true; do
       sleep 300
       # BSD awk (macOS) rejects chained ternaries — use if/else.
-      ps -eo pid,etime,comm | awk -v max="$CLAUDE_TIMEOUT_SEC" '
-        /claude/ {
+      ps -eo pid,etime,command | awk -v max="$CLAUDE_TIMEOUT_SEC" '
+        /claude --print --dangerously-skip-permissions/ {
           n = split($2, p, /[-:]/)
           if (n == 2)      { s = p[1]*60 + p[2] }
           else if (n == 3) { s = p[1]*3600 + p[2]*60 + p[3] }


### PR DESCRIPTION
## Summary
The loop's 45-min watchdog at [scripts/rewrite/resources/lib.sh:409-430](https://github.com/Hendrik040/n-aible_edtech_sims/blob/ralph-looped/scripts/rewrite/resources/lib.sh#L409-L430) matched any process with "claude" in its name (ps `comm` format) — which includes the user's own interactive Claude Code CLI sessions. Running the loop silently killed the developer's editor sessions at the 45-min mark.

Observed today: two \`WATCHDOG: killing hung claude PID\` lines landed in the master log for PIDs that were NOT the loop's subprocess (the loop's claude PID for iteration 1 was 3965; the killed PIDs were 16965 and 98394 — Claude Code sessions).

## Fix
Key off the exact argv run_claude_in uses (\`claude --print --dangerously-skip-permissions\`) and switch ps format to \`command\` so the new substring match sees the flags.

\`\`\`diff
-ps -eo pid,etime,comm | awk ... '/claude/ { ... }'
+ps -eo pid,etime,command | awk ... '/claude --print --dangerously-skip-permissions/ { ... }'
\`\`\`

Interactive \`claude\` / \`claude --resume ...\` sessions no longer match.

## Test plan
- [ ] \`bash -n scripts/rewrite/resources/lib.sh\` — syntax OK (done)
- [ ] Run a loop iteration with a long-running interactive \`claude\` session in another terminal; confirm the watchdog doesn't kill it
- [ ] Manually hang a \`claude --print --dangerously-skip-permissions\` past 45 min; confirm the watchdog does kill it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed process monitoring logic to more accurately identify target processes, preventing unintended termination of unrelated services during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->