### PR TITLE
feat(mcp): add write_summary tool to memory_tools (phase-2.05)

### DIFF
--- a/backend_v2/modules/simulation/mcp/__init__.py
+++ b/backend_v2/modules/simulation/mcp/__init__.py
@@ -1,4 +1,4 @@
 """MCP tools exposed by the simulation module."""
-from modules.simulation.mcp.memory_tools import recall_memory
+from modules.simulation.mcp.memory_tools import recall_memory, write_summary
 
-__all__ = ["recall_memory"]
+__all__ = ["recall_memory", "write_summary"]

--- a/backend_v2/modules/simulation/mcp/memory_tools.py
+++ b/backend_v2/modules/simulation/mcp/memory_tools.py
@@ -1,6 +1,6 @@
-"""``recall_memory`` MCP tool — hybrid persona+scene-scoped memory retrieval.
+"""MCP memory tools — ``recall_memory`` retrieval and ``write_summary`` write.
 
-Ports the hybrid ranking behaviour of
+``recall_memory`` ports the hybrid ranking behaviour of
 ``backend/common/services/simulation_helper/memory_service.retrieve_memories_hybrid``
 to an ``@tool``-decorated async function that plugs into an MCP server
 (assembled in phase-2.7). Memory rows are read through the phase-1.2
@@ -8,7 +8,12 @@ to an ``@tool``-decorated async function that plugs into an MCP server
 metadata, since the low-level store intentionally exposes only an
 ``entity_type`` namespace filter.
 
-Contract:
+``write_summary`` persists a scene-level conversation summary into the
+``conversation_summaries`` table. Enforces one summary per
+(user_progress, scene) — a second call with the same pair updates the
+existing row rather than inserting a duplicate.
+
+Contract (recall_memory):
 
 * Input schema:  ``persona_id: int``, ``scene_id: int``, ``query: str``,
   ``k: int = 5``.
@@ -19,21 +24,38 @@ Contract:
   The tool never raises to the MCP runtime.
 * Empty / whitespace ``query`` or non-positive ``k`` short-circuits to
   ``{"content": [], "is_error": False}`` without touching the DB.
+
+Contract (write_summary):
+
+* Input schema:  ``user_progress_id: int``, ``scene_id: int``,
+  ``summary_text: str``.
+* Success return:  ``{"content": [{"type": "text", "text": "summary saved"}],
+  "structuredContent": {"id": <int>}, "is_error": False}``.
+* Empty / whitespace ``summary_text``: raises ``ValueError``.
+* Unexpected DB exception: ``{"content": [{"type": "text", "text":
+  "<message>"}], "is_error": True}``. The tool never raises to the MCP
+  runtime.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from claude_agent_sdk import tool
 from openai import AsyncOpenAI
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
+from common.db.connection import SessionLocal
+from common.db.models import ConversationSummaries
 from common.services import pgvector_store
 from common.services.embeddings_service import EmbeddingsService
 from modules.simulation import repository
 
 logger = logging.getLogger(__name__)
+
+SessionFactory = Callable[[], Session]
 
 _MEMORY_NAMESPACE = "memory"
 _OVERFETCH_MULTIPLIER = 3
@@ -193,4 +215,99 @@ async def recall_memory(args: dict[str, Any]) -> dict[str, Any]:
         return _error(_GENERIC_ERROR_MESSAGE)
 
 
-__all__ = ["recall_memory"]
+_GENERIC_WRITE_SUMMARY_ERROR_MESSAGE = "Failed to write summary"
+_SUMMARY_TYPE = "scene"
+
+
+def _write_summary_sync(
+    user_progress_id: int,
+    scene_id: int,
+    summary_text: str,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> dict[str, Any]:
+    """Blocking implementation of ``write_summary`` — kept out of the event loop."""
+    factory = session_factory or SessionLocal
+    session = factory()
+    try:
+        existing = session.execute(
+            select(ConversationSummaries)
+            .where(ConversationSummaries.user_progress_id == user_progress_id)
+            .where(ConversationSummaries.scene_id == scene_id)
+        ).scalar_one_or_none()
+
+        if existing is not None:
+            existing.summary_text = summary_text
+            summary_id = existing.id
+        else:
+            row = ConversationSummaries(
+                user_progress_id=user_progress_id,
+                scene_id=scene_id,
+                summary_type=_SUMMARY_TYPE,
+                summary_text=summary_text,
+            )
+            session.add(row)
+            session.flush()
+            summary_id = row.id
+
+        session.commit()
+        return {
+            "content": [{"type": "text", "text": "summary saved"}],
+            "structuredContent": {"id": summary_id},
+            "is_error": False,
+        }
+    except Exception:
+        session.rollback()
+        logger.exception(
+            "write_summary failed for user_progress_id=%s scene_id=%s",
+            user_progress_id,
+            scene_id,
+        )
+        return _error(_GENERIC_WRITE_SUMMARY_ERROR_MESSAGE)
+    finally:
+        session.close()
+
+
+@tool(
+    name="write_summary",
+    description=(
+        "Persist a scene-level conversation summary for a student's "
+        "simulation run. Enforces one summary per (user_progress_id, "
+        "scene_id) pair: calling again with the same pair updates the "
+        "existing row. Raises ValueError for empty or whitespace-only "
+        "summary_text."
+    ),
+    input_schema={
+        "user_progress_id": int,
+        "scene_id": int,
+        "summary_text": str,
+    },
+)
+async def write_summary(args: dict[str, Any]) -> dict[str, Any]:
+    """MCP tool entry point for ``write_summary`` — see module docstring."""
+    try:
+        user_progress_id = args["user_progress_id"]
+        scene_id = args["scene_id"]
+        summary_text = args["summary_text"]
+
+        if not isinstance(summary_text, str) or not summary_text.strip():
+            raise ValueError("summary_text must be a non-empty string")
+
+        return await asyncio.to_thread(
+            _write_summary_sync,
+            user_progress_id,
+            scene_id,
+            summary_text,
+        )
+    except ValueError:
+        raise
+    except Exception:
+        logger.exception(
+            "write_summary failed for user_progress_id=%s scene_id=%s",
+            args.get("user_progress_id"),
+            args.get("scene_id"),
+        )
+        return _error(_GENERIC_WRITE_SUMMARY_ERROR_MESSAGE)
+
+
+__all__ = ["recall_memory", "write_summary"]

--- a/backend_v2/modules/simulation/mcp/memory_tools.py
+++ b/backend_v2/modules/simulation/mcp/memory_tools.py
@@ -48,7 +48,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from common.db.connection import SessionLocal
-from common.db.models import ConversationSummaries
+from common.db.models import ConversationSummaries, UserProgress
 from common.services import pgvector_store
 from common.services.embeddings_service import EmbeddingsService
 from modules.simulation import repository
@@ -230,10 +230,13 @@ def _write_summary_sync(
     factory = session_factory or SessionLocal
     session = factory()
     try:
+        session.get(UserProgress, user_progress_id, with_for_update=True)
+
         existing = session.execute(
             select(ConversationSummaries)
             .where(ConversationSummaries.user_progress_id == user_progress_id)
             .where(ConversationSummaries.scene_id == scene_id)
+            .where(ConversationSummaries.summary_type == _SUMMARY_TYPE)
         ).scalar_one_or_none()
 
         if existing is not None:

--- a/backend_v2/tests/modules/simulation/mcp/test_memory_tools_summary.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_memory_tools_summary.py
@@ -1,0 +1,205 @@
+"""Unit tests for the ``write_summary`` MCP tool (phase-2.5).
+
+Covers three ticket-required cases:
+
+* inserting a new ``conversation_summaries`` row,
+* updating an existing row for the same (user_progress_id, scene_id), and
+* rejecting empty / whitespace-only ``summary_text``.
+
+All tests run against the in-memory SQLite session from
+``tests/conftest.py``. A ``patched_session_factory`` fixture makes the
+tool reuse that session so commits land in the same transaction the test
+observes before teardown.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from common.db.models import (
+    ConversationSummaries,
+    Simulation,
+    SimulationScene,
+    User,
+    UserProgress,
+)
+from modules.simulation.mcp import memory_tools
+from modules.simulation.mcp.memory_tools import write_summary
+
+
+@pytest.fixture
+def patched_session_factory(db_session: Session):
+    """Route ``write_summary``'s DB work through the test's session."""
+
+    class _NoCloseSession:
+        def __init__(self, inner: Session) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str):
+            return getattr(self._inner, name)
+
+        def close(self) -> None:
+            pass
+
+        def commit(self) -> None:
+            self._inner.flush()
+
+        def rollback(self) -> None:
+            self._inner.rollback()
+
+    def factory() -> Session:  # type: ignore[return-value]
+        return _NoCloseSession(db_session)  # type: ignore[return-value]
+
+    with patch.object(memory_tools, "SessionLocal", factory):
+        yield factory
+
+
+@pytest.fixture
+def simulation(db_session: Session) -> Simulation:
+    user = User(
+        user_id="prof-summary",
+        email="prof-summary@example.com",
+        full_name="Phase 2.5 Professor",
+        username="prof-phase-2-5",
+        role="professor",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    sim = Simulation(
+        unique_id="sim-phase-2-5",
+        title="Phase 2.5 Sim",
+        description="Fixture simulation",
+        created_by=user.id,
+    )
+    db_session.add(sim)
+    db_session.flush()
+    return sim
+
+
+@pytest.fixture
+def scene(db_session: Session, simulation: Simulation) -> SimulationScene:
+    scene_row = SimulationScene(
+        simulation_id=simulation.id,
+        title="Scene 1",
+        description="",
+        scene_order=1,
+    )
+    db_session.add(scene_row)
+    db_session.flush()
+    return scene_row
+
+
+@pytest.fixture
+def user_progress(
+    db_session: Session, simulation: Simulation, scene: SimulationScene
+) -> UserProgress:
+    student = User(
+        user_id="stud-summary",
+        email="stud-summary@example.com",
+        full_name="Phase 2.5 Student",
+        username="stud-phase-2-5",
+        role="student",
+    )
+    db_session.add(student)
+    db_session.flush()
+
+    progress = UserProgress(
+        user_id=student.id,
+        simulation_id=simulation.id,
+        current_scene_id=scene.id,
+    )
+    db_session.add(progress)
+    db_session.flush()
+    return progress
+
+
+@pytest.mark.asyncio
+async def test_write_summary_inserts_new_row(
+    db_session: Session,
+    patched_session_factory,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A valid call creates a new ``conversation_summaries`` row."""
+    result = await write_summary.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "summary_text": "The student demonstrated strong analytical skills.",
+        }
+    )
+
+    assert result["is_error"] is False
+    assert result["content"][0]["text"] == "summary saved"
+
+    row = db_session.execute(
+        select(ConversationSummaries)
+        .where(ConversationSummaries.user_progress_id == user_progress.id)
+        .where(ConversationSummaries.scene_id == scene.id)
+    ).scalar_one()
+    assert row.summary_text == "The student demonstrated strong analytical skills."
+    assert row.summary_type == "scene"
+    assert result["structuredContent"]["id"] == row.id
+
+
+@pytest.mark.asyncio
+async def test_write_summary_updates_existing_row(
+    db_session: Session,
+    patched_session_factory,
+    scene: SimulationScene,
+    user_progress: UserProgress,
+) -> None:
+    """A second call for the same (user_progress, scene) updates in place."""
+    await write_summary.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "summary_text": "Original summary text.",
+        }
+    )
+
+    result = await write_summary.handler(
+        {
+            "user_progress_id": user_progress.id,
+            "scene_id": scene.id,
+            "summary_text": "Updated summary text.",
+        }
+    )
+
+    assert result["is_error"] is False
+
+    rows = db_session.execute(
+        select(ConversationSummaries)
+        .where(ConversationSummaries.user_progress_id == user_progress.id)
+        .where(ConversationSummaries.scene_id == scene.id)
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].summary_text == "Updated summary text."
+
+
+@pytest.mark.asyncio
+async def test_write_summary_rejects_empty_text(
+    patched_session_factory,
+) -> None:
+    """Empty and whitespace-only ``summary_text`` raises ``ValueError``."""
+    with pytest.raises(ValueError, match="non-empty"):
+        await write_summary.handler(
+            {
+                "user_progress_id": 1,
+                "scene_id": 1,
+                "summary_text": "",
+            }
+        )
+
+    with pytest.raises(ValueError, match="non-empty"):
+        await write_summary.handler(
+            {
+                "user_progress_id": 1,
+                "scene_id": 1,
+                "summary_text": "   \t\n  ",
+            }
+        )


### PR DESCRIPTION
## Summary
- Appends `write_summary(user_progress_id, scene_id, summary_text)` to `memory_tools.py`, inserting a `conversation_summaries` row with `summary_type="scene"`
- Enforces one summary per (user_progress, scene) — second call updates the existing row via application-level upsert
- Rejects empty/whitespace-only `summary_text` with `ValueError`

Fixes #439

## Test plan
- [x] `uv run pytest tests/modules/simulation/mcp/test_memory_tools_summary.py -q` — 3 passed
- [x] `test_write_summary_inserts_new_row` — verifies new row creation with correct fields
- [x] `test_write_summary_updates_existing_row` — confirms idempotent upsert (row count stays 1)
- [x] `test_write_summary_rejects_empty_text` — checks ValueError for empty and whitespace strings
- [x] Combined coverage with recall_memory tests: 94% (`--cov=modules.simulation.mcp.memory_tools`)
- [ ] CodeRabbit passes (or all comments addressed / replied)
- [ ] Railway experimental deploy green (post-merge)

> **Note:** The ticket's verification command (`test_memory_tools_summary.py --cov-fail-under=85`) structurally cannot reach 85% when measured against the full `memory_tools.py` file (which also contains `recall_memory`). Running both test files together yields 94% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can save and update conversation summaries per scene; empty or whitespace-only summaries are rejected.
  * Saves performed safely to avoid duplicate entries and return a confirmation with the saved summary id.

* **Tests**
  * Added comprehensive tests covering create, update, and validation behaviors of the summary feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->