### PR TITLE
feat(ralph-loop): Phase E post-merge Railway deploy verification

### DIFF
--- a/backend/modules/admin/ralph_pipeline_router.py
+++ b/backend/modules/admin/ralph_pipeline_router.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/admin/ralph-pipeline", tags=["Admin - Ralph Pipeline"])
 
 # Phases in the order they appear in the grid.
-PHASES: List[str] = ["A-implement", "B-review", "C-testing", "D-merge", "E-canny"]
+PHASES: List[str] = ["A-implement", "B-review", "C-testing", "D-merge", "E-deploy-verify", "E-canny"]
 
 # In-process fan-out for SSE /stream. Every POST /event pushes into every
 # active subscriber's queue. Lightweight — single-process only, which is

--- a/frontend/components/admin/RalphPipelineGrid.tsx
+++ b/frontend/components/admin/RalphPipelineGrid.tsx
@@ -86,14 +86,15 @@ interface StreamEvent {
 // Constants — phase order + palette
 // ---------------------------------------------------------------------------
 const GH_REPO_URL = "https://github.com/Hendrik040/n-aible_edtech_sims"
-const PHASES = ["A-implement", "B-review", "C-testing", "D-merge", "E-canny"] as const
+const PHASES = ["A-implement", "B-review", "C-testing", "D-merge", "E-deploy-verify", "E-canny"] as const
 type PhaseName = typeof PHASES[number]
 const PHASE_SHORT: Record<PhaseName, string> = {
-  "A-implement": "A",
-  "B-review":    "B",
-  "C-testing":   "C",
-  "D-merge":     "D",
-  "E-canny":     "E",
+  "A-implement":     "A",
+  "B-review":        "B",
+  "C-testing":       "C",
+  "D-merge":         "D",
+  "E-deploy-verify": "E",
+  "E-canny":         "F",
 }
 const TOTAL_TICKETS = 22
 
@@ -120,6 +121,11 @@ const PHASE_INFO: Record<PhaseName, { title: string; detail: string }> = {
     title: "Wait for CI, then auto-merge",
     detail:
       "Polls the PR's check-suite until green, then `gh pr merge --squash --delete-branch`. Passed = merge succeeded (green CI). Failed = CI not green after poll budget exhausted.",
+  },
+  "E-deploy-verify": {
+    title: "Post-merge deploy check",
+    detail:
+      "Invokes the `railway-deploy-check` skill against the experimental environment after merge. Passed = health endpoint green and no error patterns in logs. Failed = deploy came up unhealthy or logs show a startup/runtime error (advisory — does not block next iteration).",
   },
   "E-canny": {
     title: "Post to Canny (optional)",

--- a/frontend/components/admin/RalphPipelineGrid.tsx
+++ b/frontend/components/admin/RalphPipelineGrid.tsx
@@ -426,7 +426,7 @@ export default function RalphPipelineGrid({ refreshKey = 0 }: RalphPipelineGridP
           ) : (
             <pre className="text-[13px] leading-6 overflow-x-auto bg-stone-950 border border-stone-800 rounded p-3 text-stone-200">
               <div className="text-stone-500 border-b border-stone-800 pb-1 mb-1">
-                {"  ticket      A   B   C   D   E    PR      state"}
+                {"  ticket      A   B   C   D   E   F    PR      state"}
               </div>
               {sortedTickets.map((t) => (
                 <div key={t.ticket_id} className="flex items-center gap-0 whitespace-pre">

--- a/scripts/rewrite/ralph-rewrite-loop.sh
+++ b/scripts/rewrite/ralph-rewrite-loop.sh
@@ -229,6 +229,36 @@ phase_merge() {
   return 1
 }
 
+# Phase E: verify the post-merge Railway deploy on experimental. Runs
+# only after a successful merge — the merge itself already happened,
+# so this is advisory: a red deploy surfaces via the dashboard but
+# does not block the iteration ending.
+phase_verify_deploy() {
+  local work_dir=$1 issue_num=$2 ticket_id=$3 pr_num=$4
+  local prompt_file="${LOG_DIR}/prompt_${ticket_id}_deploy.md"
+  local run_log="${LOG_DIR}/deploy_${ticket_id}_iter${ITER}.log"
+
+  export TICKET_ID="$ticket_id" ISSUE_NUM="$issue_num" PR_NUM="$pr_num" \
+         BASE_BRANCH GH_REPO
+  render_prompt "${PROMPTS_DIR}/verify-deploy.md" > "$prompt_file"
+
+  local start; start=$(date +%s)
+  PR_NUM="$pr_num" emit_event "E-deploy-verify" "started"
+  log "  → invoking Claude for post-merge deploy check (log: $(basename "$run_log"))"
+  run_claude_in "$work_dir" "$prompt_file" "$run_log" >/dev/null
+
+  local dur=$(( $(date +%s) - start ))
+  if grep -q '^DEPLOY_VERIFIED' "$run_log"; then
+    log "  ✅ DEPLOY_VERIFIED"
+    PR_NUM="$pr_num" emit_event "E-deploy-verify" "passed" "" "$dur"
+    return 0
+  fi
+  local reason; reason=$(grep -oE '^DEPLOY_FAILED:.*' "$run_log" | head -1)
+  log "  ⚠ ${reason:-deploy did not report verified}"
+  PR_NUM="$pr_num" emit_event "E-deploy-verify" "failed" "${reason:-deploy did not report verified}" "$dur"
+  return 1
+}
+
 # ============================================================================
 # Main loop
 # ============================================================================
@@ -313,7 +343,16 @@ for ITER in $(seq 1 "$ITERATIONS"); do
   fi
 
   # --- Phase D: CI gate + merge -------------------------------------------
-  phase_merge "$PR_NUM" || log "  PR #${PR_NUM} left open (CI red)"
+  if phase_merge "$PR_NUM"; then
+    # --- Phase E: post-merge deploy verification (advisory) --------------
+    # Runs only on successful merge. Failure here surfaces to the
+    # dashboard and leaves a PR comment, but does not block the next
+    # iteration — the merge itself already happened.
+    phase_verify_deploy "$WORK_DIR" "$ISSUE_NUM" "$TICKET_ID" "$PR_NUM" \
+      || log "  post-merge deploy check failed — see PR comment + dashboard"
+  else
+    log "  PR #${PR_NUM} left open (CI red) — skipping Phase E"
+  fi
 
   worktree_cleanup "$WORK_DIR"; WORK_DIR=""
   log "─── iteration ${ITER} done ─────────────────────────────────────"

--- a/scripts/rewrite/resources/prompts/verify-deploy.md
+++ b/scripts/rewrite/resources/prompts/verify-deploy.md
@@ -29,7 +29,7 @@ The skill will:
    - Summarize the failure (log line or health-check status).
    - Post a comment on PR #{{PR_NUM}} with the failure summary so
      whoever triages has immediate context:
-     ```
+     ```bash
      gh pr comment {{PR_NUM}} --repo {{GH_REPO}} \
        --body "Post-merge deploy verification failed: <short reason>. See logs."
      ```

--- a/scripts/rewrite/resources/prompts/verify-deploy.md
+++ b/scripts/rewrite/resources/prompts/verify-deploy.md
@@ -1,0 +1,56 @@
+PR #{{PR_NUM}} for ticket **{{TICKET_ID}}** (issue #{{ISSUE_NUM}}) has
+just been squash-merged into `{{BASE_BRANCH}}`. Railway auto-deploys
+`{{BASE_BRANCH}}` to the **experimental** environment. Your job is to
+confirm that deploy came up healthy and that the merge didn't break
+the backend at runtime.
+
+This runs **after** merge, so a failure here does not block the merge
+— but it does mean a human should triage before the next iteration.
+
+## The skill to run
+
+Use the **railway-deploy-check** skill. Invoke it by asking to verify
+the experimental Railway deploy after merging PR #{{PR_NUM}}.
+
+The skill will:
+- Confirm the Railway CLI is authed (`railway whoami`). If not, follow
+  its auth-recovery reference — do **not** improvise.
+- Link the project to `experimental` / `Backend` non-interactively.
+- Pull recent logs and look for startup error patterns (`Traceback`,
+  `ImportError`, `ModuleNotFoundError`, `sqlalchemy.exc`,
+  `alembic.*ERROR`, `FATAL`, `ERROR.*startup`).
+- Hit the backend health endpoint and check for HTTP 200.
+
+## Workflow
+
+1. Invoke the skill.
+2. If the skill reports healthy deploy → print the verdict below.
+3. If the skill surfaces errors:
+   - Summarize the failure (log line or health-check status).
+   - Post a comment on PR #{{PR_NUM}} with the failure summary so
+     whoever triages has immediate context:
+     ```
+     gh pr comment {{PR_NUM}} --repo {{GH_REPO}} \
+       --body "Post-merge deploy verification failed: <short reason>. See logs."
+     ```
+   - Print the failure verdict. Do **not** try to fix-forward here;
+     the next iteration will pick up from merged `{{BASE_BRANCH}}`.
+
+## Output the verdict (the loop reads this)
+
+At the very end of your output, print exactly **one** of:
+
+- `DEPLOY_VERIFIED` — health endpoint green and no error patterns in
+  recent logs.
+- `DEPLOY_FAILED: <short reason>` — deploy came up unhealthy or logs
+  show a startup/runtime error.
+
+## Hard rules
+
+- Never touch `staging-v2` or `production-v3` — only read from
+  `experimental`.
+- The merge has already happened; do not attempt to revert, reset, or
+  force-push anything. If the deploy is broken, surface it and stop.
+- Railway auth tokens expire silently. If `railway whoami` fails, the
+  skill's auth-recovery reference is the only sanctioned path — don't
+  prompt the user inline from this phase.


### PR DESCRIPTION
## Summary
- Adds Phase E (`E-deploy-verify`) to the rewrite Ralph loop: after `D-merge` succeeds, invokes the `railway-deploy-check` skill against the experimental environment and reports to the admin dashboard.
- Advisory only — a red deploy surfaces via dashboard + PR comment but does not block the next iteration (merge already happened).
- Dashboard change is surgical: inserts one column between `D-merge` and `E-canny`. Historic `E-canny` events continue to render; Canny short-label shifts `E`→`F`.
- No DB migration (phase column is free-string).

## Files changed
- `scripts/rewrite/resources/prompts/verify-deploy.md` (new)
- `scripts/rewrite/ralph-rewrite-loop.sh` — new `phase_verify_deploy()` function + gated call after successful merge
- `backend/modules/admin/ralph_pipeline_router.py` — one-line insert into `PHASES`
- `frontend/components/admin/RalphPipelineGrid.tsx` — matching insert in PHASES tuple + `PHASE_SHORT` + `PHASE_INFO`

## Test plan
- [ ] `scripts/rewrite/ralph-rewrite-loop.sh --iterations 0` exits cleanly (dry mode)
- [ ] Single-ticket run (`--iterations 1 --ticket <id>`) produces `scripts/rewrite/logs/deploy_<ticket>_iter1.log` containing `DEPLOY_VERIFIED` or `DEPLOY_FAILED:`
- [ ] Dashboard renders the new column with no layout breakage on existing tickets
- [ ] An event with `phase=E-deploy-verify` flows end-to-end to the grid
- [ ] `E-canny` column still renders historic Canny events (backfill + legacy logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated post-merge "deploy verification" phase in the pipeline. After merge, the system runs health checks and marks tickets with a verification status visible in pipeline views and stats.
  * Verification failures are advisory (do not block the pipeline), are logged, and can post a short failure comment on the related PR. UI labels updated to show the extra phase column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->