### PR TITLE
feat(ECS-106): introduce permission-based access control in auth dependencies

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,6 @@
 """Reusable FastAPI dependencies."""
 
-from typing import Optional
+from typing import Optional, Callable
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import HTTPBearer, OAuth2PasswordBearer
 from sqlalchemy.orm import Session
@@ -13,85 +13,107 @@ from modules.auth.service import auth_service
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 oauth2_scheme_optional = HTTPBearer(auto_error=False)
 
+# Declarative permission map — single source of truth for what each role can do.
+# Downstream guards use named permissions rather than raw role strings.
+ROLE_PERMISSIONS: dict[str, frozenset[str]] = {
+    "admin":     frozenset({"manage_users", "manage_cohorts", "grade", "simulate", "publish"}),
+    "professor": frozenset({"manage_cohorts", "grade", "simulate", "publish"}),
+    "student":   frozenset({"simulate"}),
+}
+
 async def get_current_user(
     request: Request,
     db: Session = Depends(get_db)
 ) -> User:
-    """Get the current authenticated user from HttpOnly cookie only"""
-    
+    """Authenticate via HttpOnly cookie and attach resolved permissions to the user object."""
+
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
     )
-    
-    # Extract token from HttpOnly cookie using the service
+
     token = auth_service.extract_token_from_request(request)
     if token is None:
         raise credentials_exception
-    
-    # Validate token using the service
+
     payload = auth_service.verify_token(token)
     if payload is None:
         raise credentials_exception
-    
+
     user_id_str = payload.get("sub")
     if user_id_str is None:
         raise credentials_exception
-    
+
     try:
         user_id = int(user_id_str)
     except (ValueError, TypeError):
         raise credentials_exception
-    
-    # Ideally this should use the repository via the service
-    # For now we query directly to match existing patterns until full refactor
+
     user = db.query(User).filter(User.id == user_id).first()
     if user is None:
         raise credentials_exception
-    
+
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Inactive user"
+            detail="Inactive user",
         )
-    
+
+    # Attach the resolved permission set for this request.
+    # Downstream dependencies check named permissions, never raw role strings.
+    user.permissions = ROLE_PERMISSIONS.get(user.role, frozenset())
+
     return user
+
 
 async def get_current_user_optional(
     request: Request,
     db: Session = Depends(get_db)
 ) -> Optional[User]:
-    """Get the current authenticated user if available, otherwise return None"""
+    """Return the authenticated user if available, otherwise None."""
     try:
         return await get_current_user(request, db)
     except HTTPException:
         return None
 
+
+def require_permission(permission: str) -> Callable:
+    """Dependency factory: require a specific named permission."""
+    async def _check(current_user: User = Depends(get_current_user)) -> User:
+        if permission not in getattr(current_user, "permissions", frozenset()):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission required: '{permission}'",
+            )
+        return current_user
+    return _check
+
+
 def require_admin(current_user: User = Depends(get_current_user)) -> User:
-    """Require admin role for access"""
+    """Require admin role (holds all permissions)."""
     if current_user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions"
+            detail="Not enough permissions",
         )
     return current_user
 
 
 def require_professor(current_user: User = Depends(get_current_user)) -> User:
-    """Require professor role for access"""
-    if current_user.role != "professor":
+    """Require grade permission (professor or admin)."""
+    if "grade" not in getattr(current_user, "permissions", frozenset()):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions. Professor role required."
+            detail="Not enough permissions. Professor role required.",
         )
     return current_user
 
 
 def require_student(current_user: User = Depends(get_current_user)) -> User:
-    """Require student role for access"""
-    if current_user.role != "student":
+    """Require simulate permission (any authenticated role)."""
+    if "simulate" not in getattr(current_user, "permissions", frozenset()):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions. Student role required."
+            detail="Not enough permissions. Student role required.",
         )
     return current_user


### PR DESCRIPTION
## Summary

Replaces raw role string comparisons with a declarative `ROLE_PERMISSIONS` map. `get_current_user()` now attaches a resolved `permissions` frozenset to the user on every request, and role guards check named permissions rather than role strings.

## ⚠️ Conflict note

This PR modifies `backend/app/dependencies.py` — `feat/ECS-108-scope-based-token-auth` has made incompatible changes to the same file. The two branches represent **mutually exclusive security architectures** that require a human decision before merging:

| | `feat/ECS-108` (this base branch) | `feat/ECS-106` (this PR) |
|---|---|---|
| **Trust model** | Stateless — scope claim in the JWT is the source of truth | Stateful — DB role resolved to permissions on every request |
| **`get_current_user`** | Validates `scope` claim, rejects tokens with stale scope | Attaches `user.permissions` frozenset from `ROLE_PERMISSIONS` |
| **`require_professor`** | Checks `user.role in ("professor", "admin")` | Checks `"grade" in user.permissions` |
| **New factory** | `require_role(*roles)` — multi-role shorthand | `require_permission(permission)` — named capability guard |
| **Role change handling** | Immediate — stale token rejected at next request | Immediate — permission set always reflects current DB role |
| **Token expiry dependency** | High — role changes require re-login | None — role changes take effect without re-login |

These two approaches cannot be combined without choosing one security model. A human must decide which trust boundary is correct for this application before this can be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to a permission-based authorization model so access is now determined by explicit permissions rather than role strings.
  * Improved and more specific permission-denied messages to clarify why access was blocked.
  * Updated professor and student access checks to rely on named permissions (e.g., grading, simulation) for finer-grained control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->