### PR TITLE
feat(ECS-64): add invite token generation and bound retry loops

### DIFF
--- a/backend/common/utils/id_generator.py
+++ b/backend/common/utils/id_generator.py
@@ -4,7 +4,10 @@ ID generation utilities
 import uuid
 import secrets
 from sqlalchemy.orm import Session
-from common.db.models import User, Simulation
+from common.db.models import User, Simulation, CohortInvitation, CohortInvite
+
+_MAX_RETRIES = 100
+
 
 def generate_unique_user_id(db: Session, role: str) -> str:
     """
@@ -12,17 +15,12 @@ def generate_unique_user_id(db: Session, role: str) -> str:
     Format: ROLE-UUID-8chars (e.g. STU-12345678)
     """
     prefix = role[:3].upper() if role else "USR"
-    while True:
-        # Generate a candidate ID
+    for _ in range(_MAX_RETRIES):
         random_part = str(uuid.uuid4())[:8].upper()
         new_id = f"{prefix}-{random_part}"
-        
-        # Check for collision
-        # We use the 'user_id' field (String) not 'id' (Integer)
-        existing = db.query(User).filter(User.user_id == new_id).first()
-        
-        if not existing:
+        if not db.query(User).filter(User.user_id == new_id).first():
             return new_id
+    raise ValueError(f"Could not generate unique user ID after {_MAX_RETRIES} attempts")
 
 
 def generate_simulation_id(db: Session) -> str:
@@ -30,13 +28,33 @@ def generate_simulation_id(db: Session) -> str:
     Generate a unique simulation ID.
     Format: SC-TOKEN (e.g. SC-ABC123XY)
     """
-    while True:
-        # Generate a candidate ID (matching format used in pdf_processing)
+    for _ in range(_MAX_RETRIES):
         random_part = secrets.token_urlsafe(8).upper()
         unique_id = f"SC-{random_part}"
-        
-        # Check for collision
-        existing = db.query(Simulation).filter(Simulation.unique_id == unique_id).first()
-        
-        if not existing:
+        if not db.query(Simulation).filter(Simulation.unique_id == unique_id).first():
             return unique_id
+    raise ValueError(f"Could not generate unique simulation ID after {_MAX_RETRIES} attempts")
+
+
+def generate_invite_token(db: Session) -> str:
+    """
+    Generate a unique single-use invite token for CohortInvitation.
+    Format: INV-TOKEN (e.g. INV-Xk3mP9aQ)
+    """
+    for _ in range(_MAX_RETRIES):
+        token = f"INV-{secrets.token_urlsafe(12)}"
+        if not db.query(CohortInvitation).filter(CohortInvitation.invitation_token == token).first():
+            return token
+    raise ValueError(f"Could not generate unique invite token after {_MAX_RETRIES} attempts")
+
+
+def generate_invite_link_token(db: Session) -> str:
+    """
+    Generate a unique reusable invite link token for CohortInvite.
+    Format: LNK-TOKEN (e.g. LNK-aB3xYz8k)
+    """
+    for _ in range(_MAX_RETRIES):
+        token = f"LNK-{secrets.token_urlsafe(12)}"
+        if not db.query(CohortInvite).filter(CohortInvite.token == token).first():
+            return token
+    raise ValueError(f"Could not generate unique invite link token after {_MAX_RETRIES} attempts")


### PR DESCRIPTION
## Summary

Adds `generate_invite_token()` and `generate_invite_link_token()` to centralise token creation for `CohortInvitation` and `CohortInvite`. Also replaces the unbounded `while True` loops in `generate_unique_user_id` and `generate_simulation_id` with bounded `for` loops.

## Conflict note

This PR modifies `generate_unique_user_id` and `generate_simulation_id` — `feat/ECS-503-cohort-id-generation` has also refactored the same functions (shared helper + `RuntimeError` vs inline loop + `ValueError`). These changes conflict and will need to be resolved before merging.

## Test plan
- [ ] `generate_invite_token(db)` → `INV-...` token, unique against `CohortInvitation`
- [ ] `generate_invite_link_token(db)` → `LNK-...` token, unique against `CohortInvite`
- [ ] Exhausted retries raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased robustness of unique ID generation with a higher retry limit and clearer failure behavior if uniqueness cannot be achieved.

* **New Features**
  * Added invitation and invite-link token generation for cohort workflows with built-in collision checks to ensure tokens are unique.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->