### PR TITLE
phase-2.06: MCP extraction tools for personas, scenes, objectives

### DIFF
--- a/backend_v2/modules/simulation/mcp/__init__.py
+++ b/backend_v2/modules/simulation/mcp/__init__.py
@@ -1,4 +1,14 @@
 """MCP tools exposed by the simulation module."""
+from modules.simulation.mcp.extraction_tools import (
+    extract_objectives,
+    extract_personas,
+    extract_scenes,
+)
 from modules.simulation.mcp.memory_tools import recall_memory
 
-__all__ = ["recall_memory"]
+__all__ = [
+    "extract_objectives",
+    "extract_personas",
+    "extract_scenes",
+    "recall_memory",
+]

--- a/backend_v2/modules/simulation/mcp/extraction_tools.py
+++ b/backend_v2/modules/simulation/mcp/extraction_tools.py
@@ -1,0 +1,160 @@
+"""MCP tools for extracting personas, scenes, and objectives from Claude output.
+
+Each tool receives a string (typically a Claude response containing JSON),
+extracts the JSON payload, validates it against the appropriate Pydantic
+schema, and returns the result in an MCP envelope.  The tools themselves
+make no LLM calls — they are pure parsers/validators invoked by the
+extraction orchestrator (phase-4.3).
+
+Contract (all three tools):
+
+* Input:  ``{"pdf_text": "<claude response containing JSON>"}``
+* Success: ``{"content": [{"type": "text", "text": "<json>"}], "is_error": False}``
+* Failure: ``{"content": [{"type": "text", "text": "<message>"}], "is_error": True}``
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from claude_agent_sdk import tool
+from pydantic import ValidationError
+
+from modules.simulation.mcp.schemas import (
+    PersonaExtractionResult,
+    SceneSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+_JSON_OBJECT_RE = re.compile(r"(\{[\s\S]*\})")
+_JSON_ARRAY_RE = re.compile(r"(\[[\s\S]*\])")
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Remove optional markdown code fences wrapping JSON."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        first_newline = stripped.find("\n")
+        if first_newline != -1:
+            stripped = stripped[first_newline + 1 :]
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    return stripped.strip()
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    """Extract the first JSON object from *text*."""
+    cleaned = _strip_markdown_fences(text)
+    match = _JSON_OBJECT_RE.search(cleaned)
+    if not match:
+        raise ValueError("No JSON object found in input")
+    return json.loads(match.group(1))
+
+
+def _extract_json_array(text: str) -> list[Any]:
+    """Extract the first JSON array from *text*."""
+    cleaned = _strip_markdown_fences(text)
+    match = _JSON_ARRAY_RE.search(cleaned)
+    if not match:
+        raise ValueError("No JSON array found in input")
+    return json.loads(match.group(1))
+
+
+def _success(data: Any) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": json.dumps(data, default=str)}],
+        "is_error": False,
+    }
+
+
+def _error(message: str) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": message}],
+        "is_error": True,
+    }
+
+
+@tool(
+    name="extract_personas",
+    description=(
+        "Parse and validate a persona-extraction JSON blob produced by "
+        "Claude. Returns a list of validated persona objects in an MCP "
+        "envelope, or is_error=True on malformed/invalid input."
+    ),
+    input_schema={"pdf_text": str},
+)
+async def extract_personas(args: dict[str, Any]) -> dict[str, Any]:
+    """Parse persona JSON, validate against PersonaExtractionResult."""
+    try:
+        pdf_text = args.get("pdf_text", "")
+        raw = _extract_json_object(pdf_text)
+        result = PersonaExtractionResult.model_validate(raw)
+        return _success(
+            [p.model_dump(exclude_none=True) for p in result.key_figures]
+        )
+    except ValidationError as exc:
+        logger.debug("extract_personas validation error: %s", exc)
+        return _error(f"Validation error: {exc}")
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.debug("extract_personas JSON error: %s", exc)
+        return _error(f"Invalid JSON: {exc}")
+
+
+@tool(
+    name="extract_scenes",
+    description=(
+        "Parse and validate a scene-extraction JSON array produced by "
+        "Claude. Returns scenes sorted by sequence_order in an MCP "
+        "envelope, or is_error=True on malformed/invalid input."
+    ),
+    input_schema={"pdf_text": str},
+)
+async def extract_scenes(args: dict[str, Any]) -> dict[str, Any]:
+    """Parse scene JSON array, validate each against SceneSchema, sort."""
+    try:
+        pdf_text = args.get("pdf_text", "")
+        raw_list = _extract_json_array(pdf_text)
+        scenes = [SceneSchema.model_validate(item) for item in raw_list]
+        scenes.sort(key=lambda s: s.sequence_order)
+        return _success(
+            [s.model_dump(exclude_none=True) for s in scenes]
+        )
+    except ValidationError as exc:
+        logger.debug("extract_scenes validation error: %s", exc)
+        return _error(f"Validation error: {exc}")
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.debug("extract_scenes JSON error: %s", exc)
+        return _error(f"Invalid JSON: {exc}")
+
+
+@tool(
+    name="extract_objectives",
+    description=(
+        "Parse and validate a learning-objectives JSON array produced by "
+        "Claude. Returns a list of objective strings in an MCP envelope, "
+        "or is_error=True on malformed/invalid input."
+    ),
+    input_schema={"pdf_text": str},
+)
+async def extract_objectives(args: dict[str, Any]) -> dict[str, Any]:
+    """Parse objectives JSON array, validate as list of non-empty strings."""
+    try:
+        pdf_text = args.get("pdf_text", "")
+        raw_list = _extract_json_array(pdf_text)
+        if not isinstance(raw_list, list):
+            return _error("Expected a JSON array of strings")
+        for i, item in enumerate(raw_list):
+            if not isinstance(item, str):
+                return _error(
+                    f"Item at index {i} is {type(item).__name__}, expected str"
+                )
+        return _success(raw_list)
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.debug("extract_objectives JSON error: %s", exc)
+        return _error(f"Invalid JSON: {exc}")
+
+
+__all__ = ["extract_personas", "extract_scenes", "extract_objectives"]

--- a/backend_v2/modules/simulation/mcp/extraction_tools.py
+++ b/backend_v2/modules/simulation/mcp/extraction_tools.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any
 
 from claude_agent_sdk import tool
@@ -28,9 +27,6 @@ from modules.simulation.mcp.schemas import (
 )
 
 logger = logging.getLogger(__name__)
-
-_JSON_OBJECT_RE = re.compile(r"(\{[\s\S]*\})")
-_JSON_ARRAY_RE = re.compile(r"(\[[\s\S]*\])")
 
 
 def _strip_markdown_fences(text: str) -> str:
@@ -45,22 +41,35 @@ def _strip_markdown_fences(text: str) -> str:
     return stripped.strip()
 
 
+def _extract_first_json_value(text: str, opening_char: str) -> Any:
+    cleaned = _strip_markdown_fences(text)
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(cleaned):
+        if ch != opening_char:
+            continue
+        try:
+            value, _ = decoder.raw_decode(cleaned[idx:])
+        except json.JSONDecodeError:
+            continue
+        return value
+    kind = "object" if opening_char == "{" else "array"
+    raise ValueError(f"No JSON {kind} found in input")
+
+
 def _extract_json_object(text: str) -> dict[str, Any]:
     """Extract the first JSON object from *text*."""
-    cleaned = _strip_markdown_fences(text)
-    match = _JSON_OBJECT_RE.search(cleaned)
-    if not match:
+    value = _extract_first_json_value(text, "{")
+    if not isinstance(value, dict):
         raise ValueError("No JSON object found in input")
-    return json.loads(match.group(1))
+    return value
 
 
 def _extract_json_array(text: str) -> list[Any]:
     """Extract the first JSON array from *text*."""
-    cleaned = _strip_markdown_fences(text)
-    match = _JSON_ARRAY_RE.search(cleaned)
-    if not match:
+    value = _extract_first_json_value(text, "[")
+    if not isinstance(value, list):
         raise ValueError("No JSON array found in input")
-    return json.loads(match.group(1))
+    return value
 
 
 def _success(data: Any) -> dict[str, Any]:

--- a/backend_v2/modules/simulation/mcp/schemas.py
+++ b/backend_v2/modules/simulation/mcp/schemas.py
@@ -1,0 +1,48 @@
+"""Pydantic v2 schemas for MCP extraction tool validation.
+
+These schemas reflect the full JSON structures produced by Claude when
+extracting personas, scenes, and learning objectives from a case-study PDF.
+They are intentionally separate from the legacy ``backend/`` schemas to
+give the v2 architecture a clean slate.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PersonaSchema(BaseModel):
+    """A single persona extracted from a case-study PDF."""
+
+    name: str
+    role: str
+    background: Optional[str] = None
+    current_context: Optional[str] = None
+    correlation: Optional[str] = None
+    personality_traits: Optional[dict[str, int]] = None
+    primary_goals: Optional[list[str]] = None
+    knowledge_areas: Optional[list[str]] = None
+    communication_style: Optional[str] = None
+    is_main_character: Optional[bool] = None
+
+
+class PersonaExtractionResult(BaseModel):
+    """Full envelope returned by the persona extraction prompt."""
+
+    title: str
+    description: str
+    student_role: str
+    key_figures: list[PersonaSchema]
+
+
+class SceneSchema(BaseModel):
+    """A single scene extracted from a case-study PDF."""
+
+    title: str
+    description: str
+    personas_involved: Optional[list[str]] = None
+    user_goal: Optional[str] = None
+    goal: Optional[str] = None
+    success_metric: Optional[str] = None
+    sequence_order: int = Field(ge=0)

--- a/backend_v2/tests/modules/simulation/mcp/test_extraction_tools.py
+++ b/backend_v2/tests/modules/simulation/mcp/test_extraction_tools.py
@@ -1,0 +1,263 @@
+"""Unit tests for the MCP extraction tools (phase-2.6).
+
+All three tools are pure parsers — no external dependencies to mock.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from modules.simulation.mcp.extraction_tools import (
+    extract_objectives,
+    extract_personas,
+    extract_scenes,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — reusable valid payloads
+# ---------------------------------------------------------------------------
+
+VALID_PERSONA_PAYLOAD = {
+    "title": "Global Supply Chain Crisis",
+    "description": "A simulation about logistics management",
+    "student_role": "Operations Manager",
+    "key_figures": [
+        {
+            "name": "Alice Chen",
+            "role": "VP of Logistics",
+            "background": "20 years in supply chain",
+            "current_context": "Managing disrupted routes",
+            "correlation": "Direct report to student",
+            "personality_traits": {
+                "analytical": 8,
+                "creative": 5,
+                "assertive": 7,
+            },
+            "primary_goals": ["Reduce costs", "Maintain SLA"],
+            "knowledge_areas": ["Logistics", "Procurement"],
+            "communication_style": "Direct and data-driven",
+            "is_main_character": True,
+        },
+        {
+            "name": "Bob Martinez",
+            "role": "Warehouse Manager",
+            "background": "10 years warehouse ops",
+            "primary_goals": ["Optimize throughput"],
+        },
+    ],
+}
+
+VALID_SCENES = [
+    {
+        "title": "Scene 2: Escalation",
+        "description": "Things get worse",
+        "personas_involved": ["Alice Chen"],
+        "user_goal": "De-escalate",
+        "goal": "Resolve the conflict",
+        "success_metric": "Tension reduced",
+        "sequence_order": 2,
+    },
+    {
+        "title": "Scene 1: Introduction",
+        "description": "Meet the team",
+        "personas_involved": ["Alice Chen", "Bob Martinez"],
+        "user_goal": "Learn the situation",
+        "goal": "Understand the crisis",
+        "success_metric": "Asked 3 questions",
+        "sequence_order": 1,
+    },
+]
+
+VALID_OBJECTIVES = [
+    "Understand supply chain risk management",
+    "Apply negotiation techniques in high-pressure scenarios",
+    "Evaluate trade-offs between cost and service level",
+]
+
+
+# ---------------------------------------------------------------------------
+# extract_personas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_parses_valid_json():
+    result = await extract_personas.handler(
+        {"pdf_text": json.dumps(VALID_PERSONA_PAYLOAD)}
+    )
+    assert result["is_error"] is False
+    personas = json.loads(result["content"][0]["text"])
+    assert len(personas) == 2
+    assert personas[0]["name"] == "Alice Chen"
+    assert personas[1]["name"] == "Bob Martinez"
+    assert personas[0]["personality_traits"]["analytical"] == 8
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_returns_error_on_malformed_json():
+    result = await extract_personas.handler({"pdf_text": "{ broken json !!!"})
+    assert result["is_error"] is True
+    assert "Invalid JSON" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_handles_markdown_fences():
+    fenced = "```json\n" + json.dumps(VALID_PERSONA_PAYLOAD) + "\n```"
+    result = await extract_personas.handler({"pdf_text": fenced})
+    assert result["is_error"] is False
+    personas = json.loads(result["content"][0]["text"])
+    assert len(personas) == 2
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_validation_error_missing_required():
+    incomplete = {"title": "X", "description": "Y"}
+    result = await extract_personas.handler({"pdf_text": json.dumps(incomplete)})
+    assert result["is_error"] is True
+    assert "Validation error" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_empty_input():
+    result = await extract_personas.handler({"pdf_text": ""})
+    assert result["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_extract_personas_optional_fields_omitted():
+    minimal = {
+        "title": "T",
+        "description": "D",
+        "student_role": "S",
+        "key_figures": [{"name": "A", "role": "R"}],
+    }
+    result = await extract_personas.handler({"pdf_text": json.dumps(minimal)})
+    assert result["is_error"] is False
+    personas = json.loads(result["content"][0]["text"])
+    assert personas[0] == {"name": "A", "role": "R"}
+
+
+# ---------------------------------------------------------------------------
+# extract_scenes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_returns_ordered_list():
+    result = await extract_scenes.handler({"pdf_text": json.dumps(VALID_SCENES)})
+    assert result["is_error"] is False
+    scenes = json.loads(result["content"][0]["text"])
+    assert scenes[0]["sequence_order"] == 1
+    assert scenes[1]["sequence_order"] == 2
+    assert scenes[0]["title"] == "Scene 1: Introduction"
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_parses_valid_array():
+    single = [
+        {
+            "title": "S1",
+            "description": "D",
+            "sequence_order": 0,
+        }
+    ]
+    result = await extract_scenes.handler({"pdf_text": json.dumps(single)})
+    assert result["is_error"] is False
+    scenes = json.loads(result["content"][0]["text"])
+    assert len(scenes) == 1
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_returns_error_on_malformed_json():
+    result = await extract_scenes.handler({"pdf_text": "[{bad"})
+    assert result["is_error"] is True
+    assert "Invalid JSON" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_validation_error_missing_title():
+    bad_scene = [{"description": "D", "sequence_order": 1}]
+    result = await extract_scenes.handler({"pdf_text": json.dumps(bad_scene)})
+    assert result["is_error"] is True
+    assert "Validation error" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_empty_array():
+    result = await extract_scenes.handler({"pdf_text": "[]"})
+    assert result["is_error"] is False
+    scenes = json.loads(result["content"][0]["text"])
+    assert scenes == []
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_negative_sequence_order():
+    bad = [{"title": "T", "description": "D", "sequence_order": -1}]
+    result = await extract_scenes.handler({"pdf_text": json.dumps(bad)})
+    assert result["is_error"] is True
+    assert "Validation error" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_scenes_handles_markdown_fences():
+    fenced = "```json\n" + json.dumps(VALID_SCENES) + "\n```"
+    result = await extract_scenes.handler({"pdf_text": fenced})
+    assert result["is_error"] is False
+    scenes = json.loads(result["content"][0]["text"])
+    assert len(scenes) == 2
+
+
+# ---------------------------------------------------------------------------
+# extract_objectives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_validates_schema():
+    result = await extract_objectives.handler(
+        {"pdf_text": json.dumps(VALID_OBJECTIVES)}
+    )
+    assert result["is_error"] is False
+    objectives = json.loads(result["content"][0]["text"])
+    assert objectives == VALID_OBJECTIVES
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_returns_error_on_non_string_items():
+    mixed = ["valid", 42, "also valid"]
+    result = await extract_objectives.handler({"pdf_text": json.dumps(mixed)})
+    assert result["is_error"] is True
+    assert "index 1" in result["content"][0]["text"]
+    assert "int" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_returns_error_on_malformed_json():
+    result = await extract_objectives.handler({"pdf_text": "not json at all"})
+    assert result["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_empty_array():
+    result = await extract_objectives.handler({"pdf_text": "[]"})
+    assert result["is_error"] is False
+    objectives = json.loads(result["content"][0]["text"])
+    assert objectives == []
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_handles_markdown_fences():
+    fenced = "```\n" + json.dumps(VALID_OBJECTIVES) + "\n```"
+    result = await extract_objectives.handler({"pdf_text": fenced})
+    assert result["is_error"] is False
+    objectives = json.loads(result["content"][0]["text"])
+    assert len(objectives) == 3
+
+
+@pytest.mark.asyncio
+async def test_extract_objectives_nested_objects_rejected():
+    bad = [{"not": "a string"}]
+    result = await extract_objectives.handler({"pdf_text": json.dumps(bad)})
+    assert result["is_error"] is True
+    assert "dict" in result["content"][0]["text"]


### PR DESCRIPTION
## Summary

Fixes #440

- Add three `@tool` MCP functions (`extract_personas`, `extract_scenes`, `extract_objectives`) that parse JSON from Claude responses, validate against Pydantic v2 schemas, and return MCP envelopes
- Add `PersonaSchema`, `PersonaExtractionResult`, and `SceneSchema` Pydantic v2 models in a new `schemas.py`
- Tools are pure parsers (no LLM calls) — they strip markdown fences, extract JSON, validate, and return `is_error=True` on failure

## Test plan

- [x] `test_extract_personas_parses_valid_json` — valid nested JSON with `key_figures` returns parsed persona list
- [x] `test_extract_personas_returns_error_on_malformed_json` — broken JSON returns `is_error=True`
- [x] `test_extract_personas_handles_markdown_fences` — JSON in ` ```json ``` ` fences is handled
- [x] `test_extract_personas_validation_error_missing_required` — missing required fields returns validation error
- [x] `test_extract_personas_empty_input` — empty string returns error
- [x] `test_extract_personas_optional_fields_omitted` — minimal valid payload works
- [x] `test_extract_scenes_returns_ordered_list` — out-of-order scenes sorted by `sequence_order`
- [x] `test_extract_scenes_parses_valid_array` — single scene array parses correctly
- [x] `test_extract_scenes_returns_error_on_malformed_json` — broken JSON returns error
- [x] `test_extract_scenes_validation_error_missing_title` — missing `title` returns validation error
- [x] `test_extract_scenes_empty_array` — empty array returns success with `[]`
- [x] `test_extract_scenes_negative_sequence_order` — negative `sequence_order` returns validation error
- [x] `test_extract_scenes_handles_markdown_fences` — fenced JSON handled
- [x] `test_extract_objectives_validates_schema` — valid string array returns parsed list
- [x] `test_extract_objectives_returns_error_on_non_string_items` — non-string items return error
- [x] `test_extract_objectives_returns_error_on_malformed_json` — broken JSON returns error
- [x] `test_extract_objectives_empty_array` — empty array returns success
- [x] `test_extract_objectives_handles_markdown_fences` — fenced JSON handled
- [x] `test_extract_objectives_nested_objects_rejected` — objects in array return error

### Verification gate
```
cd backend_v2 && uv run pytest tests/modules/simulation/mcp/test_extraction_tools.py -q \
  --cov=modules.simulation.mcp.extraction_tools --cov-fail-under=85
```
**Result:** 19 passed, 99% coverage (note: the `--cov` flag requires dotted module path, not slash path, for pytest-cov to resolve the source)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three extraction tools to parse and validate personas, scenes, and objectives from generated content, normalizing outputs and providing clear validation feedback.
  * Introduced structured schemas to enforce expected fields and constraints (including non-negative ordering for scenes).

* **Tests**
  * Added comprehensive async tests covering successful extraction, fenced JSON handling, empty inputs, malformed JSON, and validation error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->