### PR TITLE
feat: improve formatRelativeDate with hours and years support

### DIFF
--- a/frontend/lib/date-utils.ts
+++ b/frontend/lib/date-utils.ts
@@ -6,13 +6,16 @@ export function formatRelativeDate(dateString: string): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
-  if (diffDays === 0) return "Today"
+  if (diffHours < 1) return "Just now"
+  if (diffHours < 24) return `${diffHours} hours ago`
   if (diffDays === 1) return "Yesterday"
   if (diffDays < 7) return `${diffDays} days ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-  return date.toLocaleDateString()
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
+  return `${Math.floor(diffDays / 365)} years ago`
 }
 
 export function formatFullDate(dateString: string): string {


### PR DESCRIPTION
## Summary

Extends `formatRelativeDate` in `frontend/lib/date-utils.ts` to handle sub-day granularity and long-past dates:

- Adds **hours ago** for timestamps within the last 24 hours
- Adds **months ago** for timestamps between 30–365 days
- Adds **years ago** for timestamps over a year old
- Shortens the weeks format from `X weeks ago` to `Xw ago`

## Conflict note

This PR modifies `formatRelativeDate` — `experimental-v2` has also received a different improvement to the same function (minutes precision + en-GB locale). These two changes conflict and will need to be resolved before merging.

## Test plan

- [ ] `formatRelativeDate` for a timestamp 30 minutes ago → `"Just now"` ... wait, that's the other branch. Check hours logic.
- [ ] Timestamp 3 hours ago → `"3 hours ago"`
- [ ] Timestamp 400 days ago → `"1 years ago"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative date formatting for clarity: very recent items show "Just now" (under 1 hour), items under 24 hours show exact hour counts (e.g., "5 hours ago"), multi-day ranges use abbreviated week labels for weeks under 30 days (e.g., "2w ago"), and older dates use month/year abbreviations (e.g., "3 months ago", "1 year ago").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->