### PR TITLE
fix: resolve merge conflict — combine minutes precision and hours/years support

### DIFF
--- a/frontend/lib/date-utils.ts
+++ b/frontend/lib/date-utils.ts
@@ -6,13 +6,16 @@ export function formatRelativeDate(dateString: string): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
-  if (diffDays === 0) return "Today"
+  if (diffHours < 1) return "Just now"
+  if (diffHours < 24) return `${diffHours} hours ago`
   if (diffDays === 1) return "Yesterday"
   if (diffDays < 7) return `${diffDays} days ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-  return date.toLocaleDateString()
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
+  return `${Math.floor(diffDays / 365)} years ago`
 }
 
 export function formatFullDate(dateString: string): string {

--- a/frontend/lib/date-utils.ts
+++ b/frontend/lib/date-utils.ts
@@ -6,13 +6,15 @@ export function formatRelativeDate(dateString: string): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / (1000 * 60))
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
+  if (diffMins < 5) return "Just now"
+  if (diffMins < 60) return `${diffMins} min ago`
   if (diffDays === 0) return "Today"
   if (diffDays === 1) return "Yesterday"
-  if (diffDays < 7) return `${diffDays} days ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-  return date.toLocaleDateString()
+  if (diffDays < 14) return `${diffDays} days ago`
+  return date.toLocaleDateString("en-GB")
 }
 
 export function formatFullDate(dateString: string): string {


### PR DESCRIPTION
## Summary

- Merges \`demo/feature-minutes\` (minutes precision) with \`demo/feature-hours\` (hours, months, years display)
- Resolves conflict in \`frontend/lib/date-utils.ts\` \`formatRelativeDate\` by combining both sets of improvements

## Resolution approach

Both branches improved \`formatRelativeDate\` independently from the same base:

| Branch | Change |
|---|---|
| \`feature-minutes\` | Added \`min ago\` / \`Just now\` for sub-hour precision |
| \`feature-hours\` | Added \`hours ago\`, \`months ago\`, \`years ago\` |

The resolved version keeps all granularity levels: **< 5 min → Just now → min ago → hours ago → days/weeks/months/years**.

## Test plan
- [ ] < 5 min ago → `"Just now"`
- [ ] 30 min ago → `"30 min ago"`
- [ ] 3 hours ago → `"3 hours ago"`
- [ ] 2 days ago → `"2 days ago"`
- [ ] 3 weeks ago → `"3w ago"`
- [ ] 2 months ago → `"2 months ago"`
- [ ] 400 days ago → `"1 years ago"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced relative date formatting with more granular time displays, now showing "Just now," minute-level precision, hour-level precision, week-based format, and explicit month and year strings for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->